### PR TITLE
fix: correct OS conditional for Windows paths

### DIFF
--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -10,7 +10,7 @@ def glob_add_path(base, pattern):
         return os.path.join(base, matches[0])
     return base
 
-if "win" in sys.platform:
+if sys.platform in ["win32", "cygwin"]:
     paths = [
         "resource",
         "modules",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When opening Cinema 4D on Mac with the AWS Deadline Cloud submitter installed, the following error appears:
```
Traceback (most recent call last):
  File "/Users/testuser/c4dplugin/DeadlineCloud.pyp", line 25, in <module>
os.add_dll_directory(dll_path)
^^^^^^^^^^^^^^^^^^^^
AttributeError:module 'os' has no attribute 'add_dll_directory'
```

### What was the solution? (How)
`os.add_dll_directory(dll_path)` is a Windows-only command. The conditional surrounding that code block was `if "win" in sys.platform`. The `sys.platform` value for Mac is `darwin`, which was unexpectedly True for the conditional.

Updated the conditional to `if sys.platform in ["win32", "cygwin"]:` to capture only the Windows OS.

### What is the impact of this change?
Mac submissions are not yet officially supported with this change, but this is a step toward it.

### How was this change tested?
Copied `deadline.pyp` into the C4D plugins folder. Re-ran the submitter.

- Have you run the unit tests?
Yes!

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes

### Was this change documented?
No, not required

### Is this a breaking change?
No. This fixes a previously not working case.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*