### PR TITLE
fix: Add path mapping to outputs

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -19,7 +19,7 @@ class Cinema4DClient(ClientInterface):
 
     def __init__(self, server_path: str) -> None:
         super().__init__(server_path=server_path)
-        self.actions.update(Cinema4DHandler().action_dict)
+        self.actions.update(Cinema4DHandler(lambda path: self.map_path(path)).action_dict)
 
     def close(self, args: Optional[dict] = None) -> None:
         sys.exit(0)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Output paths were not path mapped.

### What was the solution? (How)

Call `map_path` on the output and multipass output paths in the adaptor.

### What is the impact of this change?

Outputs will now be path mapped.

### How was this change tested?

I installed the changes on a CMF instance and rendered a scene that had both normal and multi-pass outputs. I observed that I was able to download the output and that the logs recorded the path mapping happening.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*