### PR TITLE
fix: use description from GUI submitter

### DIFF
--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -1,5 +1,6 @@
 specificationVersion: 'jobtemplate-2023-09'
 name: Adaptor Cinema4D Job Template
+description: Adaptor Cinema4D Job Description
 parameterDefinitions:
 - name: Cinema4DFile
   type: PATH

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -135,6 +135,13 @@ def _get_job_template(
 
     # Set the job's name
     job_template["name"] = settings.name
+    # Set the job's description
+    if settings.description:
+        job_template["description"] = settings.description
+    else:
+        # remove description field since it can't be empty
+        # ignore if description is missing from template
+        job_template.pop("description", None)
 
     # If there are multiple frame ranges, split up the Frames parameter by take
     if takes[0].frames_parameter_name:

--- a/src/deadline/cinema4d_submitter/default_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/default_cinema4d_job_template.yaml
@@ -1,5 +1,6 @@
 specificationVersion: 'jobtemplate-2023-09'
 name: Default Cinema4D Job Template
+description: Default Cinema4D Job Description
 parameterDefinitions:
 - name: Cinema4DFile
   type: PATH


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The description from the AWS Deadline Cloud GUI was not being submitted to the service in Cinema 4D

### What was the solution? (How)
The description field was not being captured and passed correctly to the service. Updated the relevant code.

### What is the impact of this change?
Description field now works as expected.

### How was this change tested?
Submitted jobs with various values of description, including `test` (successful submission, description is "test"), `` (empty) (successful submission, description is empty), `!@#$%^&*()` (successful submission, description is `!@#$%^&*()`), and 😀😀😀😀 (successful submission, description is 😀😀😀😀)

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes, they all succeeded.

### Was this change documented?
No, not required

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*