### PR TITLE
fix: frame override checkbox with pyside6

### DIFF
--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -157,4 +157,4 @@ class SceneSettingsWidget(QWidget):
         """
         Set the activated/deactivated status of the Frame override text box
         """
-        self.frame_override_txt.setEnabled(state == Qt.Checked)
+        self.frame_override_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)


### PR DESCRIPTION
Resolves #52 

### What was the problem/requirement? (What/Why)
Frame override checkbox wasn't working with Pyside6

This is likely only an issue when using Pyside6. Pyside6 introduced [changes to how enums are handled](https://doc.qt.io/qtforpython-6/considerations.html#the-new-python-enums) which seems to be the culprit.
### What was the solution? (How)
Convert to a CheckState enum to compare against Qt.Checked
### What is the impact of this change?
Frame override checkbox works again with Pyside6
### How was this change tested?
Verified the toggle didn't work without my change and then did with the change
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*