### PR TITLE
feat: Implement asset path mapping for Cinema 4D scene files

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -65,7 +65,7 @@ class Cinema4DHandler:
         self.doc = c4d.documents.GetActiveDocument()
         self.render_data = self.doc.GetActiveRenderData()
         self.render_data[c4d.RDATA_FRAMESEQUENCE] = c4d.RDATA_FRAMESEQUENCE_MANUAL
-        frame = int(self.render_kwargs["frame"])
+        frame = int(self.render_kwargs.get("frame", data.get("frame")))
         fps = self.doc.GetFps()
         self.render_data[c4d.RDATA_FRAMEFROM] = c4d.BaseTime(frame, fps)
         self.render_data[c4d.RDATA_FRAMETO] = c4d.BaseTime(frame, fps)

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -109,14 +109,14 @@ class Cinema4DHandler:
         if output_path:
             doc = c4d.documents.GetActiveDocument()
             render_data = doc.GetActiveRenderData()
-            render_data[c4d.RDATA_PATH] = output_path
+            render_data[c4d.RDATA_PATH] = self.map_path(output_path)
 
     def multi_pass_path(self, data: dict) -> None:
         multi_pass_path = data.get("multi_pass_path", "")
         if multi_pass_path:
             doc = c4d.documents.GetActiveDocument()
             render_data = doc.GetActiveRenderData()
-            render_data[c4d.RDATA_MULTIPASS_FILENAME] = multi_pass_path
+            render_data[c4d.RDATA_MULTIPASS_FILENAME] = self.map_path(multi_pass_path)
 
     def set_take(self, data: dict) -> None:
         """

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -50,6 +50,17 @@ class Cinema4DHandler:
         self.take = "Main"
         self.map_path = map_path
 
+    def _remap_assets(self) -> None:
+        asset_list: list[Dict[str, Any]] = []
+        c4d.documents.GetAllAssetsNew(
+            self.doc, allowDialogs=False, lastPath="", assetList=asset_list
+        )
+        for asset in asset_list:
+            asset_owner = asset.get("owner")
+            asset_param_id = asset.get("paramId")
+            if asset_owner and asset_param_id:
+                asset_owner[asset_param_id] = self.map_path(asset.get("filename", ""))
+
     def start_render(self, data: dict) -> None:
         self.doc = c4d.documents.GetActiveDocument()
         self.render_data = self.doc.GetActiveRenderData()
@@ -69,6 +80,8 @@ class Cinema4DHandler:
             self.render_data[c4d.RDATA_MULTIPASS_FILENAME] = self.map_path(
                 self.render_data[c4d.RDATA_MULTIPASS_FILENAME]
             )
+
+        self._remap_assets()
 
         bm = bitmaps.MultipassBitmap(
             int(self.render_data[c4d.RDATA_XRES]),


### PR DESCRIPTION
Fixes: #125 

### What was the problem/requirement? (What/Why)
When using a Linux worker to render a scene created on Windows, assets used in the scene would not get path mapped
### What was the solution? (How)
Implement path mapping on the asset texture files
### What is the impact of this change?
Path mapping now happens on the C4D scene and Windows paths are converted to Linux ones
### How was this change tested?
Testing In Progress on a client farm. -- IN PROGRESS

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

### Was this change documented?
No as it implements functionality that was expected

### Is this a breaking change?
Yes I believe, because we are changing functionality?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*