### PR TITLE
chore: add job_bundle_output_tests outputs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,12 @@ __pycache__/
 *_version.py
 
 /dependency_bundle/
-/scripts/dependency_bundle/
 /dev_install/
+/job_bundle_output_tests/*/scene/renders
+/job_bundle_output_tests/*/scene/*.c4d
+/job_bundle_output_tests/*/scene/*.deadline_render_settings.json
+/job_bundle_output_tests/*/scene/tex
+/job_bundle_output_tests/*/*.psd
+/scripts/dependency_bundle/
 /wheels/
 **/otls/backup


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
I had several files appearing as untracked files in my Git repo from the job bundle output tests.

### What was the solution? (How)
Added those file patterns to `.gitignore`

### What is the impact of this change?
Faster development :)

### How was this change tested?
The relevant files were ignored by Git.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, as this does not affect the submitter or adaptor.

### Was this change documented?
No, not required.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*