### PR TITLE
fix: Refactor redshift non-ascii test.

### DIFF
--- a/job_bundle_output_tests/redshift_textured_with_nonascii_characters/scene/cube.py
+++ b/job_bundle_output_tests/redshift_textured_with_nonascii_characters/scene/cube.py
@@ -3,70 +3,92 @@ import struct
 import c4d
 
 
-def _checkerboard_bmp(filename):
-    width = 128
-    height = 128
-    color1 = (255, 255, 255)
-    color2 = (0, 0, 0)
+def create_checkerboard_bmp(
+    filename, width=128, height=128, color1=(255, 255, 255), color2=(0, 0, 0)
+):
     # BMP file header
     file_size = 14 + 40 + (width * height * 3)
     file_header = struct.pack("<2sIHHI", b"BM", file_size, 0, 0, 54)
+
     # DIB header
     dib_header = struct.pack(
         "<IiiHHIIiiII", 40, width, height, 1, 24, 0, width * height * 3, 2835, 2835, 0, 0
     )
+
+    # Generate pixel data
     pixel_data = []
     for y in range(height):
-        row_data = []
         for x in range(width):
-            if (x // 8 + y // 8) % 2 == 0:
-                row_data.extend(color1)
-            else:
-                row_data.extend(color2)
+            color = color1 if (x // 8 + y // 8) % 2 == 0 else color2
+            pixel_data.extend(color)
         padding = (4 - (width * 3) % 4) % 4
-        row_data.extend([0] * padding)
-        pixel_data.extend(row_data)
+        pixel_data.extend([0] * padding)
+
+    # Write BMP file
     with open(filename, "wb") as bmp_file:
         bmp_file.write(file_header)
         bmp_file.write(dib_header)
         bmp_file.write(bytearray(pixel_data))
 
 
-def main():
-    doc = c4d.documents.GetActiveDocument()
-    doc.Flush()
+def create_cube(size=400, position=c4d.Vector(0, 50, -50)):
     cube = c4d.BaseObject(c4d.Ocube)
-    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(400, 400, 400)
-    cube.SetAbsPos(c4d.Vector(0, 50, -50))
-    doc.InsertObject(cube)
-    mat = c4d.BaseList2D(c4d.Mmaterial)
-    doc.InsertMaterial(mat)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(size, size, size)
+    cube.SetAbsPos(position)
+    return cube
+
+
+def create_material(bitmap_path):
+    mat = c4d.BaseMaterial(c4d.Mmaterial)
     mat[c4d.MATERIAL_USE_REFLECTION] = False
     bitmap_shader = c4d.BaseShader(c4d.Xbitmap)
-    tex_dir = os.path.join(os.path.dirname(__file__), "tex")
-    os.makedirs(tex_dir, exist_ok=True)
-    _checkerboard_bmp(os.path.join(tex_dir, "checkerboard-_₿_ę_ñ_β_Б_ت.bmp"))
-    bitmap_shader[c4d.BITMAPSHADER_FILENAME] = "tex/checkerboard-_₿_ę_ñ_β_Б_ت.bmp"
+    bitmap_shader[c4d.BITMAPSHADER_FILENAME] = bitmap_path
     mat[c4d.MATERIAL_COLOR_SHADER] = bitmap_shader
     mat.InsertShader(bitmap_shader)
-    texture_tag = c4d.TextureTag()
-    texture_tag.SetMaterial(mat)
-    cube.InsertTag(texture_tag)
+    return mat
+
+
+def setup_render_settings(doc, frame_start, frame_end):
     render_data = doc.GetActiveRenderData()
     render_data[c4d.RDATA_PATH] = "renders/$prj"
-    frame_start = c4d.BaseTime(1, doc.GetFps())
-    frame_end = c4d.BaseTime(1, doc.GetFps())
     render_data[c4d.RDATA_FRAMEFROM] = frame_start
     render_data[c4d.RDATA_FRAMETO] = frame_end
     render_data[c4d.RDATA_RENDERENGINE] = 1036219  # redshift
 
+
+def main():
+    doc = c4d.documents.GetActiveDocument()
+    doc.Flush()
+
+    # Create and insert cube
+    cube = create_cube()
+    doc.InsertObject(cube)
+
+    # Create texture
+    tex_dir = os.path.join(os.path.dirname(__file__), "tex")
+    os.makedirs(tex_dir, exist_ok=True)
+    texture_filename = "checkerboard-_₿_ę_ñ_β_Б_ت.bmp"
+    texture_path = os.path.join(tex_dir, texture_filename)
+    create_checkerboard_bmp(texture_path)
+
+    # Create and apply material
+    mat = create_material(f"tex/{texture_filename}")
+    doc.InsertMaterial(mat)
+    texture_tag = c4d.TextureTag()
+    texture_tag.SetMaterial(mat)
+    cube.InsertTag(texture_tag)
+
+    # Setup render settings
+    frame_time = c4d.BaseTime(1, doc.GetFps())
+    setup_render_settings(doc, frame_time, frame_time)
+
+    # Save document
     save_dir = os.path.dirname(__file__)
     save_name = "redshift_textured-_₿_ę_ñ_β_Б_ت.c4d"
-    save_file = os.path.join(save_dir, save_name)
+    save_path = os.path.join(save_dir, save_name)
     doc.SetDocumentPath(save_dir)
     doc.SetDocumentName(save_name)
-    c4d.documents.SaveDocument(doc, save_file, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
-
+    c4d.documents.SaveDocument(doc, save_path, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
     c4d.documents.InsertBaseDocument(doc)
     c4d.EventAdd()
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
I added a [test earlier](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/135) which was similar to `redshift_textured` that was causing the SonarCloud checks to fail for all the subsequent tests due to duplication of test code. 

### What was the solution? (How)
Refactored the test to ensure the checks pass as there is minimum duplication.

### What is the impact of this change?
The SonarCloud checks now passes on all commits. 

### How was this change tested?
Submitted the test scene created from the script and confirmed that the render was successful. 

### Is this a breaking change?
No. 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*