### PR TITLE
chore(deps): upgrade deadline requirement from ==0.48.* to ==0.49.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.48.*",
+    "deadline == 0.49.*",
     "openjd-adaptor-runtime >= 0.7,< 0.9",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
[Version 0.49.0 of the `deadline` library was released](https://github.com/aws-deadline/deadline-cloud/releases/tag/0.49.0)!

### What was the solution? (How)
To maintain our dependencies, upgraded to the latest version.

### What is the impact of this change?
The latest features from the `deadline-cloud` version 0.49.0 are available.

### How was this change tested?
`hatch build && hatch run fmt && hatch run lint && hatch run test`

- Have you run the unit tests?
Yep!

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
I ran the physical cube job bundle output test as a smoke test and got a cube as output :)

### Was this change documented?
No, not required.

### Is this a breaking change?
No. While the deadline 0.49.0 release has a breaking change (removing the `aggregate_asset_root_manifests`), that interface is not used in the C4D integration,

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*