### PR TITLE
feat!: add adaptor output path mapping and overrides (#55)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,15 +38,14 @@ hatch run all:test
 
 ## Submitter environment
 
-Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
-submitter and adaptor uses to set sys.path explictly and load deadline modules.
+Install deadline in a [supported search path](https://developers.maxon.net/docs/py/2024_0_0a/manuals/manual_py_libraries.html#python-interpreter-bound-search-paths) or set a [custom interpreter path](https://developers.maxon.net/docs/py/2024_0_0a/manuals/manual_py_libraries.html#custom-interpreter-bound-search-paths) to the deadline install location.
 
 - install deadline-cloud with pyside
 - set env below
 
 ```
 # deadline-cloud lib with pyside
-export DEADLINE_CLOUD_PYTHONPATH="/path/to/deadline-cloud/site-packages"
+export C4DPYTHONPATH311 "/path/to/deadline-cloud/site-packages"
 # configure cinema4d to find extension entry point
 export g_additionalModulePath="/path/to/deadline-cloud-for-cinema4d/deadline_cloud_extension"
 ```
@@ -56,8 +55,7 @@ export g_additionalModulePath="/path/to/deadline-cloud-for-cinema4d/deadline_clo
 
 ## Worker adaptor environment
 
-Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
-adaptor uses to set sys.path explictly and load deadline modules.
+Install deadline in a [supported search path](https://developers.maxon.net/docs/py/2024_0_0a/manuals/manual_py_libraries.html#python-interpreter-bound-search-paths) or set a [custom interpreter path](https://developers.maxon.net/docs/py/2024_0_0a/manuals/manual_py_libraries.html#custom-interpreter-bound-search-paths) to the deadline install location.
 
 ### Linux
 
@@ -68,16 +66,6 @@ client.
 Example linux env below:
 
 ```
-export DEADLINE_CLOUD_PYTHONPATH="/tmp/lib/python3.11/site-packages"
+export C4DPYTHONPATH311 "/path/to/deadline-cloud/site-packages"
 export DEADLINE_CINEMA4D_EXE="/opt/maxon/cinema4dr2024.200/bin/c4d"
-```
-
-### Windows
-
-To run the adaptor on Windows, you'll have to configure the environment variable `DEADLINE_CLOUD_PYTHONPATH` (like the submitter above) and install pywin32 into Cinema4D's python. Example:
-
-```
-set DEADLINE_CLOUD_PYTHONPATH="C:\path\to\deadline-cloud\site-packages"
-"C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe" -m ensurepip   
-"C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe" -m pip install pywin32  
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,7 +45,7 @@ Install deadline in a [supported search path](https://developers.maxon.net/docs/
 
 ```
 # deadline-cloud lib with pyside
-export C4DPYTHONPATH311 "/path/to/deadline-cloud/site-packages"
+export C4DPYTHONPATH311="/path/to/deadline-cloud/site-packages"
 # configure cinema4d to find extension entry point
 export g_additionalModulePath="/path/to/deadline-cloud-for-cinema4d/deadline_cloud_extension"
 ```
@@ -66,6 +66,6 @@ client.
 Example linux env below:
 
 ```
-export C4DPYTHONPATH311 "/path/to/deadline-cloud/site-packages"
+export C4DPYTHONPATH311="/path/to/deadline-cloud/site-packages"
 export DEADLINE_CINEMA4D_EXE="/opt/maxon/cinema4dr2024.200/bin/c4d"
 ```

--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -4,12 +4,7 @@ import sys
 root = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(root, 'modules'))
 
-if 'cinema4d_submitter' not in sys.modules.keys():
-    python_path = os.getenv('DEADLINE_CLOUD_PYTHONPATH')
-    python_paths = python_path.split(os.pathsep)
-    for n in python_paths:
-        if n not in sys.path:
-            sys.path.append(n)
+if 'deadline.cinema4d_submitter' not in sys.modules.keys():
     import deadline.cinema4d_submitter
 else:
     import importlib

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -26,7 +26,7 @@ class Cinema4DNotRunningError(Exception):
     pass
 
 
-_FIRST_CINEMA4D_ACTIONS = ["scene_file", "take"]
+_FIRST_CINEMA4D_ACTIONS = ["scene_file", "take", "output_path", "multi_pass_path"]
 _CINEMA4D_RUN_KEYS = {
     "frame",
 }

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
@@ -3,7 +3,9 @@
     "type": "object",
     "properties": {
         "scene_file": { "type": "string" },
-        "take": { "type": "string" }
+        "take": { "type": "string" },
+        "output_path": { "type": "string" },
+        "multi_pass_path": { "type": "string" }
     },
     "required": [ "scene_file" ]
 }

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -30,6 +30,8 @@ class Cinema4DHandler:
             "take": self.set_take,
             "frame": self.set_frame,
             "start_render": self.start_render,
+            "output_path": self.output_path,
+            "multi_pass_path": self.multi_pass_path,
         }
         self.render_kwargs = {}
         self.take = "Main"
@@ -72,6 +74,20 @@ class Cinema4DHandler:
             print("Error: RenderDocument: %s" % result)
         else:
             print("Finished Rendering")
+
+    def output_path(self, data: dict) -> None:
+        output_path = data.get("output_path", "")
+        if output_path:
+            doc = c4d.documents.GetActiveDocument()
+            render_data = doc.GetActiveRenderData()
+            render_data[c4d.RDATA_PATH] = output_path
+
+    def multi_pass_path(self, data: dict) -> None:
+        multi_pass_path = data.get("multi_pass_path", "")
+        if multi_pass_path:
+            doc = c4d.documents.GetActiveDocument()
+            render_data = doc.GetActiveRenderData()
+            render_data[c4d.RDATA_MULTIPASS_FILENAME] = multi_pass_path
 
     def set_take(self, data: dict) -> None:
         """

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
@@ -3,27 +3,13 @@ import os
 import sys
 import traceback
 
-import c4d
-
 print('c4d python version: %s' % sys.version)
 print('system paths:')
 for n in sys.path:
     print(n)
 
-# cinema4d doesn't use PYTHONPATH so explicitly load modules
-if 'openjd' not in sys.modules.keys():
-    python_path = os.getenv('DEADLINE_CLOUD_PYTHONPATH')
-    python_paths = python_path.split(os.pathsep)
-    for p in python_paths:
-        if sys.platform == 'win32':
-            try:
-                os.add_dll_directory(p)
-            except Exception:
-                print('add_dll_directory failed: %s' % p)
-        sys.path.append(p)
-
+import c4d
 from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client import main
-
 
 def parse_argv(argv):
     for arg in argv:

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -25,6 +25,20 @@ parameterDefinitions:
     groupLabel: Cinema4D Settings
   description: The frames to render. E.g. 1-3,8,11-15
   minLength: 1
+- name: OutputPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Default image output
+    groupLabel: Cinema4D Settings
+  description: Image output path
+- name: MultiPassPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Multi-pass output path
+    groupLabel: Cinema4D Settings
+  description: Multi-pass image output
 steps:
 - name: Render
   parameterSpace:
@@ -43,6 +57,8 @@ steps:
         data: |
           scene_file: '{{Param.Cinema4DFile}}'
           take: 'Main'
+          output_path: '{{Param.OutputPath}}'
+          multi_pass_path: '{{Param.MultiPassPath}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -70,6 +70,8 @@ def _get_parameter_values(
 
     # Set the c4d scene file value
     parameter_values.append({"name": "Cinema4DFile", "value": Scene.name()})
+    parameter_values.append({"name": "OutputPath", "value": settings.output_path})
+    parameter_values.append({"name": "MultiPassPath", "value": settings.multi_pass_path})
 
     if settings.override_frame_range:
         frame_list = settings.frame_list
@@ -168,7 +170,7 @@ def _get_job_template(
         else:
             # Update the init data of the step
             init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
-            init_data["data"] = "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'" % take_data.name
+            init_data["data"] = "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'" % take_data.name
 
     # If Arnold is one of the renderers, add Arnold-specific parameters
     if "arnold" in renderers:
@@ -244,10 +246,12 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
     # Set the setting defaults that come from the scene
     render_settings.name = Path(Scene.name()).name
     render_settings.frame_list = str(Animation.frame_list())
-    render_settings.output_path = Scene.output_path()
+    default_path, multi_path = Scene.get_output_paths()
+    render_settings.output_path = default_path
+    render_settings.multi_pass_path = multi_path
 
     # Load the sticky settings
-    render_settings.load_sticky_settings(Scene.name())
+    # render_settings.load_sticky_settings(Scene.name())
 
     doc = c4d.documents.GetActiveDocument()
     take_data = doc.GetTakeData()
@@ -308,6 +312,12 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
         if settings.take_selection == TakeSelection.CURRENT:
             submit_takes = current_data_list
 
+        # Add overrides to asset references
+        if settings.output_path:
+            asset_references.output_directories.add(os.path.dirname(settings.output_path))
+        if settings.multi_pass_path:
+            asset_references.output_directories.add(os.path.dirname(settings.multi_pass_path))
+
         # # Check if there are multiple frame ranges across the takes
         first_frame_range = submit_takes[0].frame_range
         per_take_frames_parameters = not settings.override_frame_range and any(
@@ -355,7 +365,6 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
 
     for take_data in take_data_list:
         auto_detected_attachments.output_directories.update(take_data.output_directories)
-
     attachments = AssetReferences(
         input_filenames=set(render_settings.input_filenames),
         input_directories=set(render_settings.input_directories),

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -170,7 +170,10 @@ def _get_job_template(
         else:
             # Update the init data of the step
             init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
-            init_data["data"] = "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'" % take_data.name
+            init_data["data"] = (
+                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'"
+                % take_data.name
+            )
 
     # If Arnold is one of the renderers, add Arnold-specific parameters
     if "arnold" in renderers:
@@ -251,7 +254,7 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
     render_settings.multi_pass_path = multi_path
 
     # Load the sticky settings
-    # render_settings.load_sticky_settings(Scene.name())
+    render_settings.load_sticky_settings(Scene.name())
 
     doc = c4d.documents.GetActiveDocument()
     take_data = doc.GetTakeData()

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -25,6 +25,7 @@ class RenderSubmitterUISettings:
     override_frame_range: bool = field(default=False, metadata={"sticky": True})
     frame_list: str = field(default="", metadata={"sticky": True})
     output_path: str = field(default="")
+    multi_pass_path: str = field(default="")
 
     input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -140,7 +140,7 @@ class Scene:
             "_frame": doc.GetTime().GetFrame(doc.GetFps()),
         }
         if take:
-            rpd["take"] = take
+            rpd["_take"] = take
         image_paths = set()
         if render_data[c4d.RDATA_SAVEIMAGE]:
             path = render_data[c4d.RDATA_PATH]
@@ -178,9 +178,6 @@ class Scene:
     def get_output_paths(take=None) -> str:
         doc = c4d.documents.GetActiveDocument()
         doc_path = doc.GetDocumentPath()
-        if not take:
-            take_data = doc.GetTakeData()
-            take = take_data.GetCurrentTake()
         render_data = Scene.get_render_data(doc=doc, take=take)
         render_base_container_instance = render_data.GetDataInstance()
         rpd = {
@@ -190,7 +187,7 @@ class Scene:
             "_frame": doc.GetTime().GetFrame(doc.GetFps()),
         }
         if take:
-            rpd["take"] = take
+            rpd["_take"] = take
         default_out = ""
         multi_out = ""
         if render_data[c4d.RDATA_SAVEIMAGE]:

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -146,7 +146,7 @@ class Scene:
             path = render_data[c4d.RDATA_PATH]
             xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
             if not os.path.isabs(xpath):
-                if xpath.startswith('./'):
+                if xpath.startswith("./"):
                     xpath = xpath[2:]
                 xpath = os.path.join(doc_path, xpath)
             image_paths.add(os.path.dirname(os.path.normpath(xpath)))
@@ -154,7 +154,7 @@ class Scene:
             path = render_data[c4d.RDATA_MULTIPASS_FILENAME]
             xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
             if not os.path.isabs(xpath):
-                if xpath.startswith('./'):
+                if xpath.startswith("./"):
                     xpath = xpath[2:]
                 xpath = os.path.join(doc_path, xpath)
             image_paths.add(os.path.dirname(os.path.normpath(xpath)))
@@ -182,22 +182,22 @@ class Scene:
             take_data = doc.GetTakeData()
             take = take_data.GetCurrentTake()
         render_data = Scene.get_render_data(doc=doc, take=take)
-        rbc = render_data.GetDataInstance()
+        render_base_container_instance = render_data.GetDataInstance()
         rpd = {
             "_doc": doc,
             "_rData": render_data,
-            "_rBc": rbc,
+            "_rBc": render_base_container_instance,
             "_frame": doc.GetTime().GetFrame(doc.GetFps()),
         }
         if take:
             rpd["take"] = take
-        default_out = ''
-        multi_out = ''
+        default_out = ""
+        multi_out = ""
         if render_data[c4d.RDATA_SAVEIMAGE]:
             path = render_data[c4d.RDATA_PATH]
             xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
             if not os.path.isabs(xpath):
-                if xpath.startswith('./'):
+                if xpath.startswith("./"):
                     xpath = xpath[2:]
                 xpath = os.path.join(doc_path, xpath)
             default_out = os.path.normpath(xpath)
@@ -205,7 +205,7 @@ class Scene:
             path = render_data[c4d.RDATA_MULTIPASS_FILENAME]
             xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
             if not os.path.isabs(xpath):
-                if xpath.startswith('./'):
+                if xpath.startswith("./"):
                     xpath = xpath[2:]
                 xpath = os.path.join(doc_path, xpath)
             multi_out = os.path.normpath(xpath)

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Tuple
 
 import c4d
 
@@ -175,7 +175,10 @@ class Scene:
         return render_data
 
     @staticmethod
-    def get_output_paths(take=None) -> str:
+    def get_output_paths(take=None) -> Tuple[str, str]:
+        """
+        Returns the default and multi-pass output paths.
+        """
         doc = c4d.documents.GetActiveDocument()
         doc_path = doc.GetDocumentPath()
         render_data = Scene.get_render_data(doc=doc, take=take)
@@ -207,14 +210,6 @@ class Scene:
                 xpath = os.path.join(doc_path, xpath)
             multi_out = os.path.normpath(xpath)
         return default_out, multi_out
-
-    @staticmethod
-    def output_path() -> str:
-        """
-        Returns the path to the default output directory.
-        """
-        doc = c4d.documents.GetActiveDocument()
-        return doc.GetDocumentPath()
 
 
 @dataclass

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -95,9 +95,18 @@ class SceneSettingsWidget(QWidget):
 
     def _build_ui(self, settings):
         lyt = QGridLayout(self)
+        self.op_path_chck = QCheckBox("Override Output Path", self)
         self.op_path_txt = FileSearchLineEdit(directory_only=True)
-        lyt.addWidget(QLabel("Output Path"), 1, 0)
+        lyt.addWidget(self.op_path_chck, 1, 0)
         lyt.addWidget(self.op_path_txt, 1, 1)
+        self.op_path_chck.stateChanged.connect(self.activate_path_changed)
+
+        self.op_multi_path_chck = QCheckBox("Override Multi-Pass Path", self)
+        self.op_multi_path_txt = FileSearchLineEdit(directory_only=True)
+        lyt.addWidget(self.op_multi_path_chck, 2, 0)
+        lyt.addWidget(self.op_multi_path_txt, 2, 1)
+        self.op_multi_path_chck.stateChanged.connect(self.activate_multi_path_changed)
+
         self.layers_box = QComboBox(self)
         layer_items = [
             (TakeSelection.MAIN, "Main Take"),
@@ -107,8 +116,8 @@ class SceneSettingsWidget(QWidget):
         ]
         for layer_value, text in layer_items:
             self.layers_box.addItem(text, layer_value)
-        lyt.addWidget(QLabel("Takes"), 2, 0)
-        lyt.addWidget(self.layers_box, 2, 1)
+        lyt.addWidget(QLabel("Takes"), 3, 0)
+        lyt.addWidget(self.layers_box, 3, 1)
 
         self.frame_override_chck = QCheckBox("Override Frame Range", self)
         self.frame_override_txt = QLineEdit(self)
@@ -125,7 +134,12 @@ class SceneSettingsWidget(QWidget):
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 
     def _configure_settings(self, settings):
+        self.op_path_chck.setChecked(False)
+        self.op_path_txt.setEnabled(False)
+        self.op_multi_path_chck.setChecked(False)
+        self.op_multi_path_txt.setEnabled(False)
         self.op_path_txt.setText(settings.output_path)
+        self.op_multi_path_txt.setText(settings.multi_pass_path)
         self.frame_override_chck.setChecked(settings.override_frame_range)
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)
@@ -142,6 +156,7 @@ class SceneSettingsWidget(QWidget):
         Update a scene settings object with the latest values.
         """
         settings.output_path = self.op_path_txt.text()
+        settings.multi_pass_path = self.op_multi_path_txt.text()
 
         settings.override_frame_range = self.frame_override_chck.isChecked()
         settings.frame_list = self.frame_override_txt.text()
@@ -158,3 +173,9 @@ class SceneSettingsWidget(QWidget):
         Set the activated/deactivated status of the Frame override text box
         """
         self.frame_override_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)
+
+    def activate_path_changed(self, state):
+        self.op_path_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)
+
+    def activate_multi_path_changed(self, state):
+        self.op_multi_path_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

#55 adaptor not path mapping or overriding output path

### What was the solution? (How)

- Add get_output_paths() to Scene to return expanded default and multi-pass paths
- Add output and multi-pass paths to parameters, init data, ui and adaptor actions
- Remove DEADLINE_PYTHON_PATH to ensure proper loading of win32 modules

### What is the impact of this change?

User can override output path and asset outputs are detected and downloadable

### How was this change tested?

- Submitted scene with default settings Override Output Path disabled, the path was mapped by adaptor and files downloaded
- Submitted scene with Override Output Path enabled and augmented to a different name, the path was mapped by adaptor and files downloaded
 
### Was this change documented?

No

### Is this a breaking change?

Potentially -- logic relying on DEADLINE_PYTHON_PATH is removed so this may impact installation instructions 

Manually adding modules from an arbitrary DEADLINE_PYTHON_PATH location failed to properly boostrap more complex modules like win32 with extra DLLs (even when calling os.add_dll_directory)

Installing the modules to a location expected by the embedded python (such as `C:\Users\<user>\AppData\Roaming\Maxon\python\python311\libs`) solves this issue and makes the plugin a more idiomatic Cinema4D extension.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*