### PR TITLE
test: add sample job bundle for physical render with texture

### DIFF
--- a/job_bundle_output_tests/physical_textured/expected_job_bundle/asset_references.yaml
+++ b/job_bundle_output_tests/physical_textured/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,10 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames:
+    - C:\normalized\job\bundle\dir\physical_textured.c4d
+    - C:\normalized\job\bundle\dir\tex\checkerboard.bmp
+  outputs:
+    directories:
+    - C:\normalized\job\bundle\dir\renders
+  referencedPaths: []

--- a/job_bundle_output_tests/physical_textured/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/physical_textured/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,17 @@
+parameterValues:
+- name: Cinema4DFile
+  value: C:\normalized\job\bundle\dir\physical_textured.c4d
+- name: OutputPath
+  value: C:\normalized\job\bundle\dir\renders\physical_textured
+- name: MultiPassPath
+  value: ''
+- name: Frames
+  value: '1'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

--- a/job_bundle_output_tests/physical_textured/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/physical_textured/expected_job_bundle/template.yaml
@@ -1,0 +1,108 @@
+specificationVersion: jobtemplate-2023-09
+name: physical_textured.c4d
+parameterDefinitions:
+- name: Cinema4DFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Cinema4D Document File
+    groupLabel: Cinema4D Settings
+    fileFilters:
+    - label: Cinema4D document files
+      patterns:
+      - '*.c4d'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Cinema4D document file to render.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Cinema4D Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: OutputPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Default image output
+    groupLabel: Cinema4D Settings
+  description: Image output path
+- name: MultiPassPath
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Multi-pass output path
+    groupLabel: Cinema4D Settings
+  description: Multi-pass image output
+steps:
+- name: Main
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - windows
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  stepEnvironments:
+  - name: Cinema4D
+    description: Runs Cinema4D in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |-
+          scene_file: '{{Param.Cinema4DFile}}'
+          take: 'Main'
+          output_path: '{{Param.OutputPath}}'
+          multi_pass_path: '{{Param.MultiPassPath}}'
+      actions:
+        onEnter:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+        onExit:
+          command: cinema4d-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+    actions:
+      onRun:
+        command: cinema4d-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE

--- a/job_bundle_output_tests/physical_textured/scene/cube.py
+++ b/job_bundle_output_tests/physical_textured/scene/cube.py
@@ -1,0 +1,76 @@
+import os
+import struct
+
+import c4d
+
+
+def _large_checkerboard_bmp(filename):
+    width = 256
+    height = 256
+    color1 = (255, 0, 0)
+    color2 = (0, 255, 0)
+    # BMP file header
+    file_size = 14 + 40 + (width * height * 3)
+    file_header = struct.pack("<2sIHHI", b"BM", file_size, 0, 0, 54)
+    # DIB header
+    dib_header = struct.pack(
+        "<IiiHHIIiiII", 40, width, height, 1, 24, 0, width * height * 3, 2835, 2835, 0, 0
+    )
+    pixel_data = []
+    for y in range(height):
+        row_data = []
+        for x in range(width):
+            if (x // 16 + y // 16) % 2 == 0:
+                row_data.extend(color1)
+            else:
+                row_data.extend(color2)
+        padding = (4 - (width * 3) % 4) % 4
+        row_data.extend([0] * padding)
+        pixel_data.extend(row_data)
+    with open(filename, "wb") as checkboard_bmp_file:
+        checkboard_bmp_file.write(file_header)
+        checkboard_bmp_file.write(dib_header)
+        checkboard_bmp_file.write(bytearray(pixel_data))
+
+
+def main():
+    doc = c4d.documents.GetActiveDocument()
+    doc.Flush()
+    cube = c4d.BaseObject(c4d.Ocube)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(300, 300, 300)
+    cube.SetAbsPos(c4d.Vector(0, 50, -50))
+    doc.InsertObject(cube)
+    mat = c4d.BaseList2D(c4d.Mmaterial)
+    doc.InsertMaterial(mat)
+    mat[c4d.MATERIAL_USE_REFLECTION] = False
+    bitmap_shader = c4d.BaseShader(c4d.Xbitmap)
+    tex_dir = os.path.join(os.path.dirname(__file__), "tex")
+    os.makedirs(tex_dir, exist_ok=True)
+    _large_checkerboard_bmp(os.path.join(tex_dir, "large_checkerboard.bmp"))
+    bitmap_shader[c4d.BITMAPSHADER_FILENAME] = "tex/large_checkerboard.bmp"
+    mat[c4d.MATERIAL_COLOR_SHADER] = bitmap_shader
+    mat.InsertShader(bitmap_shader)
+    texture_tag = c4d.TextureTag()
+    texture_tag.SetMaterial(mat)
+    cube.InsertTag(texture_tag)
+    render_data = doc.GetActiveRenderData()
+    render_data[c4d.RDATA_PATH] = "renders/$prj"
+    frame_start = c4d.BaseTime(1, doc.GetFps())
+    frame_end = c4d.BaseTime(1, doc.GetFps())
+    render_data[c4d.RDATA_FRAMEFROM] = frame_start
+    render_data[c4d.RDATA_FRAMETO] = frame_end
+    render_data[c4d.RDATA_RENDERENGINE] = 1023342  # physical
+
+    save_dir = os.path.dirname(__file__)
+    save_name = "physical_textured.c4d"
+    save_file = os.path.join(save_dir, save_name)
+    doc.SetDocumentPath(save_dir)
+    doc.SetDocumentName(save_name)
+    c4d.documents.SaveDocument(doc, save_file, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
+
+    c4d.documents.InsertBaseDocument(doc)
+    c4d.EventAdd()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When testing https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/127, I needed a physical render test case with assets. I created this job bundle test for that and I think it would be useful to others!

This test is mostly a copy of [redshift_textured](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/tree/mainline/job_bundle_output_tests/redshift_textured) but using a different texture, cube size, cube position, and asset name.

While there is some repeated code in this PR from `redshift_textured.py`, the Cinema4D user scripts run `cube.py` as `__main__`, meaning that I can't use relative imports to parent directories (making it hard to share code). To make this a standalone test (without using more complicated approaches like `exec`), I've elected to leave the duplication in this PR.

### What is the impact of this change?
Helps to debug farm issues and also avoid regressions.

### How was this change tested?
Ran `cube.py` as a user script. It generated a `.c4d` and `.bmp` file that were automatically opened. I submitted the job and ran it on a farm. The job passed and output a cube with a checkerboard texture.

- Have you run the unit tests?
No, N/A

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*