### PR TITLE
feat(adaptor)!: Update adaptor environment variable executable to C4D_COMMANDLINE_EXE

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ This library requires:
 
 1. Cinema 4D 2024 - 2025
 1. Python 3.9 or higher; but Python 3.11 is recommended as this is the version Cinema 4D uses natively.
-1. Windows is recommended; We have some information below on how to setup the submitter on Mac and adaptors on Linux but it is experimental. 
+1. Windows is recommended; We have some information below on how to setup the submitter on Mac and adaptors on Linux but it is experimental.
 
 ## Versioning
 
-This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its 
+This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its
 initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how
 versions will increment during this initial development stage, they are described below:
 
-1. The MAJOR version is currently 0, indicating initial development. 
-2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
-3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
+1. The MAJOR version is currently 0, indicating initial development.
+2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API.
+3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API.
 
 ## Getting Started
 
@@ -75,7 +75,7 @@ pip install deadline[gui]
 ```
 
 2. Set up the `C4DPYTHONPATH311` environment variable:
-  - Windows: 
+  - Windows:
 ```
 set C4DPYTHONPATH311="Path\to\site-packages"
 ```
@@ -92,13 +92,13 @@ The Cinema 4D extension can be downloaded from the git repo:
 https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/deadline_cloud_extension/DeadlineCloud.pyp
 
 
-#### Set up Cinema 4D to access DeadlingCloud extension: 
+#### Set up Cinema 4D to access DeadlingCloud extension:
 
 There are 2 ways to setup Cinema 4D to access this extension:
 
 1. Plugin directory method:
-    1. Create a new folder "plugins" within the Cinema 4D installation directory. 
-    2. Place the `DeadlineCloud.pyp` within this "plugins" directory. 
+    1. Create a new folder "plugins" within the Cinema 4D installation directory.
+    2. Place the `DeadlineCloud.pyp` within this "plugins" directory.
 
 2. Environment variable method:
     1. Add the `g_additionalModulePath` environment variable to point to the location where `DeadlineCloud.pyp` exists, so that Cinema 4D can load the plugin.
@@ -116,10 +116,10 @@ export g_additionalModulePath="Path/to/DeadlineCloud.pyp"
 #### Using the extension
 
 Windows:
-- If the above environment variables are set as user / system variables, then just start Cinema 4D from the start menu. 
+- If the above environment variables are set as user / system variables, then just start Cinema 4D from the start menu.
 
 Mac:
-- Set the above environment variables in a shell. 
+- Set the above environment variables in a shell.
 - Navigate to the location where the Cinema 4D application is present.
 Normally it is in `/Applications/Maxon Cinema 4D 2025/Cinema 4D.app/Contents/MacOS`
 - Run `./Cinema\ 4D`
@@ -128,7 +128,7 @@ If you load a scene, click on **Extensions > Deadline Cloud Submitter** to view 
 
 ### Additional Python Libraries
 
-Some specific versions of Cinema 4D ( e.g. `Cinema 4D 2024.1.0`) have been found to be missing some libraries key to Deadline requirements ; in later versions such as `2024.4.0` this has been resolved. 
+Some specific versions of Cinema 4D ( e.g. `Cinema 4D 2024.1.0`) have been found to be missing some libraries key to Deadline requirements ; in later versions such as `2024.4.0` this has been resolved.
 
 A missing library error will manifest in errors that can be visible from the **Python** section of the **Extensions > Console** UI. These typically look like:
 
@@ -139,16 +139,16 @@ PySide6/__init__.py: Unable to import Shiboken from  ...
 To remedy these errors, you can switch to a later version of Cinema 4D which resolves the missing libraries, or you can manually add them specifically to the Cinema 4D python module, e.g in Windows it will be something like:
 
 ```
-"C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m ensurepip   
+"C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m ensurepip
 "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe"-m pip install MISSING_MODULE
-``` 
+```
 
 ## Adaptor
 
 Jobs created by this submitter require this adaptor be installed on your worker hosts, and that both the installed adaptor
 and the Cinema 4D executable be available on the PATH of the user that will be running your jobs.
 
-Or you can set the `CINEMA4D_ADAPTOR_COMMANDLINE_EXE` to point to the Cinema 4D executable. 
+Or you can set the `C4D_COMMANDLINE_EXECUTABLE` to point to the Cinema 4D executable.
 
 The adaptor application is a command-line Python-based application that enhances the functionality of Cinema 4D for running within a render farm like Deadline Cloud. Its primary purpose for existing is to add a "sticky rendering" functionality where a single process instance of Cinema 4D is able to load the scene file and then dynamically be instructed to perform desired renders without needing to close and re-launch Cinema 4D between them. It also has additional benefits such as support for path mapping, and reporting the progress of your render to Deadline Cloud. The alternative to "sticky rendering" is that Cinema 4D would need to be run separately for each render that is done, and close afterwards.
 Some scenes can take 10's of minutes just to load for rendering, so being able to keep the application open and loaded between
@@ -168,12 +168,12 @@ $ cinema4d-openjd --help
 
 For more information on the commands the OpenJD adaptor runtime provides, see [here][openjd-adaptor-runtime-lifecycle].
 
-### Cinema 4D software availability in AWS Deadline Cloud Service Managed Fleets. 
+### Cinema 4D software availability in AWS Deadline Cloud Service Managed Fleets.
 You will need to ensure the desired Cinema 4D version is available on the worker host when using AWS Deadline Cloud's [Service Managed Fleets][service-managed-fleets] to run jobs. These hosts do not have pre-installed rendering applications.
 
 Cinema 4D packages are not available in the "deadline-cloud" conda channel. You must build them yourself in DeadlineCloud. We recommend using the conda recipes in our samples Github repository. Two essential conda packages for rendering on Deadline Cloud Service Managed Fleets are [`cinema4d-2025`](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-2025) and [`cinema4d-openjd`](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-openjd).
 
-For instructions on building conda recipes on Deadline Cloud, see this [article](https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/). 
+For instructions on building conda recipes on Deadline Cloud, see this [article](https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/).
 Though it refers to Blender, the process applies to Cinema 4D recipes as well.
 
 For licensing Cinema 4D workers, follow the guidelines in this [article](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/byol.html).
@@ -190,11 +190,11 @@ submitter plug-in then you can use the [Deadline Cloud application][deadline-clo
 
 ## Security
 
-We take all security reports seriously. When we receive such reports, we will 
-investigate and subsequently address any potential vulnerabilities as quickly 
-as possible. If you discover a potential security issue in this project, please 
+We take all security reports seriously. When we receive such reports, we will
+investigate and subsequently address any potential vulnerabilities as quickly
+as possible. If you discover a potential security issue in this project, please
 notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
-or directly via email to [AWS Security](aws-security@amazon.com). Please do not 
+or directly via email to [AWS Security](aws-security@amazon.com). Please do not
 create a public GitHub issue in this project.
 
 ## Telemetry

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -295,7 +295,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         # does this for us.
         # On Linux this should be a path similar to this: /opt/maxon/cinema4dr2024.200/bin/Commandline
         # On Windows it should be a path similar to this: "C:\Program Files\Maxon Cinema 4D R26\Commandline.exe"
-        c4d_exe_env = os.environ.get("CINEMA4D_ADAPTOR_COMMANDLINE_EXE", "")
+        c4d_exe_env = os.environ.get("C4D_COMMANDLINE_EXECUTABLE", "")
         if not c4d_exe_env:
             c4d_exe = "Commandline"
         else:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The environment variable executable naming was inconsistent across the DCC packages.
### What was the solution? (How)
Change `deadline-cloud-for-cinema-4d` to match the other DCC adaptor packages naming
### What is the impact of this change?
Breaking change because of the environment variable naming.

### How was this change tested?

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

### Was this change documented?
Updated the README.md which references it.

### Is this a breaking change?
Yup
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*