### PR TITLE
fix: handle CRITICAL error in adaptor regex callbacks (#51)

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -191,7 +191,9 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
 
             completed_regexes = [re.compile(".*Finished Rendering.*")]
             progress_regexes = [re.compile(".*Progress ([0-9]+)%.*")]
-            error_regexes = [re.compile(".*Error: .*|.*\\[Error\\].*|.*CRITICAL: .*", re.IGNORECASE)]
+            error_regexes = [
+                re.compile(".*Error: .*|.*\\[Error\\].*|.*CRITICAL: .*", re.IGNORECASE)
+            ]
 
             callback_list.append(RegexCallback(completed_regexes, self._handle_complete))
             callback_list.append(RegexCallback(progress_regexes, self._handle_progress))

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -191,7 +191,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
 
             completed_regexes = [re.compile(".*Finished Rendering.*")]
             progress_regexes = [re.compile(".*Progress ([0-9]+)%.*")]
-            error_regexes = [re.compile(".*Error: .*|.*\\[Error\\].*", re.IGNORECASE)]
+            error_regexes = [re.compile(".*Error: .*|.*\\[Error\\].*|.*CRITICAL: .*", re.IGNORECASE)]
 
             callback_list.append(RegexCallback(completed_regexes, self._handle_complete))
             callback_list.append(RegexCallback(progress_regexes, self._handle_progress))

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -197,8 +197,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
 
             callback_list.append(RegexCallback(completed_regexes, self._handle_complete))
             callback_list.append(RegexCallback(progress_regexes, self._handle_progress))
-            if self.init_data.get("strict_error_checking", False):
-                callback_list.append(RegexCallback(error_regexes, self._handle_error))
+            callback_list.append(RegexCallback(error_regexes, self._handle_error))
 
             callback_list.append(
                 RegexCallback(

--- a/test/deadline_adaptor_for_cinema4d/__init__.py
+++ b/test/deadline_adaptor_for_cinema4d/__init__.py
@@ -1,0 +1,8 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import sys
+from unittest.mock import MagicMock
+
+mock_modules = ["deadline.client.ui.deadline_authentication_status", "c4d", "c4d.documents"]
+
+for module in mock_modules:
+    sys.modules[module] = MagicMock()

--- a/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/__init__.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
@@ -40,3 +40,20 @@ class TestCinema4DAdaptor_on_cleanup:
         # THEN
         assert match is not None
         assert str(adaptor._exc_info) == f"Cinema4D Encountered an Error: {stdout}"
+
+    def test_handle_error(self, init_data: dict) -> None:
+        """Tests that the _handle_error method throws a error runtime error correctly"""
+        # GIVEN
+        adaptor = Cinema4DAdaptor(init_data)
+
+        # WHEN
+        error_regex = re.compile(".*Error: .*|.*\\[Error\\].*|.*CRITICAL: .*")
+        stdout = "Redshift Error: Maxon licensing error: User not logged in (7)"
+
+        match = error_regex.search(stdout)
+        if match:
+            adaptor._handle_error(match)
+
+        # THEN
+        assert match is not None
+        assert str(adaptor._exc_info) == f"Cinema4D Encountered an Error: {stdout}"

--- a/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+import re
+import pytest
+from deadline.cinema4d_adaptor.Cinema4DAdaptor import Cinema4DAdaptor
+
+
+@pytest.fixture()
+def init_data() -> dict:
+    """
+    Pytest Fixture to return an init_data dictionary that passes validation
+
+    Returns:
+        dict: An init_data dictionary
+    """
+    return {
+        "scene_file": "C:\\Users\\user123\\test.c4d",
+        "take": "Main",
+        "output_path": "C:\\Users\\user123\\test_render",
+        "multi_pass_path": "",
+    }
+
+
+class TestCinema4DAdaptor_on_cleanup:
+
+    def test_handle_critical(self, init_data: dict) -> None:
+        """Tests that the _handle_error method throws a critical runtime error correctly"""
+        # GIVEN
+        adaptor = Cinema4DAdaptor(init_data)
+
+        # WHEN
+        error_regex = re.compile(".*Error: .*|.*\\[Error\\].*|.*CRITICAL: .*")
+        stdout = "CRITICAL: Stop [ge_file.cpp(1172)]"
+
+        match = error_regex.search(stdout)
+        if match:
+            adaptor._handle_error(match)
+
+        # THEN
+        assert match is not None
+        assert str(adaptor._exc_info) == f"Cinema4D Encountered an Error: {stdout}"

--- a/test/deadline_adaptor_for_cinema4d/unit/__init__.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

#51 DCM job status would show success when task failed due to CRITICAL error

### What was the solution? (How)

Add regex callback to handle CRITICAL log messages

### What is the impact of this change?

Augment adaptor error_regexes pattern

### How was this change tested?

By manually testing the regex against [log file in the issue ](https://github.com/user-attachments/files/15973717/Deadline.Cloud.Farm_Customer.Managed.Jobs_session-7faa4fd9cf2a4dfeabd65ee9a1c2ac25.log)

### Was this change documented?

No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*