### PR TITLE
feat: prompt save before submit (#53)

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -239,6 +239,16 @@ def _get_job_template(
 
 def _show_submitter(parent=None, f=Qt.WindowFlags()):
 
+    if Scene.changed():
+        prompt = QtWidgets.QMessageBox.warning(
+            None,
+            "Deadline Cloud",
+            "Save scene changes before submission?",
+            QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel
+        )
+        if prompt == QtWidgets.QMessageBox.Ok:
+            Scene.save()
+
     render_settings = RenderSubmitterUISettings()
 
     # Set the setting defaults that come from the scene

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -245,11 +245,11 @@ def _prompt_save_current_document():
     if not c4d.gui.QuestionDialog("Save scene changes before submission?"):
         # User selected No
         return
-    filepath = doc.GetDocumentPath()
-    filename = doc.GetDocumentName()
-    if filepath:
+    file_path = doc.GetDocumentPath()
+    file_name = doc.GetDocumentName()
+    if file_path:
         # Document save path exists
-        save_path = os.path.join(filepath, filename) + ".c4d"
+        save_path = os.path.join(file_path, file_name)
     else:
         # Prompt with Save As to set path for Untitled document
         save_path = c4d.storage.SaveDialog(c4d.FILESELECTTYPE_ANYTHING, "Save As", "c4d")
@@ -257,11 +257,10 @@ def _prompt_save_current_document():
         if not save_path:
             return
         # Set document path and name
-        path = os.path.dirname(save_path)
+        doc_path = os.path.dirname(save_path)
         base_name = os.path.basename(save_path)
-        name, _ = os.path.splitext(base_name)
-        doc.SetDocumentPath(path)
-        doc.SetDocumentName(name)
+        doc.SetDocumentPath(doc_path)
+        doc.SetDocumentName(base_name)
     # Save document to disk
     c4d.documents.SaveDocument(doc, save_path, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
     # Ensure document is active

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -255,7 +255,10 @@ def _prompt_save_current_document():
         save_path = c4d.storage.SaveDialog(c4d.FILESELECTTYPE_ANYTHING, "Save As", "c4d")
         # Handle user cancels document save
         if not save_path:
-            return
+            c4d.gui.MessageDialog(
+                "Submission canceled. File must be saved to disk before submission."
+            )
+            return False
         # Set document path and name
         doc_path = os.path.dirname(save_path)
         base_name = os.path.basename(save_path)
@@ -271,7 +274,8 @@ def _prompt_save_current_document():
 
 def _show_submitter(parent=None, f=Qt.WindowFlags()):
 
-    _prompt_save_current_document()
+    if _prompt_save_current_document() is False:
+        return
 
     render_settings = RenderSubmitterUISettings()
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -44,7 +44,7 @@ class TakeData:
 
 
 def show_submitter():
-    
+
     if _prompt_save_current_document() is False:
         return
 
@@ -244,36 +244,45 @@ def _get_job_template(
 def _prompt_save_current_document():
     doc = c4d.documents.GetActiveDocument()
     if not doc.GetChanged():
-        # Document has no unsaved changed
-        return
-    if not c4d.gui.QuestionDialog("Save scene changes before submission?"):
-        # User selected No
-        return
+        # Document has no unsaved changes
+        return True
     file_path = doc.GetDocumentPath()
     file_name = doc.GetDocumentName()
+    save_path = None
     if file_path:
         # Document save path exists
         save_path = os.path.join(file_path, file_name)
-    else:
-        # Prompt with Save As to set path for Untitled document
-        save_path = c4d.storage.SaveDialog(c4d.FILESELECTTYPE_ANYTHING, "Save As", "c4d")
-        # Handle user cancels document save
+    if not c4d.gui.QuestionDialog("Save scene changes before submission?"):
+        # User selected No
         if not save_path:
             c4d.gui.MessageDialog(
                 "Submission canceled. File must be saved to disk before submission."
             )
             return False
-        # Set document path and name
-        doc_path = os.path.dirname(save_path)
-        base_name = os.path.basename(save_path)
-        doc.SetDocumentPath(doc_path)
-        doc.SetDocumentName(base_name)
+        else:
+            return True
+    else:
+        if not save_path:
+            # Prompt with Save As to set path for Untitled document
+            save_path = c4d.storage.SaveDialog(c4d.FILESELECTTYPE_ANYTHING, "Save As", "c4d")
+            # Handle user cancels document save
+            if not save_path:
+                c4d.gui.MessageDialog(
+                    "Submission canceled. File must be saved to disk before submission."
+                )
+                return False
+            # Set document path and name
+            doc_path = os.path.dirname(save_path)
+            base_name = os.path.basename(save_path)
+            doc.SetDocumentPath(doc_path)
+            doc.SetDocumentName(base_name)
     # Save document to disk
     c4d.documents.SaveDocument(doc, save_path, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
     # Ensure document is active
     c4d.documents.InsertBaseDocument(doc)
     # Update UI
     c4d.EventAdd()
+    return True
 
 
 def _show_submitter(parent=None, f=Qt.WindowFlags()):

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -44,6 +44,10 @@ class TakeData:
 
 
 def show_submitter():
+    
+    if _prompt_save_current_document() is False:
+        return
+
     try:
         app = QtWidgets.QApplication.instance()
         if not app:
@@ -273,9 +277,6 @@ def _prompt_save_current_document():
 
 
 def _show_submitter(parent=None, f=Qt.WindowFlags()):
-
-    if _prompt_save_current_document() is False:
-        return
 
     render_settings = RenderSubmitterUISettings()
 

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -101,19 +101,6 @@ class Scene:
     """
     Functionality for retrieving settings from the active scene
     """
-    @staticmethod
-    def save() -> bool:
-        """Save active document"""
-        doc = c4d.documents.GetActiveDocument()
-        return c4d.documents.SaveDocument(doc, doc.GetDocumentName(), c4d.SAVEDOCUMENTFLAGS_DIALOGSALLOWED, c4d.FORMAT_C4DEXPORT)
-
-    @staticmethod
-    def changed() -> bool:
-        """
-        Returns True if Active scene has unsaved changes
-        """
-        doc = c4d.documents.GetActiveDocument()
-        return doc.GetChanged()
 
     @staticmethod
     def name() -> str:

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -101,6 +101,19 @@ class Scene:
     """
     Functionality for retrieving settings from the active scene
     """
+    @staticmethod
+    def save() -> bool:
+        """Save active document"""
+        doc = c4d.documents.GetActiveDocument()
+        return c4d.documents.SaveDocument(doc, doc.GetDocumentName(), c4d.SAVEDOCUMENTFLAGS_DIALOGSALLOWED, c4d.FORMAT_C4DEXPORT)
+
+    @staticmethod
+    def changed() -> bool:
+        """
+        Returns True if Active scene has unsaved changes
+        """
+        doc = c4d.documents.GetActiveDocument()
+        return doc.GetChanged()
 
     @staticmethod
     def name() -> str:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

#53 prompt save scene changes before submitting

### What was the solution? (How)

Check for scene changes before submit dialog is shown and prompt user

### What is the impact of this change?

Scene changes properly persisted before submit

### How was this change tested?

C4D 2025

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*