### PR TITLE
added more verbose submitter installation instructions.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,10 +36,10 @@ hatch run fmt
 hatch run all:test
 ```
 
-## Get started
+## Submitter environment
 
 Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
-submitter uses to set sys.path explictly and load deadline modules.
+submitter and adaptor uses to set sys.path explictly and load deadline modules.
 
 - install deadline-cloud with pyside
 - set env below
@@ -54,10 +54,12 @@ export g_additionalModulePath="/path/to/deadline-cloud-for-cinema4d/deadline_clo
 - run cinema4d
 - Extensions > Deadline Cloud Submitter
 
-## Worker environment
+## Worker adaptor environment
 
 Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
 adaptor uses to set sys.path explictly and load deadline modules.
+
+### Linux
 
 Linux also requires the setup_c4d_env sourced first, we can override the exe
 path with a c4d wrapper script that sources it then call the Commandline
@@ -68,4 +70,14 @@ Example linux env below:
 ```
 export DEADLINE_CLOUD_PYTHONPATH="/tmp/lib/python3.11/site-packages"
 export DEADLINE_CINEMA4D_EXE="/opt/maxon/cinema4dr2024.200/bin/c4d"
+```
+
+### Windows
+
+To run the adaptor on Windows, you'll have to configure the environment variable `DEADLINE_CLOUD_PYTHONPATH` (like the submitter above) and install pywin32 into Cinema4D's python. Example:
+
+```
+set DEADLINE_CLOUD_PYTHONPATH="C:\path\to\deadline-cloud\site-packages"
+"C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe" -m ensurepip   
+"C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe" -m pip install pywin32  
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,21 +38,50 @@ hatch run all:test
 
 ## Submitter environment
 
-Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
-submitter and adaptor uses to set sys.path explictly and load deadline modules.
+### Submitter Python environment 
+The submitter requires the following modules to be installed:
 
-- install deadline-cloud with pyside
-- set env below
-
-```
-# deadline-cloud lib with pyside
-export DEADLINE_CLOUD_PYTHONPATH="/path/to/deadline-cloud/site-packages"
-# configure cinema4d to find extension entry point
-export g_additionalModulePath="/path/to/deadline-cloud-for-cinema4d/deadline_cloud_extension"
+```sh
+pip install deadline-cloud-for-cinema-4d
+pip install deadline[gui]
 ```
 
-- run cinema4d
-- Extensions > Deadline Cloud Submitter
+### Cinema 4D Plugin Extension Setup 
+
+The Cinema 4D plugin extension can be downloaded from the git repo:
+
+https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/deadline_cloud_extension/DeadlineCloud.pyp
+
+Place this in a location accessible by C4D instances.
+
+Add the `g_additionalModulePath` environment variable to point to the above location, so that Cinema 4D can load the plugin.
+
+By default, Cinema4D does not see **PYTHON_PATH** and as a result **deadline-cloud-for-cinema-4d** - the extension is programmed to look for an environment variable called `DEADLINE_CLOUD_PYTHONPATH`. Setup this variable to point to the location of your **Python > Lib > site-packages**  - e.g.
+
+```
+C:\Program Files\Python311\Lib\site-packages
+```
+
+If you load a scene, click on **Extensions > Deadline Cloud Submitter** to view the submitter.
+
+### Additional Python Libraries
+
+Some specific versions of Cinema 4d ( e.g. `Cinema 4D 2024.1.0`) have been found to be missing some libraries key to Deadline requirements ; in later versions such as `2024.4.0` this has been resolved. 
+
+A missing library error will manifest in errors that can be visible from the **Python** section of the **Extensions > Console** UI. These typically look like:
+
+```
+PySide6/__init__.py: Unable to import Shiboken from  ...
+```
+
+To remedy these errors, you can switch to a later version of Cinema 4D which resolves the missing libraries, or you can manually add them specifically to the Cinema 4D python module, e.g.
+
+```
+& "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m ensurepip   
+& "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m pip install MISSING_MODULE
+```       
+
+
 
 ## Worker adaptor environment
 

--- a/README.md
+++ b/README.md
@@ -34,48 +34,8 @@ This library requires:
 
 This package provides a Cinema 4D plugin that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
 
-### Submitter Python environment 
-The submitter requires the following modules to be installed:
+For installation instructions, refer to [Submitter Environment Instructions](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/DEVELOPMENT.md#submitter-environment).
 
-```sh
-pip install deadline-cloud-for-cinema-4d
-pip install deadline[gui]
-```
-
-### Cinema 4D Plugin Extension Setup 
-
-The Cinema 4D plugin extension can be downloaded from the git repo:
-
-https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/deadline_cloud_extension/DeadlineCloud.pyp
-
-Place this in a location accessible by C4D instances.
-
-Add the `g_additionalModulePath` environment variable to point to the above location, so that Cinema 4D can load the plugin.
-
-By default, Cinema4D does not see **PYTHON_PATH** and as a result **deadline-cloud-for-cinema-4d** - the extension is programmed to look for an environment variable called `DEADLINE_CLOUD_PYTHONPATH`. Setup this variable to point to the location of your **Python > Lib > site-packages**  - e.g.
-
-```
-C:\Program Files\Python311\Lib\site-packages
-```
-
-If you load a scene, click on **Extensions > Deadline Cloud Submitter** to view the submitter.
-
-### Additional Python Libraries
-
-Some specific versions of Cinema 4d ( e.g. `Cinema 4D 2024.1.0`) have been found to be missing some libraries key to Deadline requirements ; in later versions such as `2024.4.0` this has been resolved. 
-
-A missing library error will manifest in errors that can be visible from the **Python** section of the **Extensions > Console** UI. These typically look like:
-
-```
-PySide6/__init__.py: Unable to import Shiboken from  ...
-```
-
-To remedy these errors, you can switch to a later version of Cinema 4D which resolves the missing libraries, or you can manually add them specifically to the Cinema 4D python module, e.g.
-
-```
-& "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m ensurepip   
-& "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m pip install MISSING_MODULE
-```       
 
 ## Adaptor
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,49 @@ This library requires:
 
 This package provides a Cinema 4D plugin that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
 
+### Submitter Python environment 
+The submitter requires the following modules to be installed:
+
+```sh
+pip install deadline-cloud-for-cinema-4d
+pip install deadline[gui]
+```
+
+### Cinema 4D Plugin Extension Setup 
+
+The Cinema 4D plugin extension can be downloaded from the git repo:
+
+https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/deadline_cloud_extension/DeadlineCloud.pyp
+
+Place this in a location accessible by C4D instances.
+
+Add the `g_additionalModulePath` environment variable to point to the above location, so that Cinema 4D can load the plugin.
+
+By default, Cinema4D does not see **PYTHON_PATH** and as a result **deadline-cloud-for-cinema-4d** - the extension is programmed to look for an environment variable called `DEADLINE_CLOUD_PYTHONPATH`. Setup this variable to point to the location of your **Python > Lib > site-packages**  - e.g.
+
+```
+C:\Program Files\Python311\Lib\site-packages
+```
+
+If you load a scene, click on **Extensions > Deadline Cloud Submitter** to view the submitter.
+
+### Additional Python Libraries
+
+Some specific versions of Cinema 4d ( e.g. `Cinema 4D 2024.1.0`) have been found to be missing some libraries key to Deadline requirements ; in later versions such as `2024.4.0` this has been resolved. 
+
+A missing library error will manifest in errors that can be visible from the **Python** section of the **Extensions > Console** UI. These typically look like:
+
+```
+PySide6/__init__.py: Unable to import Shiboken from  ...
+```
+
+To remedy these errors, you can switch to a later version of Cinema 4D which resolves the missing libraries, or you can manually add them specifically to the Cinema 4D python module, e.g.
+
+```
+& "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m ensurepip   
+& "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m pip install MISSING_MODULE
+```       
+
 ## Adaptor
 
 The Cinema 4D Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch Cinema 4D and feed it commands. This gives the following benefits:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies = [
     "deadline == 0.48.*",
-    "openjd-adaptor-runtime == 0.7.*",
+    "openjd-adaptor-runtime >= 0.7,< 0.9",
 ]
 
 [project.urls]

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,1 @@
-python-semantic-release == 9.5.*
+python-semantic-release == 9.8.*

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -6,18 +6,13 @@ import os
 from types import FrameType
 from typing import Optional
 
-# print('Client import')
-# print('======')
-# for n in sys.path:
-#     print(n)
-# print('======')
 from openjd.adaptor_runtime_client import (
-    HTTPClientInterface,
+    ClientInterface,
 )
 from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler
 
 
-class Cinema4DClient(HTTPClientInterface):
+class Cinema4DClient(ClientInterface):
     """
     Client that runs in Cinema4D for the Cinema4D Adaptor
     """

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
@@ -22,11 +22,7 @@ if 'openjd' not in sys.modules.keys():
                 print('add_dll_directory failed: %s' % p)
         sys.path.append(p)
 
-try:
-    from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client import main
-except Exception as e:
-    print(e)
-    traceback.print_exc()
+from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client import main
 
 
 def parse_argv(argv):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Customers were failing to understand how to setup the submitter.
Some versions of C4D were also causing issues due to missing libraries.

### What was the solution? (How)
Just updated the README file to elevate the instructions more verbosely.

### What is the impact of this change?
Customer should be able to setup C4d submitters.

### How was this change tested?
In consulation with service team.

### Was this change documented?
This is a doc change.

### Is this a breaking change?
NO
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*