### PR TITLE
fix: install pip if required before installing GUI dependencies

### DIFF
--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -50,9 +50,9 @@ if __name__ == '__main__':
 
     c4d.plugins.RegisterCommandPlugin(
         id=PLUGIN_ID,
-        str="Deadline Cloud Submitter",
+        str="AWS Deadline Cloud Submitter",
         info=0,
-        help="Submit to Deadline Cloud",
+        help="Submit to AWS Deadline Cloud",
         dat=DeadlineCloudRenderCommand(),
         icon=None
     )

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -1,10 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import logging as _logging
 import sys
 import subprocess
 from pathlib import Path
+
 import c4d
 
-import logging as _logging
 
 _logger = _logging.getLogger(__name__)
 
@@ -23,42 +24,51 @@ def has_gui_deps():
 
 
 def install_gui():
-    import deadline.client
-
-    deadline.client.version
     c4d_app = sys.executable
     # We want to install the GUI components using Cinema 4D's python.
     c4d_python = c4d_app.replace(
         "Cinema 4D.exe", "resource\\modules\\python\\libs\\win64\\python.exe"
     )
-    pip_install_command = [
+
+    # install pip if needed - C4D python doesn't come with it installed by default
+    ensurepip_command = [
+        c4d_python,
+        "-m",
+        "ensurepip",
+    ]
+    subprocess.run(ensurepip_command)
+
+    import deadline.client
+
+    deadline_gui_install_command = [
         c4d_python,
         "-m",
         "pip",
         "install",
         f"deadline[gui]=={deadline.client.version}",
     ]
+
     # module_directory assumes relative install location of:
     #   * [installdir]/Submitters/Cinema4D/deadline/cinema4d_submitter/cinema4d_render_submitter.py
     module_directory = Path(__file__).parent.parent.parent
     if module_directory.exists():
         _logger.info(f"Missing GUI libraries, installing deadline[gui] to {module_directory}")
-        pip_install_command.extend(["--target", str(module_directory)])
+        deadline_gui_install_command.extend(["--target", str(module_directory)])
     else:
         _logger.info(
             "Missing GUI libraries with non-standard set-up, installing deadline[gui] into Cinema 4D's python"
         )
-    subprocess.run(pip_install_command)
+    subprocess.run(deadline_gui_install_command)
 
 
 if not has_gui_deps():
     if c4d.gui.QuestionDialog(
-        "DeadlineCloud needs few GUI components to work. Press Yes to install."
+        "The AWS Deadline Cloud extension needs a few GUI components to work. Press Yes to install."
     ):
         install_gui()
     else:
         c4d.gui.MessageDialog(
-            "Did not install GUI components, DeadlineCloud will fail with qtpy bindings errors."
+            "Did not install GUI components, the AWS Deadline Cloud extension will fail with qtpy bindings errors."
         )
 
 from .cinema4d_render_submitter import show_submitter  # noqa: E402


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When installing the Deadline Cloud Cinema4D submitter on my workstation, I could not see the Deadline Cloud plugin in the C4D extensions menu. 

### What was the solution? (How)
Upon investigation, I found errors in the C4D Python console with module not found errors. The message was actually referring to `pip` being missing. To remedy this, added `python -m ensurepip` before installing the GUI dependencies.

Also fixed a few typos, re-organized imports, and updated plugin display name.

Also fixed a typo and re-organized imports

### What is the impact of this change?
Smoother installation for most users.

### How was this change tested?
Opened Cinema4D and confirmed that the the Deadline Cloud extension was installed.

- Have you run the unit tests?
Yep!

### Was this change documented?
No, not required. While this makes the installation easier, any of the existing troubleshooting docs should be kept in case of errors.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*