### PR TITLE
chore: update adaptor packaging script to use win-64 by default

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -15,7 +15,7 @@ SCRIPTDIR=$(realpath $(dirname $0))
 SOURCE=0
 # Python 3.11 is for https://vfxplatform.com/ CY2024
 PYTHON_VERSION=3.11
-CONDA_PLATFORM=linux-64
+CONDA_PLATFORM=win-64
 TAR_BASE=
 
 while [ $# -gt 0 ]; do
@@ -112,14 +112,14 @@ else
         --platform $PYPI_PLATFORM \
         --python-version $PYTHON_VERSION \
         --ignore-installed \
-        --only-binary=:all: \
+        --no-deps \
         $RUNTIME_INSTALLABLE
     pip install \
         --target $PACKAGEDIR \
         --platform $PYPI_PLATFORM \
         --python-version $PYTHON_VERSION \
         --ignore-installed \
-        --no-deps \
+        --only-binary=:all: \
         $ADAPTOR_INSTALLABLE
 fi
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The adaptor packaging script was defaulting to Linux, even though we currently only support Windows. Updated it to default to Windows.

Also updated the dependency installation to be consistent with other packages like [KeyShot](https://github.com/aws-deadline/deadline-cloud-for-keyshot/blob/mainline/scripts/create_adaptor_packaging_artifact.sh)

### How was this change tested?
`./create_adaptor_packaging_artifact`
Environment: Git Bash v2.45.1 on Windows 10 Enterprise 22H2

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, N/A. This is just creating an adaptor packaging artifact, it is not yet in use for adaptors.

### Was this change documented?
No, N/A

### Is this a breaking change?
No, because this does not affect the submitter or adaptor in any existing installation.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*