### PR TITLE
fix: add path mapping rules to convert Windows paths to C4D's Linux path format

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -51,6 +51,10 @@ class Cinema4DHandler:
         self.map_path = map_path
 
     def _remap_assets(self) -> None:
+        """
+        Asset references in the .c4d files are not automatically re-mapped if they are
+        absolute paths. This function remaps the asset references to the new paths.
+        """
         asset_list: list[Dict[str, Any]] = []
         c4d.documents.GetAllAssetsNew(
             self.doc, allowDialogs=False, lastPath="", assetList=asset_list
@@ -58,8 +62,9 @@ class Cinema4DHandler:
         for asset in asset_list:
             asset_owner = asset.get("owner")
             asset_param_id = asset.get("paramId")
-            if asset_owner and asset_param_id:
-                asset_owner[asset_param_id] = self.map_path(asset.get("filename", ""))
+            asset_filename = asset.get("filename")
+            if asset_owner and asset_param_id and asset_filename:
+                asset_owner[asset_param_id] = self.map_path(asset_filename)
 
     def start_render(self, data: dict) -> None:
         self.doc = c4d.documents.GetActiveDocument()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/118

### What was the problem/requirement? (What/Why)
Jobs with assets that use absolute paths will fail due to missing assets


### What was the solution? (How)
This adds additional path mapping rules for Windows -> Linux in the form of `./C:\*` to allow paths to be mapped in the intended way. In conjunction with https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/126 this applies path mapping to `RDATA_PATH`, `RDATA_MULTIPASS_FILENAME`, and all assets. 

### What is the impact of this change?
Absolute path references for assets now work on Linux!

### How was this change tested?
Submitted a physical render job (cube) with a texture that was mapped with an absolute path. It mapped the path correctly and succeeded the render!

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
I ran the physical job bundle output test and a test for a physical cube with a texture. On my test instance, Redshift is not working for any scene.

### Was this change documented?
I added some in-code docstrings. We're still not confident enough to have official support for Linux, but both Physical and Redshift renders appear to be working on RedHat Linux types without GPUs. With GPUs, only physical renders have been working.

### Is this a breaking change?
No, this was an existing broken path before, so it would not have been part of a customer flow.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*