### PR TITLE
fix: properly access multipass filename from render data

### DIFF
--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -149,7 +149,7 @@ class Scene:
                 xpath = os.path.join(doc_path, xpath)
             image_paths.add(os.path.dirname(xpath))
         if render_data[c4d.RDATA_MULTIPASS_SAVEIMAGE]:
-            path = render_data.GetFilename(c4d.RDATA_MULTIPASS_FILENAME)
+            path = render_data[c4d.RDATA_MULTIPASS_FILENAME]
             xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
             if not os.path.isabs(xpath):
                 xpath = os.path.join(doc_path, xpath)


### PR DESCRIPTION
Resolves #38 

### What was the problem/requirement? (What/Why)

When opening the submitter in a scene that saves multipass output, the submitter would always crash regardless if there any info or not.

```
Deadline UI launch failed
Traceback (most recent call last):
  File "C:\Program Files\Python310\Lib\site-packages\deadline\cinema4d_submitter\cinema4d_render_submitter.py", line 54, in show_submitter
    w = _show_submitter(None)
        ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python310\Lib\site-packages\deadline\cinema4d_submitter\cinema4d_render_submitter.py", line 273, in _show_submitter
    output_directories = Scene.get_output_directories(take=take)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python310\Lib\site-packages\deadline\cinema4d_submitter\scene.py", line 152, in get_output_directories
    path = render_data.GetFilename(c4d.RDATA_MULTIPASS_FILENAME)
           ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'c4d.documents.RenderData' object has no attribute 'GetFilename'
```

### What was the solution? (How)

We were accessing it as if the render data was the data container, rather than the data instance. Swapped to the data instance method

### What is the impact of this change?

Submitter now properly loads when the scene has multipass data

### How was this change tested?

1. Reproduced issue locally
1. made the change and installed
1. verified the submitter no longer crashes when loading

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*