### PR TITLE
docs: update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,18 @@
 ## 0.2.1 (2024-03-26)
 
 ### Dependencies
-* update deadline-cloud dependency 0.45.0 (#15) ([`3677a7b`](https://github.com/casillas2/deadline-cloud-for-cinema-4d/pull/15/commits/3677a7b7e1e73939ecae6987fbdc4bc4842c38ec))
+* update deadline-cloud dependency 0.45.0 (#15) ([`3677a7b`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/15/commits/3677a7b7e1e73939ecae6987fbdc4bc4842c38ec))
 
 ## v0.2.0 (2024-03-15)
 
 ### Breaking
-* change project naming from ...cinema4d -&gt; ...cinema-4d (#8) ([`676cbab`](https://github.com/casillas2/deadline-cloud-for-cinema-4d/commit/676cbab3b6fb10054d4e9c987c137aa40736921f))
+* change project naming from ...cinema4d -&gt; ...cinema-4d (#8) ([`676cbab`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/676cbab3b6fb10054d4e9c987c137aa40736921f))
 
 ## v0.1.0 (2024-03-15)
 
 ### Breaking
-* init integration commit (#1) ([`0cd4e1c`](https://github.com/casillas2/deadline-cloud-for-cinema-4d/commit/0cd4e1ccab0398090e3878f9c27123acf00748df))
+* init integration commit (#1) ([`0cd4e1c`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/0cd4e1ccab0398090e3878f9c27123acf00748df))
 
 ### Chore
-* update deps deadline-cloud 0.40 (#6) ([`479adab`](https://github.com/casillas2/deadline-cloud-for-cinema-4d/commit/479adab182a2072d002ad960e1e32c91cf3dfa07))
+* update deps deadline-cloud 0.40 (#6) ([`479adab`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/479adab182a2072d002ad960e1e32c91cf3dfa07))
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,41 @@
 # AWS Deadline Cloud for Cinema4D Development
 
+This package has two active branches:
+
+- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
+- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
+## Build / Test / Release
+
+### Build the package
+
+```bash
+hatch build
+```
+
+### Run tests
+
+```bash
+hatch run test
+```
+
+### Run linting
+
+```bash
+hatch run lint
+```
+
+### Run formatting
+
+```bash
+hatch run fmt
+```
+
+## Run tests for all supported Python versions
+
+```bash
+hatch run all:test
+```
+
 ## Get started
 
 Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the

--- a/README.md
+++ b/README.md
@@ -1,71 +1,61 @@
-# AWS Deadline Cloud for Cinema 4D
 
+# AWS Deadline Cloud for Cinema 4D
+[![pypi](https://img.shields.io/pypi/v/deadline-cloud-for-cinema-4d.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-cinema-4d)
+[![python](https://img.shields.io/pypi/pyversions/deadline-cloud-for-cinema-4d.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-cinema-4d)
+[![license](https://img.shields.io/pypi/l/deadline-cloud-for-cinema-4d.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/LICENSE)
+
+### Disclaimer
+---
 This GitHub repository is an example integration with AWS Deadline Cloud that is intended to only be used for testing and is subject to change. This code is an alpha release. It is not a commercial release and may contain bugs, errors, defects, or harmful components. Accordingly, the code in this repository is provided as-is. Use within a production environment is at your own risk!
- 
+
 Our focus is to explore a variety of software applications to ensure we have good coverage across common workflows. We prioritized making this example available earlier to users rather than being feature complete.
 
 This example has been used by at least one internal or external development team to create a series of jobs that successfully rendered. However, your mileage may vary. If you have questions or issues with this example, please start a discussion or cut an issue.
+---
 
-## Overview
+AWS Deadline Cloud for Cinema 4D is a python package that allows users to create [AWS Deadline Cloud][deadline-cloud] jobs from within Cinema 4D. Using the [Open Job Description (OpenJD) Adaptor Runtime][openjd-adaptor-runtime] this package also provides a command line application that adapts Cinema 4D's command line interface to support the [OpenJD specification][openjd].
 
-This package has two active branches:
+[deadline-cloud]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html
+[deadline-cloud-client]: https://github.com/aws-deadline/deadline-cloud
+[openjd]: https://github.com/OpenJobDescription/openjd-specifications/wiki
+[openjd-adaptor-runtime]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python
+[openjd-adaptor-runtime-lifecycle]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/blob/release/README.md#adaptor-lifecycle
 
-- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
-- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
-
-## Development
-
-See [DEVELOPMENT](DEVELOPMENT.md) for more information.
-
-## Telemetry
-
-This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
-
-You can opt out of telemetry data collection by either:
-
-1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
-2. Setting the config file: `deadline config set telemetry.opt_out true`
-
-Note that setting the environment variable supersedes the config file setting.
-
-## Build / Test / Release
-
-### Build the package
-
-```bash
-hatch build
-```
-
-### Run tests
-
-```bash
-hatch run test
-```
-
-### Run linting
-
-```bash
-hatch run lint
-```
-
-### Run formatting
-
-```bash
-hatch run fmt
-```
-
-## Run tests for all supported Python versions
-
-```bash
-hatch run all:test
-```
 
 ## Compatibility
 
 This library requires:
 
+1. Cinema 4D 2023 - 2024,
 1. Python 3.9 or higher; and
-2. Linux, Windows, or macOS operating system.
+1. Linux, Windows, or a macOS operating system.
+
+## Submitter
+
+This package provides a Cinema 4D plugin that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
+
+## Adaptor
+
+The Cinema 4D Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch Cinema 4D and feed it commands. This gives the following benefits:
+* a standardized render application interface,
+* sticky rendering, where the application stays open between tasks,
+* path mapping, that enables cross-platform rendering
+
+Jobs created by the submitter use this adaptor by default.
+
+### Getting Started
+
+The adaptor can be installed by the standard python packaging mechanisms:
+```sh
+$ pip install deadline-cloud-for-cinema-4d
+```
+
+After installation it can then be used as a command line tool:
+```sh
+$ cinema4d-openjd --help
+```
+
+For more information on the commands the OpenJD adaptor runtime provides, see [here][openjd-adaptor-runtime-lifecycle].
 
 ## Versioning
 
@@ -77,14 +67,13 @@ versions will increment during this initial development stage, they are describe
 2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
 3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
 
-## Downloading
-
-You can download this package from:
-- [GitHub releases](https://github.com/casillas2/deadline-cloud-for-cinema-4d/releases)
-
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/release/CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## Telemetry
+
+See [telemetry](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/release/docs/telemetry.md) for more information.
 
 ## License
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,10 @@
+# Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.9"
 description = "The submitter and adaptor to enable Cinema 4D support for AWS Deadline Cloud"
+authors = [
+  {name = "Amazon Web Services"},
+]
 # https://pypi.org/classifiers/
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -30,6 +33,10 @@ dependencies = [
     "deadline == 0.45.*",
     "openjd-adaptor-runtime == 0.6.*",
 ]
+
+[project.urls]
+Homepage = "https://github.com/aws-deadline/deadline-cloud-for-cinema-4d"
+Source = "https://github.com/aws-deadline/deadline-cloud-for-cinimema-4d"
 
 [project.scripts]
 cinema4d-openjd = "deadline.cinema4d_adaptor.Cinema4DAdaptor:main"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are preparing for the first public release which includes publishing our distribution artifacts to PyPI. The description of the package on PyPI will include the `README.md` contents of this repository. Any links in the `README.md` that are relative need to be made absolute since they will not resolve correctly on PyPI. When choosing the absolute link, the link must refer to the correct branch (`mainline` vs `release`) depending on the context of the link.

Additionally, once the repository becomes public, visitors will be looking for basic information about the project such as:

*   what is it?
*   what can it be used for?
*   how can it be used and operated?
*   how can people interact with the project?

### What was the solution? (How)

* Wrote it in VSCode with .md rendering
* view in Github rendering

### What is the impact of this change?

Readers landing on our published PyPI and GitHub pages will have a more clear and curated introduction to the project, emphasizing why they might find it important and providing information to help them get started using it and contributing to it.

### How was this change tested?

*   Using Visual Studio Code's markdown preview feature
*   Reviewing GitHub's markdown rendered version

### Was this change documented?

This change is documentation :)

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
