### PR TITLE
chore: hard-code the default max size for job settings to PyQt's default

### DIFF
--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -41,6 +41,7 @@ class FileSearchLineEdit(QWidget):
         lyt.setContentsMargins(0, 0, 0, 0)
 
         self.edit = QLineEdit(self)
+        self.edit.setMaxLength(32767)
         self.btn = QPushButton("...", parent=self)
         self.btn.setMaximumSize(QSize(100, 40))
         self.btn.clicked.connect(self.get_file)
@@ -121,6 +122,7 @@ class SceneSettingsWidget(QWidget):
 
         self.frame_override_chck = QCheckBox("Override Frame Range", self)
         self.frame_override_txt = QLineEdit(self)
+        self.frame_override_txt.setMaxLength(32767)
         lyt.addWidget(self.frame_override_chck, 4, 0)
         lyt.addWidget(self.frame_override_txt, 4, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently, the [default max size for PyQt text fields is 32767 characters](https://doc.qt.io/qt-6/qlineedit.html#maxLength-prop). In case the default is changed in the future, we want to hard-code the value to 32767 characters. The max size is enforced by truncating input to 32767 characters during form submission.

### What is the impact of this change?
There is no functional impact. This improves forward compatibility for our submitter.

### How was this change tested?
Re-opened the submitter in Cinema 4D and confirmed that the fields are still truncated to 32767 characters, as expected.

![image](https://github.com/user-attachments/assets/bb8aeb62-2996-4fc3-bc93-a1e860d23a7f)

![image](https://github.com/user-attachments/assets/38941d9e-50d1-45d6-9074-2dbe3e6f9090)

![image](https://github.com/user-attachments/assets/dadc368f-c5dd-44d3-985a-3329aa12860d)

* Have you run the unit tests?
Yep!

### Did you run the "Job Bundle Output Tests"? If not, why not?
Yep!

### Was this change documented?
No, not required

### Is this a breaking change?
No, there is no functional change

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*