### PR TITLE
fix: Ensure stdout/err streams are unbuffered. 

### DIFF
--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -55,6 +55,9 @@ steps:
   stepEnvironments:
   - name: Cinema4D
     description: Runs Cinema4D in the background.
+    variables:
+      # Turn off buffering in Python
+      PYTHONUNBUFFERED: "1"
     script:
       embeddedFiles:
       - name: initData


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Cinema 4D was getting stuck while running files. This was only in CMF instance and I couldn't replicate it in SMF instance.  

### What was the solution? (How)
Investigated and turns out Cinema4D was able to render the scene file but finishes before the output is flushed. The adaptor then fails to detect the status of the application and the job is stuck. 

Kudos to @mwiebe for sharing this idea to use `PYTHONUNBUFFERED` which ensures all the output is sent immediately instead of being saved into buffer and then flushed. 

### What is the impact of this change?
Adds a new environment variable to the jobs template. 

### How was this change tested?
Submitted a job locally and confirmed that the test worked. 

```
2024/12/21 18:26:22-06:00 ==============================================
2024/12/21 18:26:22-06:00 --------- Entering Environment: Cinema4D
2024/12/21 18:26:22-06:00 ==============================================
2024/12/21 18:26:22-06:00 Setting: PYTHONUNBUFFERED=1
2024/12/21 18:26:22-06:00 ----------------------------------------------
2024/12/21 18:26:22-06:00 Phase: Setup
2024/12/21 18:26:22-06:00 ----------------------------------------------
...
2024/12/21 18:27:10-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2024/12/21 18:27:10-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2024/12/21 18:27:11-06:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
2024/12/21 18:27:11-06:00 INFO: Done Cinema4DAdaptor main
2024/12/21 18:27:11-06:00 Process pid 3412 exited with code: 0 (unsigned) / 0x0 (hex)
2024/12/21 18:27:11-06:00 ----------------------------------------------
2024/12/21 18:27:11-06:00 Uploading output files to Job Attachments
2024/12/21 18:27:11-06:00 ----------------------------------------------
2024/12/21 18:27:11-06:00 Started syncing outputs using Job Attachments
```

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes. I was able to submit and confirm that all the renders worked. 

### Was this change documented?
Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*