### PR TITLE
feat!: install Conda packages by default

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -19,6 +19,7 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint
 from deadline.client.exceptions import DeadlineOperationError
 from qtpy.QtCore import Qt  # type: ignore[attr-defined]
 
+from ._version import version_tuple as adaptor_version_tuple
 from .data_classes import (
     RenderSubmitterUISettings,
 )
@@ -422,11 +423,15 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
         output_directories=set(render_settings.output_directories),
     )
 
+    c4d_major_version = str(c4d.GetC4DVersion())[:4]
+    adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
+    conda_packages = f"cinema4d={c4d_major_version}.* cinema4d-openjd={adaptor_version}.*"
+
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,
         initial_job_settings=render_settings,
         initial_shared_parameter_values={
-            "CondaPackages": "",
+            "CondaPackages": conda_packages,
         },
         auto_detected_attachments=auto_detected_attachments,
         attachments=attachments,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
By default, the list of Conda packages to use for a C4D submission is empty. This means that users will have to re-enter the Conda packages every time they want to submit a job if they are using Conda.

### What was the solution? (How)
We believe most users will want to use `cinema4d=<major version>.* cinema4d-openjd=0.*` Conda packages by default, so we've added those. 

![DefaultCondaPackages](https://github.com/user-attachments/assets/e67fd013-7bd5-45f0-86e9-ef40589ec704)

Customers who wish to use the a different configuration can modify their `deadline/cinema4d_submitter/cinema4d_render_submitter.py` file manually.

Sticky settings are out of scope for this change. I've added a GitHub issue to track that [here](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/95)

### What is the impact of this change?
Users submitting jobs from Cinema 4D should be able to onboard easier and faster!

### How was this change tested?
Opened the submitter and confirmed that `cinema4d=2025.* cinema4d-openjd=0.*` were set as the default Conda packages. Submitted a Cinema 4D job and confirmed that it rendered successfully

- Have you run the unit tests?
Yep!

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes! All tests output a cube, as expected.

### Was this change documented?
No, not required

### Is this a breaking change?
Yes, this is a breaking change. Customers that used AWS Deadline Cloud customer managed fleets that had Cinema 4D pre-installed on their workers and do not use Conda packages will need to update their `deadline/cinema4d_submitter/cinema4d_render_submitter.py` file to remove the default Conda packages.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

BREAKING CHANGE