### PR TITLE
feat: Add DeadlineCloudSubmitter plugin ID to submitter plugin.

### DIFF
--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -17,8 +17,9 @@ else:
 
 import c4d
 
-# TODO: replace with real id, 1062029 is a dev id
-PLUGIN_ID = 1062029
+# This is the ID generated from Maxon's PluginCafe 
+# Plugin ID generator for DeadlineCloudSubmitter.
+PLUGIN_ID = 1064358
 
 class DeadlineCloudRenderCommand(c4d.plugins.CommandData):
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The plugin ID for the submitter used to be a dummy ID which used to output the following warning whenever we used the submitter. 

```
RuntimeError:The plugin ID '1062029' collides with another plugin ID in 'DeadlineCloud.pyp'.
You have to use a unique ID for registering your plugin!
You can get a personal number for free from PluginCafe at www.plugincafe.com
```

### What was the solution? (How)

Generated a unique ID from Maxon's website and updating it here. 

### What is the impact of this change?

We don't get this error anymore. 

### How was this change tested?

I ran this with Windows and Mac OS submitters for Cinema 4D 2025/2024. 

To confirm if the registration was successful, I modified the `DeadlineCloud.pyp` to print the registration status. 

```
    register_val = c4d.plugins.RegisterCommandPlugin(
        id=PLUGIN_ID,
        str="Deadline Cloud Submitter",
        info=0,
        help="Submit to Deadline Cloud",
        dat=DeadlineCloudRenderCommand(),
        icon=None
    )
    print(f"Register val= {register_val}")
```

This resulted in Cinema 4D console to print True. [According to the docs](https://developers.maxon.net/docs/py/2025_0_0/modules/c4d.plugins/index.html#c4d.plugins.RegisterCommandPlugin), this returns True only if the registration is successful.   

<img width="1383" alt="Screenshot 2024-10-09 at 11 15 01 AM" src="https://github.com/user-attachments/assets/5a760c08-366e-40f6-9275-66b9683c62b8">


### Was this change documented?

Added a comment to suggest that this was added from Maxon's PluginCafe Plugin ID generator. 

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*