### PR TITLE
fix!: use only Windows workers by default

### DIFF
--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -41,6 +41,11 @@ parameterDefinitions:
   description: Multi-pass image output
 steps:
 - name: Render
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - windows
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently, Cinema 4D is only supported for Windows on AWS Deadline Cloud. However, Linux workers were being assigned to Cinema 4D renders by default, causing jobs to fail unexpectedly.

### What was the solution? (How)
By default, generated Cinema 4D job templates which use the adaptor (the default workflow) have been configured to only use Windows workers for Cinema 4D rendering. This will be used in most customers' workflows.

I chose to leave the non-default non-OpenJD `default_cinema4d_job_template.yaml` file without host requirements because it is experimental and there is [some code working toward Linux support for it](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py#L293-L302).

### What is the impact of this change?
This will help customers avoid having work picked up by Linux fleets, which most customers will not have setup to work with Cinema 4D.

### How was this change tested?

- Have you run the unit tests?

Yep!

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
I ran the physical cube rendering test and confirmed that the submitted job template contained the Windows host requirement and was only picked up by Windows workers in the AWS Deadline Cloud service.

### Was this change documented?
No, this is effectively already documented in our README 

> Windows is recommended; We have some information below on how to setup the submitter on Mac and adaptors on Linux but it is experimental.

### Is this a breaking change?
Yes, this is a breaking change, although we do not think any customers will be affected by it due to current experimental status of Cinema4D Linux renders on AWS Deadline Cloud. Note that Windows renders can be done using the Deadline Cloud samples.

If a customer wishes to use Linux renders, they can change the "windows" `attr.worker.os.family` in `src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml` to `linux`. If they wish to use both Linux and Windows renders, they can remove the `hostRequirements` section entirely or add both `windows` and `linux` to the list.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

BREAKING CHANGE