### PR TITLE
fix: Tighten error regex pattern.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -218,7 +218,27 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
             completed_regexes = [re.compile(".*Finished Rendering.*")]
             progress_regexes = [re.compile(".*Progress ([0-9]+)%.*")]
             error_regexes = [
-                re.compile(r"(.*Error: .*)|(.*\[Error\].*)|(.*CRITICAL: Stop.*)", re.IGNORECASE)
+                re.compile(r".*CRITICAL: Stop.*", re.IGNORECASE),
+                re.compile(r".*Document not found.*", re.IGNORECASE),
+                re.compile(r".*Project not found.*", re.IGNORECASE),
+                re.compile(r".*Error rendering project.*", re.IGNORECASE),
+                re.compile(r".*Error loading project.*", re.IGNORECASE),
+                re.compile(r".*Error rendering document.*", re.IGNORECASE),
+                re.compile(r".*Error loading document.*", re.IGNORECASE),
+                re.compile(r".*Rendering failed.*", re.IGNORECASE),
+                re.compile(r".*Asset missing.*", re.IGNORECASE),
+                re.compile(r".*Asset Error.*", re.IGNORECASE),
+                re.compile(r".*Invalid License.*", re.IGNORECASE),
+                re.compile(r".*licensing error.*", re.IGNORECASE),
+                re.compile(r".*License Check error.*", re.IGNORECASE),
+                re.compile(r".*Files cannot be written.*", re.IGNORECASE),
+                re.compile(r".*Enter Registration Data.*", re.IGNORECASE),
+                re.compile(r".*Unable to write file.*", re.IGNORECASE),
+                re.compile(r".*\[rlm\] abort_on_license_fail enabled.*", re.IGNORECASE),
+                re.compile(r".*RenderDocument failed with return code.*", re.IGNORECASE),
+                re.compile(r".*Frame rendering aborted.*", re.IGNORECASE),
+                re.compile(r".*Rendering was internally aborted.*", re.IGNORECASE),
+                re.compile(r'.*Cannot find procedure "rsPreference".*', re.IGNORECASE),
             ]
 
             callback_list.append(RegexCallback(completed_regexes, self._handle_complete))

--- a/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_cinema4d/unit/Cinema4DAdaptor/test_adaptor.py
@@ -32,11 +32,28 @@ class TestCinema4DAdaptor_on_cleanup:
             ("CRITICAL: Stop [ge_file.cpp(1172)]", True),
             # Any string with substring "Error:" should fail the job
             ("Redshift Error: Maxon licensing error: User not logged in (7)", True),
-            # Any string with substring "[Error]" should fail the job
-            ("[Error] Application crashed", True),
             # This error can be printed but the jobs are still successful.
             # Hence, this should not fail the job.
             ("CRITICAL: nullptr [text_object.cpp(1082)] [objectbase1.hxx(549)]", False),
+            ("Project not found", True),
+            ("Error rendering project", True),
+            ("Error loading project", True),
+            ("Error rendering document", True),
+            ("Error loading document", True),
+            ("Rendering failed", True),
+            ("Asset missing", True),
+            ("Asset Error", True),
+            ("Invalid License", True),
+            ("License Check error", True),
+            ("Files cannot be written", True),
+            ("Enter Registration Data", True),
+            ("Unable to write file", True),
+            ("[rlm] abort_on_license_fail enabled", True),
+            ("RenderDocument failed with return code", True),
+            ("Frame rendering aborted", True),
+            ("Rendering was internally aborted", True),
+            ('Cannot find procedure "rsPreference"', True),
+            ("Description Error: ainode_image is already registered", False),
         ],
     )
     def test_handle_errors_on_error_stdout(
@@ -47,12 +64,14 @@ class TestCinema4DAdaptor_on_cleanup:
         adaptor = Cinema4DAdaptor(init_data)
         regex_callbacks = adaptor._get_regex_callbacks()
         # Currently the callback for errors is at index 2
-        error_regex = regex_callbacks[2].regex_list[0]
+        error_regexes = regex_callbacks[2].regex_list
 
         # WHEN
-        match = error_regex.search(stdout)
-        if match:
-            adaptor._handle_error(match)
+        for regex in error_regexes:
+            match = regex.search(stdout)
+            if match:
+                adaptor._handle_error(match)
+                break
 
         # THEN
         if error_expected:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/133

### What was the problem/requirement? (What/Why)

Cinema 4D adaptor used to fail jobs for even non-fatal errors as mentioned in the ticket issue above. 

### What was the solution? (How)

Modified the regex pattern so that Cinema 4D fails only for specific regexes. These regexes have been used in Deadline 10 for a long time and have been proven to be robust. 

### What is the impact of this change?

Adaptor will not fail jobs that have non-fatal errors in their outputs. 

### How was this change tested?
Submitted the jobs in "Job Bundle Output Tests" and confirmed that the renders worked as expected. 

- Have you run the unit tests?
Yes and I also added a few to test the cases. 

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Yes. Confirmed that the current test files rendered successfully. 

<img width="756" alt="Screenshot 2024-12-23 at 3 00 03 PM" src="https://github.com/user-attachments/assets/3454a112-9d6e-462e-a9ae-6b2b94124726" />


Also submitted a modified job with textures missing and the job failed as expected. (The 2nd redshift_textured job that had failed in the screenshot)

```
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: Asset Error: tex (Mat)
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: 
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)Traceback (most recent call last):
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)  File "C:\Program Files\Python312\Lib\site-packages\deadline\cinema4d_adaptor\Cinema4DClient\plugin\DeadlineCloudClient.pyp", line 30, in PluginMessage
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)    return parse_argv(sys.argv)
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)           ^^^^^^^^^^^^^^^^^^^^
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)  File "C:\Program Files\Python312\Lib\site-packages\deadline\cinema4d_adaptor\Cinema4DClient\plugin\DeadlineCloudClient.pyp", line 23, in parse_argv
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)    main()
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)  File "C:\Program Files\Python312\Lib\site-packages\deadline\cinema4d_adaptor\Cinema4DClient\cinema4d_client.py", line 58, in main
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)    client.poll()
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)  File "C:\Program Files\Python312\Lib\site-packages\openjd\adaptor_runtime_client\base_client_interface.py", line 212, in poll
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)    self._perform_action(action)
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)  File "C:\Program Files\Python312\Lib\site-packages\openjd\adaptor_runtime_client\base_client_interface.py", line 233, in _perform_action
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)    action_func(a.args)
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)  File "C:\Program Files\Python312\Lib\site-packages\deadline\cinema4d_adaptor\Cinema4DClient\cinema4d_handler.py", line 96, in start_render
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)    raise RuntimeError("Error: render result: %s" % result_description)
2024/12/23 14:46:50-06:00 ADAPTOR_OUTPUT: STDOUT: (null)RuntimeError: Error: render result: Assets (textures etc.) are missing.
2024/12/23 14:46:50-06:00 openjd_fail: Error encountered while running adaptor: Cinema4D Encountered an Error: Asset Error: tex (Mat)
```

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*