### PR TITLE
test: add plain text job_bundle_output_tests

### DIFF
--- a/job_bundle_output_tests/physical/expected_job_bundle/asset_references.yaml
+++ b/job_bundle_output_tests/physical/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - C:\normalized\job\bundle\dir\physical.c4d
+  outputs:
+    directories:
+    - C:\normalized\job\bundle\dir\renders
+  referencedPaths: []

--- a/job_bundle_output_tests/physical/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/physical/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,17 @@
+parameterValues:
+- name: Cinema4DFile
+  value: C:\normalized\job\bundle\dir\physical.c4d
+- name: OutputPath
+  value: C:\normalized\job\bundle\dir\renders\physical
+- name: MultiPassPath
+  value: ''
+- name: Frames
+  value: '1'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/job_bundle_output_tests/physical/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/physical/expected_job_bundle/template.yaml
@@ -1,0 +1,103 @@
+specificationVersion: jobtemplate-2023-09
+name: physical.c4d
+parameterDefinitions:
+- name: Cinema4DFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Cinema4D Document File
+    groupLabel: Cinema4D Settings
+    fileFilters:
+    - label: Cinema4D document files
+      patterns:
+      - '*.c4d'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Cinema4D document file to render.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Cinema4D Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: OutputPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Default image output
+    groupLabel: Cinema4D Settings
+  description: Image output path
+- name: MultiPassPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Multi-pass output path
+    groupLabel: Cinema4D Settings
+  description: Multi-pass image output
+steps:
+- name: Main
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  stepEnvironments:
+  - name: Cinema4D
+    description: Runs Cinema4D in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |-
+          scene_file: '{{Param.Cinema4DFile}}'
+          take: 'Main'
+          output_path: '{{Param.OutputPath}}'
+          multi_pass_path: '{{Param.MultiPassPath}}'
+      actions:
+        onEnter:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+        onExit:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+    actions:
+      onRun:
+        command: cinema4d-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE

--- a/job_bundle_output_tests/physical/scene/cube.py
+++ b/job_bundle_output_tests/physical/scene/cube.py
@@ -1,0 +1,31 @@
+import os
+import c4d
+
+
+def main():
+    doc = c4d.documents.GetActiveDocument()
+    doc.Flush()
+    cube = c4d.BaseObject(c4d.Ocube)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(200, 200, 200)
+    cube.SetAbsPos(c4d.Vector(0, 170, -170))
+    doc.InsertObject(cube)
+    render_data = doc.GetActiveRenderData()
+    render_data[c4d.RDATA_PATH] = "renders/$prj"
+    frame_start = c4d.BaseTime(1, doc.GetFps())
+    frame_end = c4d.BaseTime(1, doc.GetFps())
+    render_data[c4d.RDATA_FRAMEFROM] = frame_start
+    render_data[c4d.RDATA_FRAMETO] = frame_end
+    render_data[c4d.RDATA_RENDERENGINE] = 1023342  # physical
+
+    save_dir = os.path.dirname(__file__)
+    save_name = "physical.c4d"
+    save_file = os.path.join(save_dir, save_name)
+    doc.SetDocumentPath(save_dir)
+    doc.SetDocumentName(save_name)
+    c4d.documents.SaveDocument(doc, save_file, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
+
+    c4d.EventAdd()
+
+
+if __name__ == "__main__":
+    main()

--- a/job_bundle_output_tests/redshift/expected_job_bundle/asset_references.yaml
+++ b/job_bundle_output_tests/redshift/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - C:\normalized\job\bundle\dir\redshift.c4d
+  outputs:
+    directories:
+    - C:\normalized\job\bundle\dir\renders
+  referencedPaths: []

--- a/job_bundle_output_tests/redshift/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/redshift/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,17 @@
+parameterValues:
+- name: Cinema4DFile
+  value: C:\normalized\job\bundle\dir\redshift.c4d
+- name: OutputPath
+  value: C:\normalized\job\bundle\dir\renders\redshift
+- name: MultiPassPath
+  value: ''
+- name: Frames
+  value: '1'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/job_bundle_output_tests/redshift/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/redshift/expected_job_bundle/template.yaml
@@ -1,0 +1,103 @@
+specificationVersion: jobtemplate-2023-09
+name: redshift.c4d
+parameterDefinitions:
+- name: Cinema4DFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Cinema4D Document File
+    groupLabel: Cinema4D Settings
+    fileFilters:
+    - label: Cinema4D document files
+      patterns:
+      - '*.c4d'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Cinema4D document file to render.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Cinema4D Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: OutputPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Default image output
+    groupLabel: Cinema4D Settings
+  description: Image output path
+- name: MultiPassPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Multi-pass output path
+    groupLabel: Cinema4D Settings
+  description: Multi-pass image output
+steps:
+- name: Main
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  stepEnvironments:
+  - name: Cinema4D
+    description: Runs Cinema4D in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |-
+          scene_file: '{{Param.Cinema4DFile}}'
+          take: 'Main'
+          output_path: '{{Param.OutputPath}}'
+          multi_pass_path: '{{Param.MultiPassPath}}'
+      actions:
+        onEnter:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+        onExit:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+    actions:
+      onRun:
+        command: cinema4d-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE

--- a/job_bundle_output_tests/redshift/scene/cube.py
+++ b/job_bundle_output_tests/redshift/scene/cube.py
@@ -1,0 +1,30 @@
+import os
+import c4d
+
+
+def main():
+    doc = c4d.documents.GetActiveDocument()
+    doc.Flush()
+    cube = c4d.BaseObject(c4d.Ocube)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(200, 200, 200)
+    cube.SetAbsPos(c4d.Vector(0, 170, -170))
+    doc.InsertObject(cube)
+    render_data = doc.GetActiveRenderData()
+    render_data[c4d.RDATA_PATH] = "renders/$prj"
+    frame_start = c4d.BaseTime(1, doc.GetFps())
+    frame_end = c4d.BaseTime(1, doc.GetFps())
+    render_data[c4d.RDATA_FRAMEFROM] = frame_start
+    render_data[c4d.RDATA_FRAMETO] = frame_end
+    render_data[c4d.RDATA_RENDERENGINE] = 1036219  # redshift
+    save_dir = os.path.dirname(__file__)
+    save_name = "redshift.c4d"
+    save_file = os.path.join(save_dir, save_name)
+    doc.SetDocumentPath(save_dir)
+    doc.SetDocumentName(save_name)
+    c4d.documents.SaveDocument(doc, save_file, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
+    c4d.documents.InsertBaseDocument(doc)
+    c4d.EventAdd()
+
+
+if __name__ == "__main__":
+    main()

--- a/job_bundle_output_tests/redshift_multipass/expected_job_bundle/asset_references.yaml
+++ b/job_bundle_output_tests/redshift_multipass/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - C:\normalized\job\bundle\dir\redshift_multipass.c4d
+  outputs:
+    directories:
+    - C:\normalized\job\bundle\dir\renders
+  referencedPaths: []

--- a/job_bundle_output_tests/redshift_multipass/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/redshift_multipass/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,17 @@
+parameterValues:
+- name: Cinema4DFile
+  value: C:\normalized\job\bundle\dir\redshift_multipass.c4d
+- name: OutputPath
+  value: ''
+- name: MultiPassPath
+  value: C:\normalized\job\bundle\dir\renders\redshift_multipass_multipass
+- name: Frames
+  value: '1'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
@@ -1,0 +1,103 @@
+specificationVersion: jobtemplate-2023-09
+name: redshift_multipass.c4d
+parameterDefinitions:
+- name: Cinema4DFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Cinema4D Document File
+    groupLabel: Cinema4D Settings
+    fileFilters:
+    - label: Cinema4D document files
+      patterns:
+      - '*.c4d'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Cinema4D document file to render.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Cinema4D Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: OutputPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Default image output
+    groupLabel: Cinema4D Settings
+  description: Image output path
+- name: MultiPassPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Multi-pass output path
+    groupLabel: Cinema4D Settings
+  description: Multi-pass image output
+steps:
+- name: Main
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  stepEnvironments:
+  - name: Cinema4D
+    description: Runs Cinema4D in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |-
+          scene_file: '{{Param.Cinema4DFile}}'
+          take: 'Main'
+          output_path: '{{Param.OutputPath}}'
+          multi_pass_path: '{{Param.MultiPassPath}}'
+      actions:
+        onEnter:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+        onExit:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+    actions:
+      onRun:
+        command: cinema4d-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE

--- a/job_bundle_output_tests/redshift_multipass/scene/cube.py
+++ b/job_bundle_output_tests/redshift_multipass/scene/cube.py
@@ -1,0 +1,33 @@
+import os
+import c4d
+
+
+def main():
+    doc = c4d.documents.GetActiveDocument()
+    doc.Flush()
+    cube = c4d.BaseObject(c4d.Ocube)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(200, 200, 200)
+    cube.SetAbsPos(c4d.Vector(0, 170, -170))
+    doc.InsertObject(cube)
+    render_data = doc.GetActiveRenderData()
+    render_data[c4d.RDATA_SAVEIMAGE] = False
+    render_data[c4d.RDATA_MULTIPASS_SAVEIMAGE] = True
+    render_data[c4d.RDATA_MULTIPASS_FILENAME] = "renders/$prj_multipass"
+    frame_start = c4d.BaseTime(1, doc.GetFps())
+    frame_end = c4d.BaseTime(1, doc.GetFps())
+    render_data[c4d.RDATA_FRAMEFROM] = frame_start
+    render_data[c4d.RDATA_FRAMETO] = frame_end
+    render_data[c4d.RDATA_RENDERENGINE] = 1036219  # redshift
+    save_dir = os.path.dirname(__file__)
+    save_name = "redshift_multipass.c4d"
+    save_file = os.path.join(save_dir, save_name)
+    doc.SetDocumentPath(save_dir)
+    doc.SetDocumentName(save_name)
+    c4d.documents.SaveDocument(doc, save_file, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
+    c4d.documents.InsertBaseDocument(doc)
+    c4d.EventAdd()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/job_bundle_output_tests/redshift_multipass/scene/cube.py
+++ b/job_bundle_output_tests/redshift_multipass/scene/cube.py
@@ -30,4 +30,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/job_bundle_output_tests/redshift_takes/expected_job_bundle/asset_references.yaml
+++ b/job_bundle_output_tests/redshift_takes/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,9 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - C:\normalized\job\bundle\dir\redshift_takes.c4d
+  outputs:
+    directories:
+    - C:\normalized\job\bundle\dir\renders
+  referencedPaths: []

--- a/job_bundle_output_tests/redshift_takes/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/redshift_takes/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,17 @@
+parameterValues:
+- name: Cinema4DFile
+  value: C:\normalized\job\bundle\dir\redshift_takes.c4d
+- name: OutputPath
+  value: C:\normalized\job\bundle\dir\renders\redshift_takes_$take
+- name: MultiPassPath
+  value: ''
+- name: Frames
+  value: '1'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/job_bundle_output_tests/redshift_takes/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/redshift_takes/expected_job_bundle/template.yaml
@@ -1,0 +1,164 @@
+specificationVersion: jobtemplate-2023-09
+name: redshift_takes.c4d
+parameterDefinitions:
+- name: Cinema4DFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Cinema4D Document File
+    groupLabel: Cinema4D Settings
+    fileFilters:
+    - label: Cinema4D document files
+      patterns:
+      - '*.c4d'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Cinema4D document file to render.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Cinema4D Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: OutputPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Default image output
+    groupLabel: Cinema4D Settings
+  description: Image output path
+- name: MultiPassPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Multi-pass output path
+    groupLabel: Cinema4D Settings
+  description: Multi-pass image output
+steps:
+- name: Main
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  stepEnvironments:
+  - name: Cinema4D
+    description: Runs Cinema4D in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |-
+          scene_file: '{{Param.Cinema4DFile}}'
+          take: 'Main'
+          output_path: 'C:\normalized\job\bundle\dir\renders\redshift_takes_$take'
+          multi_pass_path: ''
+      actions:
+        onEnter:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+        onExit:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+    actions:
+      onRun:
+        command: cinema4d-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+- name: A
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  stepEnvironments:
+  - name: Cinema4D
+    description: Runs Cinema4D in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |-
+          scene_file: '{{Param.Cinema4DFile}}'
+          take: 'A'
+          output_path: 'C:\normalized\job\bundle\dir\renders\redshift_takes_$take'
+          multi_pass_path: ''
+      actions:
+        onEnter:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+        onExit:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+    actions:
+      onRun:
+        command: cinema4d-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE

--- a/job_bundle_output_tests/redshift_takes/scene/cube.py
+++ b/job_bundle_output_tests/redshift_takes/scene/cube.py
@@ -1,0 +1,39 @@
+import os
+import c4d
+
+
+def main():
+    doc = c4d.documents.GetActiveDocument()
+    doc.Flush()
+    cube = c4d.BaseObject(c4d.Ocube)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(200, 200, 200)
+    cube.SetAbsPos(c4d.Vector(0, 170, -170))
+    doc.InsertObject(cube)
+    take_data = doc.GetTakeData()
+    main_take = take_data.GetMainTake()
+    take_a = take_data.AddTake("", main_take, main_take)
+    take_a.SetName("A")
+    take_data.SetCurrentTake(take_a)
+    take_a.OverrideNode(take_data, cube, False)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(100, 100, 100)
+    take_data.SetCurrentTake(main_take)
+    render_data = doc.GetActiveRenderData()
+    render_data[c4d.RDATA_PATH] = "renders/$prj_$take"
+    frame_start = c4d.BaseTime(1, doc.GetFps())
+    frame_end = c4d.BaseTime(1, doc.GetFps())
+    render_data[c4d.RDATA_FRAMEFROM] = frame_start
+    render_data[c4d.RDATA_FRAMETO] = frame_end
+    render_data[c4d.RDATA_RENDERENGINE] = 1036219  # redshift
+    save_dir = os.path.dirname(__file__)
+    save_name = "redshift_takes.c4d"
+    save_file = os.path.join(save_dir, save_name)
+    doc.SetDocumentPath(save_dir)
+    doc.SetDocumentName(save_name)
+    c4d.documents.SaveDocument(doc, save_file, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
+    c4d.documents.InsertBaseDocument(doc)
+    c4d.EventAdd()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/job_bundle_output_tests/redshift_takes/scene/cube.py
+++ b/job_bundle_output_tests/redshift_takes/scene/cube.py
@@ -36,4 +36,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/job_bundle_output_tests/redshift_textured/expected_job_bundle/asset_references.yaml
+++ b/job_bundle_output_tests/redshift_textured/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,10 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - C:\normalized\job\bundle\dir\redshift_textured.c4d
+    - C:\normalized\job\bundle\dir\tex\checkerboard.bmp
+  outputs:
+    directories:
+    - C:\normalized\job\bundle\dir\renders
+  referencedPaths: []

--- a/job_bundle_output_tests/redshift_textured/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/redshift_textured/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,17 @@
+parameterValues:
+- name: Cinema4DFile
+  value: C:\normalized\job\bundle\dir\redshift_textured.c4d
+- name: OutputPath
+  value: C:\normalized\job\bundle\dir\renders\redshift_textured
+- name: MultiPassPath
+  value: ''
+- name: Frames
+  value: '1'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/job_bundle_output_tests/redshift_textured/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/redshift_textured/expected_job_bundle/template.yaml
@@ -1,0 +1,103 @@
+specificationVersion: jobtemplate-2023-09
+name: redshift_textured.c4d
+parameterDefinitions:
+- name: Cinema4DFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Cinema4D Document File
+    groupLabel: Cinema4D Settings
+    fileFilters:
+    - label: Cinema4D document files
+      patterns:
+      - '*.c4d'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Cinema4D document file to render.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Cinema4D Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: OutputPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Default image output
+    groupLabel: Cinema4D Settings
+  description: Image output path
+- name: MultiPassPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Multi-pass output path
+    groupLabel: Cinema4D Settings
+  description: Multi-pass image output
+steps:
+- name: Main
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  stepEnvironments:
+  - name: Cinema4D
+    description: Runs Cinema4D in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |-
+          scene_file: '{{Param.Cinema4DFile}}'
+          take: 'Main'
+          output_path: '{{Param.OutputPath}}'
+          multi_pass_path: '{{Param.MultiPassPath}}'
+      actions:
+        onEnter:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+        onExit:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+    actions:
+      onRun:
+        command: cinema4d-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE

--- a/job_bundle_output_tests/redshift_textured/scene/cube.py
+++ b/job_bundle_output_tests/redshift_textured/scene/cube.py
@@ -1,0 +1,74 @@
+import os
+import struct
+import c4d
+
+
+def _checkerboard_bmp(filename):
+    width = 128
+    height = 128
+    color1 = (255, 255, 255)
+    color2 = (0, 0, 0)
+    # BMP file header
+    file_size = 14 + 40 + (width * height * 3)
+    file_header = struct.pack("<2sIHHI", b"BM", file_size, 0, 0, 54)
+    # DIB header
+    dib_header = struct.pack("<IiiHHIIiiII", 40, width, height, 1, 24, 0,
+                             width * height * 3, 2835, 2835, 0, 0)
+    pixel_data = []
+    for y in range(height):
+        row_data = []
+        for x in range(width):
+            if (x // 8 + y // 8) % 2 == 0:
+                row_data.extend(color1)
+            else:
+                row_data.extend(color2)
+        padding = (4 - (width * 3) % 4) % 4
+        row_data.extend([0] * padding)
+        pixel_data.extend(row_data)
+    with open(filename, "wb") as bmp_file:
+        bmp_file.write(file_header)
+        bmp_file.write(dib_header)
+        bmp_file.write(bytearray(pixel_data))
+
+
+def main():
+    doc = c4d.documents.GetActiveDocument()
+    doc.Flush()
+    cube = c4d.BaseObject(c4d.Ocube)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(200, 200, 200)
+    cube.SetAbsPos(c4d.Vector(0, 170, -170))
+    doc.InsertObject(cube)
+    mat = c4d.BaseList2D(c4d.Mmaterial)
+    doc.InsertMaterial(mat)
+    mat[c4d.MATERIAL_USE_REFLECTION] = False
+    bitmapShader = c4d.BaseShader(c4d.Xbitmap)
+    tex_dir = os.path.join(os.path.dirname(__file__), "tex")
+    os.makedirs(tex_dir, exist_ok=True)
+    _checkerboard_bmp(os.path.join(tex_dir, "checkerboard.bmp"))
+    bitmapShader[c4d.BITMAPSHADER_FILENAME] = "tex/checkerboard.bmp"
+    mat[c4d.MATERIAL_COLOR_SHADER] = bitmapShader
+    mat.InsertShader(bitmapShader)
+    texture_tag = c4d.TextureTag()
+    texture_tag.SetMaterial(mat)
+    cube.InsertTag(texture_tag)
+    render_data = doc.GetActiveRenderData()
+    render_data[c4d.RDATA_PATH] = "renders/$prj"
+    frame_start = c4d.BaseTime(1, doc.GetFps())
+    frame_end = c4d.BaseTime(1, doc.GetFps())
+    render_data[c4d.RDATA_FRAMEFROM] = frame_start
+    render_data[c4d.RDATA_FRAMETO] = frame_end
+    render_data[c4d.RDATA_RENDERENGINE] = 1036219  # redshift
+
+    save_dir = os.path.dirname(__file__)
+    save_name = "redshift_textured.c4d"
+    save_file = os.path.join(save_dir, save_name)
+    doc.SetDocumentPath(save_dir)
+    doc.SetDocumentName(save_name)
+    c4d.documents.SaveDocument(doc, save_file, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
+
+    c4d.documents.InsertBaseDocument(doc)
+    c4d.EventAdd()
+
+
+if __name__ == "__main__":
+    main()

--- a/job_bundle_output_tests/redshift_textured/scene/cube.py
+++ b/job_bundle_output_tests/redshift_textured/scene/cube.py
@@ -12,8 +12,9 @@ def _checkerboard_bmp(filename):
     file_size = 14 + 40 + (width * height * 3)
     file_header = struct.pack("<2sIHHI", b"BM", file_size, 0, 0, 54)
     # DIB header
-    dib_header = struct.pack("<IiiHHIIiiII", 40, width, height, 1, 24, 0,
-                             width * height * 3, 2835, 2835, 0, 0)
+    dib_header = struct.pack(
+        "<IiiHHIIiiII", 40, width, height, 1, 24, 0, width * height * 3, 2835, 2835, 0, 0
+    )
     pixel_data = []
     for y in range(height):
         row_data = []
@@ -41,13 +42,13 @@ def main():
     mat = c4d.BaseList2D(c4d.Mmaterial)
     doc.InsertMaterial(mat)
     mat[c4d.MATERIAL_USE_REFLECTION] = False
-    bitmapShader = c4d.BaseShader(c4d.Xbitmap)
+    bitmap_shader = c4d.BaseShader(c4d.Xbitmap)
     tex_dir = os.path.join(os.path.dirname(__file__), "tex")
     os.makedirs(tex_dir, exist_ok=True)
     _checkerboard_bmp(os.path.join(tex_dir, "checkerboard.bmp"))
-    bitmapShader[c4d.BITMAPSHADER_FILENAME] = "tex/checkerboard.bmp"
-    mat[c4d.MATERIAL_COLOR_SHADER] = bitmapShader
-    mat.InsertShader(bitmapShader)
+    bitmap_shader[c4d.BITMAPSHADER_FILENAME] = "tex/checkerboard.bmp"
+    mat[c4d.MATERIAL_COLOR_SHADER] = bitmap_shader
+    mat.InsertShader(bitmap_shader)
     texture_tag = c4d.TextureTag()
     texture_tag.SetMaterial(mat)
     cube.InsertTag(texture_tag)


### PR DESCRIPTION
5 test scenes implemented as python scripts and respective job bundles:
- simple physical render
- simple redshift render
- redshift with multipass render
- redhsift with takes
- redshift with texture asset, bmp file generated by python script

### What was the problem/requirement? (What/Why)

Example scenes and respective expected job bundle outputs

### What was the solution? (How)

Plain text py files to generate scenes and their respective job bundle outputs with normalized paths

### What is the impact of this change?

Developers have a common set of test scenes

### How was this change tested?

- Launch Cinema 4D
- Extensions > User Scripts > Run Script ...
- Select script file ./job_bundle_output_tests/{test}/scene/cube.py
- The script builds the scene and saves it to ./job_bundle_output_tests/{test}/scene/{test}.c4d
- Extensions > Deadline Cloud Submitter
- Submit or Export Bundle 

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*