### PR TITLE
fix: update imports to namespace package

### DIFF
--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -10,10 +10,10 @@ if 'cinema4d_submitter' not in sys.modules.keys():
     for n in python_paths:
         if n not in sys.path:
             sys.path.append(n)
-    import cinema4d_submitter
+    import deadline.cinema4d_submitter
 else:
     import importlib
-    importlib.reload(cinema4d_submitter)
+    importlib.reload(deadline.cinema4d_submitter)
 
 import c4d
 
@@ -23,7 +23,7 @@ PLUGIN_ID = 1062029
 class DeadlineCloudRenderCommand(c4d.plugins.CommandData):
 
     def Execute(self, doc):
-        cinema4d_submitter.show_submitter()
+        deadline.cinema4d_submitter.show_submitter()
         return True
 
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 import c4d
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
@@ -17,7 +17,7 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint
     JobBundlePurpose,
 )
 from deadline.client.exceptions import DeadlineOperationError
-from PySide2.QtCore import Qt  # pylint: disable=import-error
+from qtpy.QtCore import Qt  # type: ignore[attr-defined]
 
 from .data_classes import (
     RenderSubmitterUISettings,

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -1,8 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 
-from PySide2.QtCore import QSize, Qt  # type: ignore
-from PySide2.QtWidgets import (  # type: ignore
+from qtpy.QtCore import QSize, Qt  # type: ignore
+from qtpy.QtWidgets import (  # type: ignore
     QCheckBox,
     QComboBox,
     QFileDialog,
@@ -39,7 +39,6 @@ class FileSearchLineEdit(QWidget):
 
         lyt = QHBoxLayout(self)
         lyt.setContentsMargins(0, 0, 0, 0)
-        lyt.setMargin(0)
 
         self.edit = QLineEdit(self)
         self.btn = QPushButton("...", parent=self)

--- a/test/deadline_submitter_for_cinema4d/unit/__init__.py
+++ b/test/deadline_submitter_for_cinema4d/unit/__init__.py
@@ -9,6 +9,10 @@ mock_modules = [
     "PySide2.QtCore",
     "PySide2.QtGui",
     "PySide2.QtWidgets",
+    "qtpy",
+    "qtpy.QtCore",
+    "qtpy.QtGui",
+    "qtpy.QtWidgets",
 ]
 
 for module in mock_modules:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The submitter failed to load in C4D and it seems to be looking for the submitter outside the deadline namespace package

### What was the solution? (How)

fix the imports to use the deadline namespace package. We were also hard-coded to pyside2 in the submitter, but should use whatever gui is available to us. ie. PySide6 or PySide2

### What is the impact of this change?

Submitter launches in 2024 which requires python 3.11. Also launches in 2023 as well (3.10)

### How was this change tested?

Ran it on my local machine.

### Was this change documented?

N/A

### Is this a breaking change?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*