### PR TITLE
fix: remove host requirements tab by default since it doesn't pick up job template host requirements

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -438,7 +438,11 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
         on_create_job_bundle_callback=on_create_job_bundle_callback,
         parent=parent,
         f=f,
-        show_host_requirements_tab=True,
+        # host requirements are currently not sticky and don't pick up
+        # the job template's host requirements. To avoid confusion, remove
+        # the tab by default
+        # https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/105
+        show_host_requirements_tab=False,
     )
 
     return submitter_dialog


### PR DESCRIPTION
This is an example CR for removing the host requirements tab.

### What was the problem/requirement? (What/Why)
Currently, host requirements encoded in a job template are not reflected in the host requirements tab of `deadline bundle gui-submit`. Since Cinema 4D submits only to Windows fleets by default, this could cause confusion.

### What was the solution? (How)
To prevent confusion, customers have the option to remove the host requirements tab. The tab was previously of limited use because it [did not support sticky settings](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/95).

![image](https://github.com/user-attachments/assets/ae380232-7c0f-44c8-adfe-8452d153a623)

### What is the impact of this change?
This avoids customer confusion about host requirement defaults that are hidden.

### How was this change tested?
Opened the AWS Deadline Cloud submitter in Cinema 4D and confirmed that the host requirements tab was not present.

- Have you run the unit tests?
Yep!

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yep!

### Was this change documented?
It is documented in a GitHub issue: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/105

### Is this a breaking change?
Yes. This removes the host requirements tab, which prevents customers from changing the configuration of workers that are assigned C4D jobs.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*