### PR TITLE
chore: add new release workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @casillas2/Developers

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,33 @@
+name: "\U0001F41B Bug Report"
+description: Report a bug
+title: "Bug: TITLE"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: expected_behaviour
+    attributes:
+      label: Expected Behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behaviour
+    attributes:
+      label: Current Behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Reproduction Steps
+    validations:
+      required: true
+
+  - type: textarea
+    id: code_snippet
+    attributes:
+      label: Code Snippet
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,0 +1,13 @@
+
+name: "📕 Documentation Issue"
+description: Issue in the documentation
+title: "Docs: TITLE"
+labels: ["documenation"]
+body:
+  - type: textarea
+    id: documentation_issue
+    attributes:
+      label: Documentation Issue
+      description: Describe the issue
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,17 @@
+name: "\U0001F680 Feature Request"
+description: Request a new feature
+title: "Feature request: TITLE"
+labels: ["feature"]
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed Solution
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,17 @@
+name: "🛠️ Maintenance"
+description: Some type of improvement
+title: "Maintenance: TITLE"
+labels: ["feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What was the problem/requirement? (What/Why)
+
+### What was the solution? (How)
+
+### What is the impact of this change?
+
+### How was this change tested?
+
+### Was this change documented?
+
+### Is this a breaking change?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    commit-message: 
+      prefix: "chore(deps):"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+This script gets the changelog notes for the latest version of this package. It makes the following assumptions
+1. A file called CHANGELOG.md is in the current directory that has the changelog
+2. The changelog file is formatted in a way such that level 2 headers are:
+    a. The only indication of the beginning of a version's changelog notes.
+    b. Always begin with `## `
+3. The changelog file contains the newest version's changelog notes at the top of the file.
+
+Example CHANGELOG.md:
+```
+## 1.0.0 (2024-02-06)
+
+### BREAKING CHANGES
+* **api**: rename all APIs
+
+## 0.1.0 (2024-02-06)
+
+### Features
+* **api**: add new api
+```
+
+Running this script on the above CHANGELOG.md should return the following contents:
+```
+## 1.0.0 (2024-02-06)
+
+### BREAKING CHANGES
+* **api**: rename all APIs
+
+```
+"""
+import re
+
+h2 = r"^##\s.*$"
+with open("CHANGELOG.md") as f:
+    contents = f.read()
+matches = re.findall(h2, contents, re.MULTILINE)
+changelog = contents[: contents.find(matches[1]) - 1] if len(matches) > 1 else contents
+print(changelog)

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,0 +1,17 @@
+name: Code Quality
+
+on:
+  pull_request:
+    branches: [ mainline, release ]
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+
+jobs:
+  TestPython:
+    name: Code Quality
+    uses: ./.github/workflows/reuse_python_build.yml
+    secrets: inherit
+

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -1,0 +1,96 @@
+name: "Release: Bump"
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_version_bump:
+        required: false
+        default: ""
+        type: choice
+        options:
+        - ""
+        - patch
+        - minor
+        - major
+
+concurrency:
+  group: release
+
+jobs:
+  TestMainline:
+    name: Test Mainline
+    uses: ./.github/workflows/code_quality.yml
+    with:
+      branch: mainline
+    secrets: inherit
+
+  Bump:
+    needs: TestMainline
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: ConfigureGit
+        run: |
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
+          git config --local user.name "client-software-ci"
+
+      - name: MergePushRelease
+        run: |
+          git merge --ff-only origin/mainline -v
+          git push origin release
+
+      - name: Bump
+        run: |
+          BUMP_ARGS=""
+          if [[ "${{ inputs.force_version_bump }}" != "" ]]; then
+            BUMP_ARGS="$BUMP_ARGS --${{ inputs.force_version_bump }}"
+          fi
+
+          # Backup actual changelog to preserve its contents
+          touch CHANGELOG.md
+          cp CHANGELOG.md CHANGELOG.bak.md
+
+          # Run semantic-release to generate new changelog
+          pip install --upgrade hatch
+          hatch env create release
+          NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
+
+          # Grab the new version's changelog and prepend it to the original changelog contents
+          python .github/scripts/get_latest_changelog.py > NEW_LOG.md
+          cat NEW_LOG.md CHANGELOG.bak.md > CHANGELOG.md
+          rm NEW_LOG.md
+
+          git checkout -b bump/$NEXT_SEMVER
+          git add CHANGELOG.md
+          git commit -sm "chore(release): $NEXT_SEMVER"
+
+          echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
+          {
+            echo 'RELEASE_NOTES<<EOF'
+            python .github/scripts/get_latest_changelog.py
+            echo EOF
+          } >> $GITHUB_ENV
+
+      - name: PushPR
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          git push -u origin bump/$NEXT_SEMVER
+
+          # Needs "Allow GitHub Actions to create and approve pull requests" under Settings > Actions
+          gh pr create --base release --title "chore(release): $NEXT_SEMVER" --body "$RELEASE_NOTES"

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,0 +1,238 @@
+name: "Release: Publish"
+run-name: "Release: ${{ github.event.head_commit.message }}"
+
+on:
+  push:
+    branches:
+      - release
+    paths:
+      - CHANGELOG.md
+
+concurrency:
+  group: release
+
+jobs:
+  VerifyCommit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: VerifyAuthor
+        run: |
+          EXPECTED_AUTHOR="129794699+client-software-ci@users.noreply.github.com"
+          AUTHOR=$(git show -s --format='%ae' HEAD)
+          if [[ $AUTHOR != $EXPECTED_AUTHOR ]]; then
+            echo "ERROR: Expected author email to be '$EXPECTED_AUTHOR', but got '$AUTHOR'. Aborting release."
+            exit 1
+          else
+            echo "Verified author email ($AUTHOR) is as expected ($EXPECTED_AUTHOR)"
+          fi
+
+  Release:
+    needs: VerifyCommit
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    env:
+      CODEARTIFACT_REGION: "us-west-2"
+      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+
+      - name: VerifyReleaseBranch
+        run: |
+          RELEASE_HEAD=$(git show -s --format='%H')
+          if [[ $RELEASE_HEAD != ${{ github.sha }} ]]; then
+            echo "ERROR: tip of release branch ($RELEASE_HEAD) does not match the commit that started this release (${{ github.sha }}). Aborting release."
+            exit 1
+          else
+            echo "Verified tip of release branch ($RELEASE_HEAD) matches the commit that started this release (${{ github.sha }})"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: PrepRelease
+        id: prep-release
+        run: |
+          COMMIT_TITLE=$(git show -s --format='%s' HEAD)
+          NEXT_SEMVER=$(python -c 'import sys, re; print(re.match(r"chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*", sys.argv[1]).group(1))' "$COMMIT_TITLE")
+
+          # The format of the tag must match the pattern in pyproject.toml -> tool.semantic_release.tag_format
+          TAG="$NEXT_SEMVER"
+
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
+          git config --local user.name "client-software-ci"
+
+          git tag -a $TAG -m "Release $TAG"
+
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
+          {
+            echo 'RELEASE_NOTES<<EOF'
+            python .github/scripts/get_latest_changelog.py
+            echo EOF
+          } >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      # Tag must be made before building so the generated _version.py files have the correct version
+      - name: Build
+        run: |
+          export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+          pip install --upgrade hatch
+          hatch build
+
+      # TODO: Uncomment below once the Deadline Cloud PGP key is available
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
+      #     aws-region: us-west-2
+      #     mask-aws-account-id: true
+
+      # - name: Import PGP Key
+      #   run: |
+      #     export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
+      #     printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
+
+      #     PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
+      #     echo "::add-mask::$PGP_KEY_PASSPHRASE"
+      #     echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
+
+      # - name: Sign
+      #   run: |
+      #     for file in dist/*; do
+      #       printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "Open Job Description" --passphrase-fd 0 --output $file.sig --detach-sign $file
+      #       echo "Created signature file for $file"
+      #     done
+
+      - name: PushRelease
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          git push origin $TAG
+          gh release create $TAG dist/* --notes "$RELEASE_NOTES"
+
+  MergeBack:
+    needs: Release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: mainline
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: MergeBackMainline
+        run: |
+          git merge --ff-only origin/release
+          git push origin mainline
+
+  PublishToRepository:
+    needs: Release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CODEARTIFACT_REGION: "us-west-2"
+      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+      CUSTOMER_DOMAIN: ${{ secrets.CUSTOMER_DOMAIN }}
+      CUSTOMER_REPOSITORY: ${{ secrets.CUSTOMER_REPOSITORY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+          pip install --upgrade hatch
+          pip install --upgrade twine
+
+      - name: Build
+        run: hatch build
+
+      - name: Publish to Repository
+        run: |
+          export TWINE_USERNAME=aws
+          export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text`
+          export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CODEARTIFACT_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
+          twine upload dist/*
+
+      - name: Publish to Customer Repository
+        run: |
+          export TWINE_USERNAME=aws
+          export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text`
+          export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CUSTOMER_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
+          twine upload dist/*
+
+      # TODO: Uncomment this block to publish to PyPI once this package is public
+      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+
+  PublishToInternal:
+    needs: Release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ github.event.repository.name }}-Publish
+          hide-cloudwatch-logs: true

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -1,0 +1,63 @@
+name: Python Build
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+
+jobs:
+  Python:
+    runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    env:
+      PYTHON: ${{ matrix.python-version }}
+      CODEARTIFACT_REGION: "us-west-2"
+      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+      if: ${{ !inputs.branch }}
+
+    - uses: actions/checkout@v4
+      if: ${{ inputs.branch }}
+      with:
+        ref: ${{ inputs.branch }}
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+
+    - name: Install Hatch
+      shell: bash
+      run: |
+        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Linting
+      run: hatch run lint
+
+    - name: Run Build
+      run: hatch build
+
+    - name: Run Tests
+      run: hatch run test -vv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@ documentation, we greatly value feedback and contributions from our community.
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
 
-
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
@@ -19,8 +18,12 @@ reported the issue. Please try to include as much information as you can. Detail
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
+## Development
+
+Please see [DEVELOPMENT.md](./DEVELOPMENT.md) for more information.
 
 ## Contributing via Pull Requests
+
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
 1. You are working against the latest source on the *main* branch.
@@ -36,23 +39,29 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-
 ## Finding contributions to work on
+
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
 
 ## Code of Conduct
+
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+We take all security reports seriously. When we receive such reports, we will 
+investigate and subsequently address any potential vulnerabilities as quickly 
+as possible. If you discover a potential security issue in this project, please 
+notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
+or directly via email to [AWS Security](aws-security@amazon.com). Please do not 
+create a public GitHub issue in this project.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,28 @@ Be sure to:
 * Change the title in this README
 * Edit your repository description on GitHub
 
+## Compatibility
+
+This library requires:
+
+1. Python 3.7 or higher; and
+2. Linux, MacOS, or Windows operating system.
+
+## Versioning
+
+This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its 
+initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how
+versions will increment during this initial development stage, they are described below:
+
+1. The MAJOR version is currently 0, indicating initial development. 
+2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
+3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
+
+## Downloading
+
+You can download this package from:
+- [GitHub releases](https://github.com/casillas2/deadline-cloud-for-cinema-4d/releases)
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/hatch.toml
+++ b/hatch.toml
@@ -1,0 +1,11 @@
+
+
+[envs.release]
+detached = true
+dependencies = [
+  "python-semantic-release == 8.7.*"
+]
+
+[envs.release.scripts]
+bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
+version = "semantic-release -v --strict version --print {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+
+[tool.semantic_release]
+# Can be removed or set to true once we are v1
+major_on_zero = false
+tag_format = "v{version}"
+tag_format = "{version}"
+
+[tool.semantic_release.publish]
+upload_to_vcs_release = false
+
+[tool.semantic_release.changelog]
+template_dir = ".semantic_release"
+
+[tool.semantic_release.changelog.environment]
+trim_blocks = true
+lstrip_blocks = true
+
+[tool.semantic_release.branches.release]
+match = "(mainline|release)"

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,0 +1,3 @@
+# HACK: This file solely exists for dependabot checks. The actual dependencies are in `hatch.toml` in the `release` environment.
+# If dependabot opens a PR that modifies this file, please make sure to update the coresponding dependency in `hatch.toml` as well.
+python-semantic-release == 8.7.*


### PR DESCRIPTION
### PRE-MERGE CHECKLIST
- [ ] Move the `CI_TOKEN` into the `release` environment.
- [ ] Update the `release` environment to require an approval from "OpenJobDescription/developers" before running.
- [ ] Add `mainline` as a branch allowed to use `release` environment
- [ ] Add `client-software-ci` to bypass required pull requests
- [ ] Remove "Do not allow bypassing above rules" protection rule for `mainline`
- [ ] Add "Restrict who can push to matching branches" protection rule for `mainline` and set it to the `client-software-ci` so `MergeBack` in `Release: Publish` can pass

### What was the problem/requirement? (What/Why)
The release workflow is currently broken

### What was the solution? (How)
Fix the release workflow

### What is the impact of this change?
Release workflow is fixed

### How was this change tested?
Tested on the OpenJD repositories

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*