### PR TITLE
feat!: Updates to work towards a GA release

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,5 +67,5 @@ Example linux env below:
 
 ```
 export C4DPYTHONPATH311="/path/to/deadline-cloud/site-packages"
-export DEADLINE_CINEMA4D_EXE="/opt/maxon/cinema4dr2024.200/bin/c4d"
+export CINEMA4D_ADAPTOR_COMMANDLINE_EXE="/opt/maxon/cinema4dr2024.200/bin/Commandline"
 ```

--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -1,5 +1,28 @@
+import functools
+import glob
 import os
 import sys
+
+
+def glob_add_path(base, pattern):
+    matches = list(glob.iglob(os.path.join(base, pattern)))
+    if matches:
+        return os.path.join(base, matches[0])
+    return base
+
+if "win" in sys.platform:
+    paths = [
+        "resource",
+        "modules",
+        "python",
+        "libs",
+        "*win64*",
+        "dlls"
+    ]
+    dll_path = functools.reduce(glob_add_path, paths, os.path.dirname(sys.executable))
+    # Required due to a longstanding bug in C4D to not include the python dll library path required by many compiled libs
+    #   Read more here: https://github.com/danbradham/wheels/issues/4#issuecomment-1772721170
+    os.add_dll_directory(dll_path)
 
 root = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(root, 'modules'))

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -8,6 +8,7 @@ import re
 import threading
 import time
 from functools import wraps
+import platform
 from typing import Callable
 
 from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators, SemanticVersion
@@ -300,8 +301,12 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
             new_module_path = plugin_dir + os.pathsep + module_path
         os.environ[module_path_key] = new_module_path
 
+        arguments = [c4d_exe, "-nogui", "-DeadlineCloudClient"]
+        if "linux" in platform.system().lower():
+            _logger.info("Inserting Linux adaptor wrapper script")
+            arguments.insert(0, os.path.join(os.path.dirname(__file__), "adaptor.sh"))
         self._cinema4d_client = LoggingSubprocess(
-            args=[c4d_exe, "-nogui", "-DeadlineCloudClient"],
+            args=arguments,
             stdout_handler=regexhandler,
             stderr_handler=regexhandler,
         )

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -446,4 +446,5 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         set to be added to the action queue.
         """
         for name in _FIRST_CINEMA4D_ACTIONS:
-            self._action_queue.enqueue_action(Action(name, {name: self.init_data[name]}))
+            if name in self.init_data:
+                self._action_queue.enqueue_action(Action(name, {name: self.init_data[name]}))

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -272,7 +272,9 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         # XXX: on linux we need to run the c4d env setup script first, this env
         # var allows us to use a wrapper around Commandline. Ideally a conda env
         # does this for us.
-        c4d_exe_env = os.getenv("DEADLINE_CINEMA4D_EXE", "")
+        # On Linux this should be a path similar to this: /opt/maxon/cinema4dr2024.200/bin/Commandline
+        # On Windows it should be a path similar to this: "C:\Program Files\Maxon Cinema 4D R26\Commandline.exe"
+        c4d_exe_env = os.environ.get("CINEMA4D_ADAPTOR_COMMANDLINE_EXE", "")
         if not c4d_exe_env:
             c4d_exe = "Commandline"
         else:

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.sh
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+set -euo pipefail
+C4DEXE="$1"
+echo "C4D Executable: ${C4DEXE}"
+echo "$@"
+shift
+ARGS="$@"
+echo "  Passed argument list: ${ARGS}"
+
+
+C4DBASE=$(dirname "${C4DEXE}")
+
+echo "Manually setting LD_LIBRARY_PATH, PATH, and PYTHONPATH to Cinema4D components"
+LD_LIBRARY_PATH_=${LD_LIBRARY_PATH-""}
+export LD_LIBRARY_PATH="${C4DBASE}/resource/modules/python/libs/*linux64*/lib64:${C4DBASE}/resource/modules/embree.module/libs/linux64:$LD_LIBRARY_PATH_"
+export PATH="${C4DBASE}:$PATH"
+PYTHONPATH_=${PYTHONPATH-""}
+export PYTHONPATH="${C4DBASE}/resource/modules/python/libs/*linux64*/lib/python*/lib-dynload:${C4DBASE}/resource/modules/python/libs/*linux64*/lib64/python*:$PYTHONPATH_"
+
+if [ -f "${C4DBASE}/setup_c4d_env" ]
+then
+  cd $C4DBASE
+  echo "Sourcing setup_c4d_env from ${C4DBASE}/setup_c4d_env";
+  source "${C4DBASE}/setup_c4d_env";
+else
+  echo "setup_c4d_env not found in ${C4DBASE}";
+fi
+
+echo "Executing C4D Executable with argument list after sourcing environment"
+$C4DEXE ${ARGS[*]}

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.sh
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.sh
@@ -9,6 +9,12 @@ shift
 ARGS="$@"
 echo "  Passed argument list: ${ARGS}"
 
+C4DVERSION=""
+
+if [[ "$C4DEXE" =~ [^/]*cinema4dr([0-9\.]+)[^/]* ]]
+then
+  C4DVERSION="${BASH_REMATCH[1]}"
+fi
 
 C4DBASE=$(dirname "${C4DEXE}")
 
@@ -24,6 +30,12 @@ then
   cd $C4DBASE
   echo "Sourcing setup_c4d_env from ${C4DBASE}/setup_c4d_env";
   source "${C4DBASE}/setup_c4d_env";
+  # Hacky patch to allow for libwebkit2gtk to load if C4D provides a really old version of libstdc++.so
+  if (( $(echo "2024.4 > $C4DVERSION" |bc -l) )); then
+    echo "Cinema 4D version $C4DVERSION is less than 2024.4."
+    echo "  Patching in libstdc++.so from system"
+    export LD_LIBRARY_PATH="/usr/lib64:$LD_LIBRARY_PATH"
+  fi
 else
   echo "setup_c4d_env not found in ${C4DBASE}";
 fi


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`deadline-cloud-for-cinema-4d` is an "alpha release" and during my testing trying to get this up and running on a customer managed fleet on AWS I have had to make several changes to get it working correctly.
### What was the solution? (How)
Each of these commits are aimed to be mostly separate features or fixes however in my testing some of them do build on others.
- [Add COMMANDLINE_EXECUTABLE env var](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/0c261e4efb3600cd4a554164417dc2aeeb6e8302) This implements optional environment variable overrides to point to a custom "Commandline" installation.
- [Forcefully add the dll path for C4D python](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/a5dbdb10519b4b436a80db75335fcaad19a542f1) Implement some DLL patching required for versions of C4D below 2024.2. See https://github.com/danbradham/wheels/issues/4#issuecomment-1772721170
- [Creating an adaptor script wrapper for Linux](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/74da6c2e121f9cccdabd4b5a87c2bb11a48368ad) On Linux, C4D requires environment variables set up and they provide a `setup_c4d_env` script which mostly works. We've built an `adaptor.sh` for Linux to run with will apply the `setup_c4d_env` script. This also introduces some environment variable changes that I found from Deadline10.
- [Include a patch for versions below 2024.4](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/814dc9e77f032b69a34e93097c9290434931cce2) This patch will add `/usr/lib64` to the LD_LIBRARY path if the C4D version is below 2024.4. Versions lower than this had an issue where `c4dplugin.xso64` required libwebkit2gtk even in a headless `-nogui` mode.
- [Add a better safety around the os.environ call](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/8e0d1e18810be185c1469b8cec633c985a27a474) A quick fix around querying for an environment variable that may be None.

### How was this change tested?
I have been working with and using `farm-2573f61b9d784c7fa38e61dbdc39172f` to do all of my testing. This testing implements fixes that get us ready for a Linux render node worker, but currently appear to only work for 2024+. I have tested it on R26 and am getting hanging on launch (unrealted to Deadline as far as I can tell). Once I determine how to get that working, I will implement another PR with R26 fixes potentially.

### Was this change documented?
Yes see `DEVELOPMENT.md`
### Is this a breaking change?
No, the Linux support is a feature and the environment variable support is an optional feature
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*