### PR TITLE
feat: Only import openjd and deadline modules for Cinema 4D adaptor.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -6,10 +6,21 @@ import os
 from types import FrameType
 from typing import Optional
 
-from openjd.adaptor_runtime_client import (
-    ClientInterface,
-)
-from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler
+# The Cinema4D Adaptor adds the `openjd` namespace directory to PYTHONPATH,
+# so that importing just the adaptor_runtime_client should work.
+try:
+    from adaptor_runtime_client import ClientInterface  # type: ignore[import]
+except (ImportError, ModuleNotFoundError):
+    # On Windows, HTTPClientInterface is not available, only ClientInterface
+    from openjd.adaptor_runtime_client import ClientInterface  # type: ignore[import]
+
+
+# The Cinema4D Adaptor adds the `deadline` namespace directory to PYTHONPATH,
+# so that importing just the cinema4d_adaptor should work.
+try:
+    from cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler  # type: ignore[import]
+except (ImportError, ModuleNotFoundError):
+    from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler  # type: ignore[import]
 
 
 class Cinema4DClient(ClientInterface):

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
@@ -9,7 +9,13 @@ for n in sys.path:
     print(n)
 
 import c4d
-from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client import main
+
+# The Cinema4D Adaptor adds the `deadline` namespace directory to PYTHONPATH,
+# so that importing just the cinema4d_adaptor should work.
+try:
+    from cinema4d_adaptor.Cinema4DClient.cinema4d_client import main # type: ignore[import]
+except (ImportError, ModuleNotFoundError):
+    from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client import main # type: ignore[import]
 
 def parse_argv(argv):
     for arg in argv:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I observed that while building the Cinema 4D adaptor in Python 3.12, we would break Cinema 4D's python. This is because Cinema 4D's python was using Python 3.11 and it was failing to import modules that were compiled from Python 3.12. 

```
2024/11/07 10:58:24-06:00 ADAPTOR_OUTPUT: STDOUT: (null)    import win32file
2024/11/07 10:58:24-06:00 ADAPTOR_OUTPUT: STDOUT: (null)ImportError: Module use of python312.dll conflicts with this version of Python.
```

### What was the solution? (How)

Credits to @mwiebe  for helping out with the fix. We essentially only import `deadline` and `openjd` modules that the adaptor needs. 

This is similar to how Maya does it: https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py#L373-L383 

### What is the impact of this change?

Now the adaptor and Cinema 4D's python versions can be different but it would still work. 

### How was this change tested?

To test this was a multi-step process: 

- First I submitted a conda build that would use Python 3.12 for building the Cinema 4D adaptor recipe with these changes as a patch. Cinema 4D python installs the dependencies (pywin32) that it needs. 


- Next I submitted a simple job to a farm that used this new conda package and confirmed that everything worked as expected. 

```
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 94.5833
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 95.4167
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 95.8333
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 96.6667
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 97.0833
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 97.5
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 97.9167
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 98.3333
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 98.75
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 99.1667
2024/11/11 18:04:05-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 99.5833
2024/11/11 18:04:06-06:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
2024/11/11 18:04:06-06:00 INFO: Done Cinema4DAdaptor main
2024/11/11 18:04:06-06:00 Process pid 4064 exited with code: 0 (unsigned) / 0x0 (hex)
```



### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*