### PR TITLE
fix: Use Path instead of string in output paths in adaptor template.

### DIFF
--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -27,16 +27,20 @@ parameterDefinitions:
   description: The frames to render. E.g. 1-3,8,11-15
   minLength: 1
 - name: OutputPath
-  type: STRING
+  type: PATH
+  objectType: FILE
+  dataFlow: OUT
   userInterface:
-    control: LINE_EDIT
+    control: CHOOSE_OUTPUT_FILE
     label: Default image output
     groupLabel: Cinema4D Settings
   description: Image output path
 - name: MultiPassPath
-  type: STRING
+  type: PATH
+  objectType: FILE
+  dataFlow: OUT
   userInterface:
-    control: LINE_EDIT
+    control: CHOOSE_OUTPUT_FILE
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `adaptor_cinema4d_job_template.yaml` used strings for output path and multi-pass outputs. It should have used PATH instead. 

### What was the solution? (How)

Output and multi-pass paths now are PATHs instead and hence non-editable in resubmit. 

### How was this change tested?

Submitted jobs with this change in my local workstation and it worked as expected. Also the jobs now have these fields as non-editable. 

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Yes. 

![Screenshot 2025-01-15 at 5 38 24 PM](https://github.com/user-attachments/assets/43daf1a0-b923-4226-b6ef-5ccea26dfb97)


### Was this change documented?
Does not require documentation change. 

### Is this a breaking change?
No. Old customers that use the service will not be impacted. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*