### PR TITLE
fix: Fix adaptor packaging script to package dependencies.

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -100,7 +100,7 @@ if [ $SOURCE = 1 ]; then
         --platform $PYPI_PLATFORM \
         --python-version $PYTHON_VERSION \
         --ignore-installed \
-        --no-deps \
+        --only-binary=:all: \
         $ADAPTOR_INSTALLABLE
 else
     # In PyPI mode, PyPI and/or a CodeArtifact must have these packages


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Cinema 4D was failing with the following error: 

```
2024/12/27 16:33:37-06:00 openjd_fail: Error encountered while starting adaptor: Cinema4D Encountered an Error: https://assets.maxon.net/assets/MaxonAssets.db/_index/modified.dat: SSL_do_handshake returned error: SSL_ERROR_SSL (certificate verify failed Certificate Information: not available) [network_ip_ssl_impl.cpp(619)]
```

### What was the solution? (How)

There was an issue in the script where the dependencies were not being packaged properly. 
As this script was different from other scripts like [Keyshot's](https://github.com/aws-deadline/deadline-cloud-for-keyshot/blob/mainline/scripts/create_adaptor_packaging_artifact.sh#L101) which installed to the target directory with its dependencies, I updated the script to be similar to Keyshot and other DCCs.

### What is the impact of this change?

This fixes the above SSL errors. 

### How was this change tested?
To check if this fixed the issue, I submitted jobs from Job Bundle Output tests with only `cinema4d` and `cinema4d-openjd` as conda packages and verified that they rendered successfully.

```
...
2024/12/31 09:25:29-06:00   added / updated specs:
2024/12/31 09:25:29-06:00     - cinema4d
2024/12/31 09:25:29-06:00     - cinema4d-openjd
2024/12/31 09:25:29-06:00  
2024/12/31 09:25:29-06:00  
2024/12/31 09:25:29-06:00 The following NEW packages will be INSTALLED:
2024/12/31 09:25:29-06:00  
2024/12/31 09:25:29-06:00   cinema4d           Conda/internal-cinema4d-conda-packages/win-64::cinema4d-2025.1.1-0 
2024/12/31 09:25:29-06:00   cinema4d-openjd    Conda/internal-cinema4d-conda-packages/win-64::cinema4d-openjd-0.5.4-0 
...
2024/12/31 09:33:30-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 98
2024/12/31 09:33:30-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2024/12/31 09:33:31-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2024/12/31 09:33:35-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2024/12/31 09:33:35-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2024/12/31 09:33:36-06:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
2024/12/31 09:33:36-06:00 INFO: Done Cinema4DAdaptor main
...
```

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*