### PR TITLE
fix: windows adaptor was failing to load

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,10 +36,10 @@ hatch run fmt
 hatch run all:test
 ```
 
-## Get started
+## Submitter environment
 
 Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
-submitter uses to set sys.path explictly and load deadline modules.
+submitter and adaptor uses to set sys.path explictly and load deadline modules.
 
 - install deadline-cloud with pyside
 - set env below
@@ -54,10 +54,12 @@ export g_additionalModulePath="/path/to/deadline-cloud-for-cinema4d/deadline_clo
 - run cinema4d
 - Extensions > Deadline Cloud Submitter
 
-## Worker environment
+## Worker adaptor environment
 
 Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
 adaptor uses to set sys.path explictly and load deadline modules.
+
+### Linux
 
 Linux also requires the setup_c4d_env sourced first, we can override the exe
 path with a c4d wrapper script that sources it then call the Commandline
@@ -68,4 +70,14 @@ Example linux env below:
 ```
 export DEADLINE_CLOUD_PYTHONPATH="/tmp/lib/python3.11/site-packages"
 export DEADLINE_CINEMA4D_EXE="/opt/maxon/cinema4dr2024.200/bin/c4d"
+```
+
+### Windows
+
+To run the adaptor on Windows, you'll have to configure the environment variable `DEADLINE_CLOUD_PYTHONPATH` (like the submitter above) and install pywin32 into Cinema4D's python. Example:
+
+```
+set DEADLINE_CLOUD_PYTHONPATH="C:\path\to\deadline-cloud\site-packages"
+"C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe" -m ensurepip   
+"C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe" -m pip install pywin32  
 ```

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -6,18 +6,13 @@ import os
 from types import FrameType
 from typing import Optional
 
-# print('Client import')
-# print('======')
-# for n in sys.path:
-#     print(n)
-# print('======')
 from openjd.adaptor_runtime_client import (
-    HTTPClientInterface,
+    ClientInterface,
 )
 from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler
 
 
-class Cinema4DClient(HTTPClientInterface):
+class Cinema4DClient(ClientInterface):
     """
     Client that runs in Cinema4D for the Cinema4D Adaptor
     """

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
@@ -22,11 +22,7 @@ if 'openjd' not in sys.modules.keys():
                 print('add_dll_directory failed: %s' % p)
         sys.path.append(p)
 
-try:
-    from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client import main
-except Exception as e:
-    print(e)
-    traceback.print_exc()
+from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client import main
 
 
 def parse_argv(argv):


### PR DESCRIPTION
Resolves https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/40

### What was the problem/requirement? (What/Why)

There were a few problems with using C4D on windows:
1. The adaptor runtime client was failing to find pywin32 when attempting to connect: `ModuleNotFoundError: No module named 'win32file'`
2. There were some misdirection in the stack trace when failing to load pywin32. It would complain with `NameError: name 'main' is not defined. Did you mean: 'min'?` since we were catching the above error
3. The adaptor was trying to load the posix interface to communicate

### What was the solution? (How)

1. Documented the requirement to install pywin32 into C4D's python environment. 
2. Removed the try/except around loading the runtime client to make it easier to debug
3. Swapped `HTTPClientInterface` to the OS-agnostic `ClientInterface` to work on both Linux and Windows.
4. Cut an issue to remove the pywin32 dependency from the openjd adaptor runtime to remove this rough edge. Link: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/issues/131

### What is the impact of this change?

You can render on Windows!

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

The adaptor was also able to successfully render a job

### Was this change documented?

Yup!

### Is this a breaking change?

Nope!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*