### PR TITLE
chore: add length contraints to parameters

### DIFF
--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -17,6 +17,7 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+  maxLength: 100000
 - name: Frames
   type: STRING
   userInterface:
@@ -25,6 +26,7 @@ parameterDefinitions:
     groupLabel: Cinema4D Settings
   description: The frames to render. E.g. 1-3,8,11-15
   minLength: 1
+  maxLength: 100000
 - name: OutputPath
   type: STRING
   userInterface:
@@ -32,6 +34,7 @@ parameterDefinitions:
     label: Default image output
     groupLabel: Cinema4D Settings
   description: Image output path
+  maxLength: 100000
 - name: MultiPassPath
   type: STRING
   userInterface:
@@ -39,6 +42,7 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+  maxLength: 100000
 steps:
 - name: Render
   hostRequirements:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There are no length constraints on the job parameters. Someone could put excessive amounts of text in the parameter fields which might cause issues with the submitter.

### What was the solution? (How)
Add length constraints on the inputs. The constraints are high (100k characters) so reasonable inputs will not be affected. 

### What is the impact of this change?
Better handling of edge cases and devious user inputs.

### How was this change tested?
Not tested. I don't have C4D setup.

### Was this change documented?
Does not need documentation.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*