### PR TITLE
chore: add tests verifying adaptor validates commands

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -392,11 +392,12 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         performs a busy wait until the render completes.
         """
 
+        self.validators.run_data.validate(run_data)
+
         if not self._cinema4d_is_running:
             raise Cinema4DNotRunningError("Cannot render because Cinema4D is not running.")
 
         run_data["frame"] = int(run_data["frame"])
-        self.validators.run_data.validate(run_data)
         self._is_rendering = True
 
         for name in _CINEMA4D_RUN_KEYS:

--- a/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pytest
+from jsonschema.exceptions import ValidationError
 from deadline.cinema4d_adaptor.Cinema4DAdaptor import Cinema4DAdaptor
 
 
@@ -58,3 +59,15 @@ class TestCinema4DAdaptor_on_cleanup:
             assert str(adaptor._exc_info) == f"Cinema4D Encountered an Error: {stdout}"
         else:
             assert match is None
+
+
+def test_adapter_rejects_malformed_init_data():
+    adapter = Cinema4DAdaptor({"invalid": "data"})
+    with pytest.raises(ValidationError):
+        adapter.on_start()
+
+
+def test_adapter_rejects_malformed_run_data(init_data: dict):
+    adapter = Cinema4DAdaptor(init_data)
+    with pytest.raises(ValidationError):
+        adapter.on_run({"invalid": "data"})

--- a/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
@@ -61,13 +61,13 @@ class TestCinema4DAdaptor_on_cleanup:
             assert match is None
 
 
-def test_adapter_rejects_malformed_init_data():
+def test_adaptor_rejects_malformed_init_data():
     adapter = Cinema4DAdaptor({"invalid": "data"})
     with pytest.raises(ValidationError):
         adapter.on_start()
 
 
-def test_adapter_rejects_malformed_run_data(init_data: dict):
+def test_adaptor_rejects_malformed_run_data(init_data: dict):
     adapter = Cinema4DAdaptor(init_data)
     with pytest.raises(ValidationError):
         adapter.on_run({"invalid": "data"})


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to verify the adapter is validating incoming data using the JSON schemas.

### What was the solution? (How)
Add a unit tests.

### What is the impact of this change?
More confidence data validation is working as expected.

### How was this change tested?
Unit tests pass successfully.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*