### PR TITLE
fix!: change project naming from ...cinema4d -> ...cinema-4d

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -63,6 +63,7 @@ jobs:
           # Run semantic-release to generate new changelog
           pip install --upgrade hatch
           hatch env create release
+          hatch run release:deps
           NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
 
           # Grab the new version's changelog and prepend it to the original changelog contents

--- a/hatch.toml
+++ b/hatch.toml
@@ -37,10 +37,8 @@ SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 
 [envs.release]
 detached = true
-dependencies = [
-  "python-semantic-release == 9.1.*"
-]
 
 [envs.release.scripts]
+deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
-name = "deadline-cloud-for-cinema4d"
+name = "deadline-cloud-for-cinema-4d"
 dynamic = ["version"]
 readme = "README.md"
-license = ""
+license = "Apache-2.0"
 requires-python = ">=3.9"
 
 dependencies = [
@@ -108,7 +108,11 @@ filterwarnings = [
 source_pkgs = [ "deadline/cinema4d_adaptor", "deadline/cinema4d_submitter" ]
 branch = true
 parallel = true
-omit = [ "**/__main__.py", "**/_version.py" ]
+omit = [
+  "**/__main__.py",
+  "**/_version.py",
+  "*/deadline/cinema4d_submitter/ui/*"
+]
 
 [tool.coverage.paths]
 source =  [

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,3 +1,1 @@
-# HACK: This file solely exists for dependabot checks. The actual dependencies are in `hatch.toml` in the `release` environment.
-# If dependabot opens a PR that modifies this file, please make sure to update the coresponding dependency in `hatch.toml` as well.
 python-semantic-release == 9.1.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Project was specified as cinema4d, whereas repo is cinema-4d

### What was the solution? (How)

Update to match

### What is the impact of this change?

To install, you must now do a `pip install deadline-cloud-for-cinema-4d`

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```
to verify that the created output now was `deadline_cloud_for_cinema_4d`

### Was this change documented?

N/A

### Is this a breaking change?

Yes, since it's now a new project