### PR TITLE
fix: Add error logs for Redshift.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -367,6 +367,9 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         os.environ[module_path_key] = new_module_path
 
         arguments = [c4d_exe, "-nogui", "-DeadlineCloudClient"]
+        # If this is a Redshift render, we would want to emit at least error logs
+        # For non-Redshift renders this does not print any extra information.
+        arguments.extend(["-redshift-log-console", "Error"])
         if "linux" in platform.system().lower():
             _logger.info("Inserting Linux adaptor wrapper script")
             arguments.insert(0, os.path.join(os.path.dirname(__file__), "adaptor.sh"))


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/83

### What was the problem/requirement? (What/Why)

Redshift renders did not print logs to the console making debugging hard. 

### What was the solution? (How)

We added an CLI argument `-redshift-log-console` which ensures that we at least print the "Error" logs. 

I chose "Error" as it showed the exact error while the "Debug" logs were too verbose. 

Before:

```
2025/01/08 13:35:38-06:00 ADAPTOR_OUTPUT: STDOUT: Rendering frame 150 at <Wed Jan  8 19:35:38 2025>
2025/01/08 13:35:42-06:00 openjd_fail: Error encountered while running adaptor: Cinema4D exited early and did not render successfully, please check render logs. Exit code 3221226505
2025/01/08 13:35:42-06:00 ERROR: Entrypoint failed: openjd_fail: Error encountered while running adaptor: Cinema4D exited early and did not render successfully, please check render logs. Exit code 3221226505
2025/01/08 13:35:42-06:00 Process pid 3516 exited with code: 1 (unsigned) / 0x1 (hex)
```

Now: 

```
2025/01/09 18:23:49-06:00 ADAPTOR_OUTPUT: STDOUT: Rendering frame 150 at <Fri Jan 10 00:23:49 2025>
2025/01/09 18:23:51-06:00 ADAPTOR_OUTPUT: STDOUT: Redshift Error: Skipped device Tesla T4 because kernel files are missing. Please deactivate the device or reinstall Redshift!
2025/01/09 18:23:51-06:00 ADAPTOR_OUTPUT: STDOUT: 
2025/01/09 18:23:51-06:00 ADAPTOR_OUTPUT: STDOUT: Redshift Error: No devices available
2025/01/09 18:23:51-06:00 ADAPTOR_OUTPUT: STDOUT: 
2025/01/09 18:23:55-06:00 openjd_fail: Error encountered while running adaptor: Cinema4D exited early and did not render successfully, please check render logs. Exit code 3221226505
```

### What is the impact of this change?

Better helpful messages for customers to debug. 

### How was this change tested?

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Yes. 

![Screenshot 2025-01-09 at 6 42 06 PM](https://github.com/user-attachments/assets/1e18e79e-b4b1-4074-8569-8c30d5170490)


### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*