### PR TITLE
fix: use user configured installdir for C4D submitter location

### DIFF
--- a/install_builder/deadline-cloud-for-cinema-4d.xml
+++ b/install_builder/deadline-cloud-for-cinema-4d.xml
@@ -60,7 +60,6 @@
                 <setInstallerVariable name="component(deadline_cloud_for_cinema_4d).show" value="0"/>
             </elseActionList>
         </if>
-        <setInstallerVariable name="cinema_4d_submitter_installdir" value="${installdir}\Submitters\Cinema4D" />
         <if>
             <conditionRuleList>
                 <platformTest type="windows" />
@@ -80,6 +79,9 @@
             </value>
         </stringParameter>
     </parameterList>
+    <readyToInstallActionList>
+        <setInstallerVariable name="cinema_4d_submitter_installdir" value="${installdir}\Submitters\Cinema4D" />
+    </readyToInstallActionList>
     <postInstallationActionList>
         <unzip>
             <destinationDirectory>${cinema_4d_submitter_installdir}</destinationDirectory>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When attempting to install with a non-default installation directory, the Cinema 4D installer still used the default directory,

### What was the solution? (How)
The `cinema_4d_submitter_installdir` variable was being set based on the `installdir` variable during `initializationActionList`, before the user had been able to input a custom `installdir`.

### What is the impact of this change?
The functionality works as expected,

### How was this change tested?
- User install with default directory
- User install with non-default directory
- System install with default directory
- System install non-default directory

Submitted a physical render from each.

- Have you run the unit tests?
No, N/A

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
I ran the physical job bundle output test

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*