### PR TITLE
fix: Ensure only Critical stops fail the job and not others.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -193,7 +193,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
             completed_regexes = [re.compile(".*Finished Rendering.*")]
             progress_regexes = [re.compile(".*Progress ([0-9]+)%.*")]
             error_regexes = [
-                re.compile(".*Error: .*|.*\\[Error\\].*|.*CRITICAL: .*", re.IGNORECASE)
+                re.compile(r"(.*Error: .*)|(.*\[Error\].*)|(.*CRITICAL: Stop.*)", re.IGNORECASE)
             ]
 
             callback_list.append(RegexCallback(completed_regexes, self._handle_complete))

--- a/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
-import re
 import pytest
 from deadline.cinema4d_adaptor.Cinema4DAdaptor import Cinema4DAdaptor
 
@@ -24,36 +23,38 @@ def init_data() -> dict:
 
 class TestCinema4DAdaptor_on_cleanup:
 
-    def test_handle_critical(self, init_data: dict) -> None:
-        """Tests that the _handle_error method throws a critical runtime error correctly"""
-        # GIVEN
-        adaptor = Cinema4DAdaptor(init_data)
-
-        # WHEN
-        error_regex = re.compile(".*Error: .*|.*\\[Error\\].*|.*CRITICAL: .*")
-        stdout = "CRITICAL: Stop [ge_file.cpp(1172)]"
-
-        match = error_regex.search(stdout)
-        if match:
-            adaptor._handle_error(match)
-
-        # THEN
-        assert match is not None
-        assert str(adaptor._exc_info) == f"Cinema4D Encountered an Error: {stdout}"
-
-    def test_handle_error(self, init_data: dict) -> None:
+    @pytest.mark.parametrize(
+        "stdout,error_expected",
+        [
+            # Only critical stop errors should fail the job
+            ("CRITICAL: Stop [ge_file.cpp(1172)]", True),
+            # Any string with substring "Error:" should fail the job
+            ("Redshift Error: Maxon licensing error: User not logged in (7)", True),
+            # Any string with substring "[Error]" should fail the job
+            ("[Error] Application crashed", True),
+            # This error can be printed but the jobs are still successful.
+            # Hence, this should not fail the job.
+            ("CRITICAL: nullptr [text_object.cpp(1082)] [objectbase1.hxx(549)]", False),
+        ],
+    )
+    def test_handle_errors_on_error_stdout(
+        self, init_data: dict, stdout: str, error_expected: bool
+    ) -> None:
         """Tests that the _handle_error method throws a error runtime error correctly"""
         # GIVEN
         adaptor = Cinema4DAdaptor(init_data)
+        regex_callbacks = adaptor._get_regex_callbacks()
+        # Currently the callback for errors is at index 2
+        error_regex = regex_callbacks[2].regex_list[0]
 
         # WHEN
-        error_regex = re.compile(".*Error: .*|.*\\[Error\\].*|.*CRITICAL: .*")
-        stdout = "Redshift Error: Maxon licensing error: User not logged in (7)"
-
         match = error_regex.search(stdout)
         if match:
             adaptor._handle_error(match)
 
         # THEN
-        assert match is not None
-        assert str(adaptor._exc_info) == f"Cinema4D Encountered an Error: {stdout}"
+        if error_expected:
+            assert match is not None
+            assert str(adaptor._exc_info) == f"Cinema4D Encountered an Error: {stdout}"
+        else:
+            assert match is None


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Apparently, sometimes CRITICAL regex can be printed out even though the job itself is successful. 
Thanks to @Ahuge for pointing it out to us. 
For example, here's the logs for one such job. 
```
2024/10/15 16:03:39-07:00 ==============================================
2024/10/15 16:03:39-07:00 --------- Running Task
2024/10/15 16:03:39-07:00 ==============================================
2024/10/15 16:03:39-07:00 Parameter values:
2024/10/15 16:03:39-07:00 Frame(INT) = 2
2024/10/15 16:03:39-07:00 ----------------------------------------------
2024/10/15 16:03:39-07:00 Phase: Setup
2024/10/15 16:03:39-07:00 ----------------------------------------------
...

2024/10/15 16:03:40-07:00 ADAPTOR_OUTPUT: STDOUT: CRITICAL: nullptr [text_object.cpp(1082)] [objectbase1.hxx(549)]
2024/10/15 16:03:40-07:00 ADAPTOR_OUTPUT: STDOUT: CRITICAL: nullptr [text_object.cpp(1082)] [objectbase1.hxx(549)]
....
2024/10/15 16:08:42-07:00 ADAPTOR_OUTPUT: STDOUT: Progress: 100%
2024/10/15 16:08:45-07:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
```

### What was the solution? (How)
I modified the regex to only fail the jobs with `CRITICAL Stop` in output. 
I couldn't find any information regarding which critical errors should fail the job for Cinema 4D. Hence, I'm only checking for stops. 
If we find out that its not true and somehow `CRITICAL: nullptr` is special, we can change the error regex accordingly in the future. 

### What is the impact of this change?
This avoids the problem of failing successful jobs. 

### How was this change tested?
Added few test cases and ran `hatch run all:test` and ensured that the tests all passed. 

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*