### PR TITLE
fix: Resolve issues with create_adaptor_packaging_artifact and depsBundle 

### DIFF
--- a/depsBundle.sh
+++ b/depsBundle.sh
@@ -3,10 +3,10 @@ set -xeuo pipefail
 
 python depsBundle.py
 
-rm -f dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-windows.zip
-rm -f dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-linux.zip
-rm -f dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-macos.zip
+rm -f dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-windows.zip
+rm -f dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-linux.zip
+rm -f dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-macos.zip
 
-cp dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-windows.zip
-cp dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-linux.zip
-cp dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-macos.zip
+cp dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-windows.zip
+cp dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-linux.zip
+cp dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-macos.zip

--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -104,7 +104,7 @@ if [ $SOURCE = 1 ]; then
         $ADAPTOR_INSTALLABLE
 else
     # In PyPI mode, PyPI and/or a CodeArtifact must have these packages
-    RUNTIME_INSTALLABLE=openjd-adaptor-runtime-for-python
+    RUNTIME_INSTALLABLE=openjd-adaptor-runtime
     ADAPTOR_INSTALLABLE=$ADAPTOR_NAME
 
     pip install \


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There were 2 issues that I noticed on the 2 scripts:

- `create_adaptor_packaging_artifact.sh` was incorrectly using the `RUNTIME_INSTALLABLE` as `openjd-adaptor-runtime-for-python` instead of `openjd-adaptor-runtime`. 

- `depsBundle.sh` had a typo in the package name and used `deadline_cloud_for_cinema4d_submitter` instead of `deadline_cloud_for_cinema_4d_submitter`. 

### What was the solution? (How)

Fixed the typos and confirmed that the scripts were working successfully. 

And running the scripts created the dependency bundles in the `dependency_bundle` folder. 

### What is the impact of this change?

This will help with our release process. 

### How was this change tested?


Here's the output from running the `create_adaptor_packaging_artifact.sh` script. 
```
$ bash scripts/create_adaptor_packaging_artifact.sh 
+ APP=cinema4d
+ APP_WITH_HYPEN=cinema-4d
+ MODULE_CAPITAL_D=Cinema4D
+ ADAPTOR_NAME=deadline-cloud-for-cinema-4d
+++ dirname scripts/create_adaptor_packaging_artifact.sh
++ realpath scripts
+ SCRIPTDIR=/local/home/pattatk/bealine-clients/deadline-cloud-for-cinema-4d/scripts
+ SOURCE=0
...
/bealine-clients/deadline-cloud-for-cinema-4d
+ cleanup_workdir
+ echo 'Cleaning up adaptor-pkg.xrDprDEPQX'
Cleaning up adaptor-pkg.xrDprDEPQX
+ rm -rf adaptor-pkg.xrDprDEPQX
```

This also created `cinema4d-openjd-py3.11-linux-64-0.3.4.dist-info.tar.gz` file. 

Here's the output from running the `depsBundle.sh` script. 

```
$ bash depsBundle.sh 
+ python depsBundle.py
Looking in indexes: https://aws:****@amazon-deadline-cloud-938076848303.d.codeartifact.us-west-2.amazonaws.com/pypi/amazon-deadline-cloud-client-software/simple/
Collecting deadline==0.48.*
...
+ rm -f dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-windows.zip
+ rm -f dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-linux.zip
+ rm -f dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps-macos.zip
+ cp dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-windows.zip
+ cp dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-linux.zip
+ cp dependency_bundle/deadline_cloud_for_cinema_4d_submitter-deps.zip dependency_bundle/deadline_cloud_for_cinema4d_submitter-deps-macos.zip
```


### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*