### PR TITLE
chore: test that all text elements enforce length limits

### DIFF
--- a/test/deadline_submitter_for_cinema4d/unit/test_submitter.py
+++ b/test/deadline_submitter_for_cinema4d/unit/test_submitter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import deadline.cinema4d_submitter.cinema4d_render_submitter as submitter_module
 from deadline.cinema4d_submitter.data_classes import RenderSubmitterUISettings
+from unittest.mock import Mock
+import sys
 
 
 def test_get_job_template():
@@ -26,3 +28,40 @@ def test_get_job_template():
         "take"
         in job_template["steps"][0]["stepEnvironments"][0]["script"]["embeddedFiles"][0]["data"]
     )
+
+
+def test_text_elements_enforce_length_checks():
+    try:
+        # Create new mocks. We need to use a real class for QWidget instead of a Mock() so that the
+        # SceneSettingsWidget which is a subclass of QWidget actually runs its methods (instead its
+        # methods being mocked out).
+        class MockQWidget:
+            setEnabled = Mock()
+
+            def __init__(self, parent):
+                pass
+
+        mock_q_widgets = Mock()
+        mock_line_edit = Mock()
+
+        sys.modules["qtpy.QtWidgets"] = mock_q_widgets
+        mock_q_widgets.QWidget = MockQWidget
+        mock_q_widgets.QLineEdit = mock_line_edit
+
+        # Reload SceneSettingsWidget with the new mocks in place.
+        del sys.modules["deadline.cinema4d_submitter.ui.components.scene_settings_tab"]
+        from deadline.cinema4d_submitter.ui.components.scene_settings_tab import SceneSettingsWidget
+
+        # Stub out a method
+        SceneSettingsWidget._configure_settings = Mock()  # type: ignore
+
+        # Create the scene widget
+        SceneSettingsWidget(initial_settings=Mock())
+
+        # Verify that every line edit UI element has a max legnth constraint applied
+        assert mock_line_edit.call_count == mock_line_edit.return_value.setMaxLength.call_count
+        # Make sure the mock is working and there's at least 1 call (because there's at least 1 line edit element)
+        assert mock_line_edit.call_count > 0
+    finally:
+        # Reset QtWidgets mock
+        sys.modules["qtpy.QtWidgets"] = Mock()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We should verify that all submitter text UI elements enforce length constraints so the submitter doesn't accidentally accept unreasonably large amounts of text which could cause issues.

### What was the solution? (How)
Add a unit test.

### What is the impact of this change?
More confidence that we didn't miss a length constraint on a text element.

### How was this change tested?
Unit tests.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*