### PR TITLE
chore: add needs triage label to doc issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,8 +1,7 @@
-
 name: "📕 Documentation Issue"
 description: Issue in the documentation
-title: "Docs: TITLE"
-labels: ["documenation"]
+title: "Docs: (short description of the issue)"
+labels: ["documenation", "needs triage"]
 body:
   - type: textarea
     id: documentation_issue


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We were missing a "needs triage" label on our doc issue template.

### What was the solution? (How)
Added the label. Also cleaned up the issue template a bit.

### What is the impact of this change?
Highlights tickets that haven't yet been triaged by the AWS Deadline Cloud team.

### How was this change tested?
N/A

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, since this does not affect the functionality of the integration.

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*