### PR TITLE
chore: reformat code

### DIFF
--- a/depsBundle.py
+++ b/depsBundle.py
@@ -4,7 +4,6 @@ import re
 import shutil
 import subprocess
 import sys
-
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any

--- a/hatch_custom_hook.py
+++ b/hatch_custom_hook.py
@@ -1,9 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 import shutil
+from typing import Any
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
-from typing import Any
 
 
 class HatchCustomBuildHook(BuildHookInterface):

--- a/job_bundle_output_tests/physical/scene/cube.py
+++ b/job_bundle_output_tests/physical/scene/cube.py
@@ -1,4 +1,5 @@
 import os
+
 import c4d
 
 
@@ -6,8 +7,8 @@ def main():
     doc = c4d.documents.GetActiveDocument()
     doc.Flush()
     cube = c4d.BaseObject(c4d.Ocube)
-    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(200, 200, 200)
-    cube.SetAbsPos(c4d.Vector(0, 170, -170))
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(300, 300, 300)
+    cube.SetAbsPos(c4d.Vector(0, 170, 170))
     doc.InsertObject(cube)
     render_data = doc.GetActiveRenderData()
     render_data[c4d.RDATA_PATH] = "renders/$prj"

--- a/job_bundle_output_tests/redshift/scene/cube.py
+++ b/job_bundle_output_tests/redshift/scene/cube.py
@@ -1,4 +1,5 @@
 import os
+
 import c4d
 
 

--- a/job_bundle_output_tests/redshift_multipass/scene/cube.py
+++ b/job_bundle_output_tests/redshift_multipass/scene/cube.py
@@ -1,4 +1,5 @@
 import os
+
 import c4d
 
 

--- a/job_bundle_output_tests/redshift_takes/scene/cube.py
+++ b/job_bundle_output_tests/redshift_takes/scene/cube.py
@@ -1,4 +1,5 @@
 import os
+
 import c4d
 
 

--- a/job_bundle_output_tests/redshift_textured/scene/cube.py
+++ b/job_bundle_output_tests/redshift_textured/scene/cube.py
@@ -1,5 +1,6 @@
 import os
 import struct
+
 import c4d
 
 

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -4,19 +4,19 @@ from __future__ import annotations
 
 import logging
 import os
+import platform
 import re
 import sys
 import threading
 import time
 from functools import wraps
-import platform
 from typing import Callable
 
 from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators, SemanticVersion
 from openjd.adaptor_runtime.adaptors.configuration import AdaptorConfiguration
-from openjd.adaptor_runtime.process import LoggingSubprocess
 from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
 from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
+from openjd.adaptor_runtime.process import LoggingSubprocess
 from openjd.adaptor_runtime_client import Action
 
 _logger = logging.getLogger(__name__)
@@ -24,8 +24,6 @@ _logger = logging.getLogger(__name__)
 
 class Cinema4DNotRunningError(Exception):
     """Error that is raised when attempting to use Cinema4D while it is not running"""
-
-    pass
 
 
 _FIRST_CINEMA4D_ACTIONS = ["scene_file", "take", "output_path", "multi_pass_path"]
@@ -293,8 +291,8 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
     def _add_deadline_openjd_paths(self) -> None:
         # Add the openjd namespace directory to PYTHONPATH, so that adaptor_runtime_client
         # will be available directly to the adaptor client.
-        import openjd.adaptor_runtime_client
         import deadline.cinema4d_adaptor
+        import openjd.adaptor_runtime_client
 
         openjd_namespace_dir = os.path.dirname(
             os.path.dirname(openjd.adaptor_runtime_client.__file__)
@@ -334,7 +332,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         if cinema4d_pathmap:
             os.environ["CINEMA4D_PATHMAP"] = cinema4d_pathmap
 
-        _logger.info("Setting CINEMA4D_PATHMAP to: {}".format(cinema4d_pathmap))
+        _logger.info(f"Setting CINEMA4D_PATHMAP to: {cinema4d_pathmap}")
 
         # set plugin path to DeadlineCloudClient
         parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -450,7 +448,6 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
     def on_stop(self) -> None:
         """ """
         self._action_queue.enqueue_action(Action("close"), front=True)
-        return
 
     def on_cleanup(self):
         """

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -1,8 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from __future__ import annotations
-import sys
+
 import os
+import sys
 from types import FrameType
 from typing import Optional
 
@@ -18,9 +19,13 @@ except (ImportError, ModuleNotFoundError):
 # The Cinema4D Adaptor adds the `deadline` namespace directory to PYTHONPATH,
 # so that importing just the cinema4d_adaptor should work.
 try:
-    from cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler  # type: ignore[import]
+    from cinema4d_adaptor.Cinema4DClient.cinema4d_handler import (
+        Cinema4DHandler,  # type: ignore[import]
+    )
 except (ImportError, ModuleNotFoundError):
-    from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler  # type: ignore[import]
+    from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import (
+        Cinema4DHandler,  # type: ignore[import]
+    )
 
 
 class Cinema4DClient(ClientInterface):

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -101,7 +101,7 @@ class Cinema4DHandler:
             c4d.RENDERFLAGS_EXTERNAL | c4d.RENDERFLAGS_SHOWERRORS,
             prog=progress_callback,
         )
-        result_description = _RENDERRESULT.get(result, None)
+        result_description = _RENDERRESULT.get(result)
         if result_description is None:
             raise RuntimeError("Error: unhandled render result: %s" % result)
         if result != c4d.RENDERRESULT_OK:

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -1,11 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import logging as _logging
-import sys
 import subprocess
+import sys
 from pathlib import Path
 
 import c4d
-
 
 _logger = _logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ def install_gui():
         "-m",
         "ensurepip",
     ]
-    subprocess.run(ensurepip_command)
+    subprocess.run(ensurepip_command, check=False)
 
     import deadline.client
 
@@ -58,7 +57,7 @@ def install_gui():
         _logger.info(
             "Missing GUI libraries with non-standard set-up, installing deadline[gui] into Cinema 4D's python"
         )
-    subprocess.run(deadline_gui_install_command)
+    subprocess.run(deadline_gui_install_command, check=False)
 
 
 if not has_gui_deps():

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -1,9 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
+
 import re
 from pathlib import Path
-from .scene import Scene
+
 import c4d
+
+from .scene import Scene
 
 _FRAME_RE = re.compile("#+")
 

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
-import json
 
 from .takes import TakeSelection  # type: ignore
 
@@ -64,7 +64,6 @@ class RenderSubmitterUISettings:
                 print(
                     f"WARNING: Failed to load sticky settings file {sticky_settings_filename}, reverting to the default settings."
                 )
-                pass
 
     def save_sticky_settings(self, scene_filename: str):
         sticky_settings_filename = Path(scene_filename).with_suffix(

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Iterator, Optional, Tuple
+from typing import Optional, Tuple
 
 import c4d
 
@@ -84,7 +85,7 @@ class Animation:
         return 4
 
     @classmethod
-    def frame_list(cls, data=None) -> "FrameRange":
+    def frame_list(cls, data=None) -> FrameRange:
         """
         Retursn a FrameRange object representing the full framelist.
         """

--- a/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 import pytest
 from jsonschema.exceptions import ValidationError
+
 from deadline.cinema4d_adaptor.Cinema4DAdaptor import Cinema4DAdaptor
 
 
-@pytest.fixture()
+@pytest.fixture
 def init_data() -> dict:
     """
     Pytest Fixture to return an init_data dictionary that passes validation

--- a/test/deadline_submitter_for_cinema4d/unit/test_assets.py
+++ b/test/deadline_submitter_for_cinema4d/unit/test_assets.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from __future__ import annotations
+
 from unittest.mock import patch
 
 from deadline.cinema4d_submitter.assets import AssetIntrospector

--- a/test/deadline_submitter_for_cinema4d/unit/test_scene.py
+++ b/test/deadline_submitter_for_cinema4d/unit/test_scene.py
@@ -1,9 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from typing import Optional
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 
 from deadline.cinema4d_submitter.scene import FrameRange, RendererNames, Scene
 

--- a/test/deadline_submitter_for_cinema4d/unit/test_submitter.py
+++ b/test/deadline_submitter_for_cinema4d/unit/test_submitter.py
@@ -1,10 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
+import sys
+from unittest.mock import Mock
+
 import deadline.cinema4d_submitter.cinema4d_render_submitter as submitter_module
 from deadline.cinema4d_submitter.data_classes import RenderSubmitterUISettings
-from unittest.mock import Mock
-import sys
 
 
 def test_get_job_template():

--- a/test/test_copyright_headers.py
+++ b/test/test_copyright_headers.py
@@ -22,12 +22,11 @@ def _check_file(filename: Path) -> None:
                     f"Could not find a valid Amazon.com copyright header in the top of {filename}."
                     " Please add one."
                 )
-        else:
-            # __init__.py files are usually empty, this is to catch that.
-            raise Exception(
-                f"Could not find a valid Amazon.com copyright header in the top of {filename}."
-                " Please add one."
-            )
+        # __init__.py files are usually empty, this is to catch that.
+        raise Exception(
+            f"Could not find a valid Amazon.com copyright header in the top of {filename}."
+            " Please add one."
+        )
 
 
 def _is_version_file(filename: Path) -> bool:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Reformatted the code using `hatch fmt`. This is the built in [hatch formatter](https://hatch.pypa.io/1.9/config/static-analysis/) (`ruff`) which is not run as part of `hatch run fmt` (which [formats using black](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/hatch.toml#L14-L17)). The `black` formatter is currently only applying a subset of the rules from `hatch fmt`.

Also updated a job bundle output test to increase test coverage and avoid a SonarCloud duplicated code error.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
I ran the `physical` job bundle output test, since it was modified.

### Was this change documented?
No, N/A. I decided not to include `hatch format` in `DEVELOPMENT.md` yet because it outputs a number of formatting errors e.g. `test\test_copyright_headers.py:72:5: S101 Use of 'assert' detected` which are false positives.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*