### PR TITLE
fix: improve error handling for sticky settings having a long path

### DIFF
--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
+import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from .takes import TakeSelection  # type: ignore
 
 RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -58,21 +62,32 @@ class RenderSubmitterUISettings:
             except (OSError, json.JSONDecodeError):
                 # If something bad happened to the sticky settings file,
                 # just use the defaults instead of producing an error.
-                import traceback
-
                 traceback.print_exc()
-                print(
-                    f"WARNING: Failed to load sticky settings file {sticky_settings_filename}, reverting to the default settings."
+                _logger.warning(
+                    f"Failed to load sticky settings file {sticky_settings_filename.absolute()}, reverting to the"
+                    + "default settings."
                 )
 
     def save_sticky_settings(self, scene_filename: str):
         sticky_settings_filename = Path(scene_filename).with_suffix(
             RENDER_SUBMITTER_SETTINGS_FILE_EXT
         )
-        with open(sticky_settings_filename, "w", encoding="utf8") as fh:
-            obj = {
-                field.name: getattr(self, field.name)
-                for field in dataclasses.fields(self)
-                if field.metadata.get("sticky")
-            }
-            json.dump(obj, fh, indent=1)
+        sticky_settings_path = str(sticky_settings_filename.absolute())
+        try:
+            with open(sticky_settings_filename, "w", encoding="utf8") as fh:
+                obj = {
+                    field.name: getattr(self, field.name)
+                    for field in dataclasses.fields(self)
+                    if field.metadata.get("sticky")
+                }
+                json.dump(obj, fh, indent=1)
+        except OSError as e:
+            traceback.print_exc()
+            if len(sticky_settings_path) >= 256:
+                # raise an error here because if we ignore this error, there will likely be later errors in rendering
+                # due to exceeding the max path length
+                raise RuntimeError(
+                    "Failed to save sticky settings file. This usually occurs from exceeding the maximum path length. "
+                    + f"Please reduce the length of your .c4d filename. Error: {e}"
+                )
+            _logger.warning(f"Failed to save sticky settings file to {sticky_settings_path}.")


### PR DESCRIPTION
Relates to https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/84

### What was the problem/requirement? (What/Why)
Cinema 4D does not support long paths. Because of this, there are various errors when attempting to submit jobs with long path files. One of the errors is:

![olderror](https://github.com/user-attachments/assets/29efef5f-3dc1-4e5f-912b-97cf52059cd1)

### What was the solution? (How)
Handle the error where the sticky settings file cannot be created by raising a more useful error message. I chose to raise an error for the long path case rather than simply ignoring the failure because there will be [further issues later in submission anyway](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/84#issuecomment-2596345886) if the .c4d file path is not shortened.

If the issue is not a long path issue, then only a warning is logged and the submission is allowed.

### What is the impact of this change?
Easier debugging for long path issues.

### How was this change tested?
Created a `.c4d` file with a long path where the sticky settings file would make the file exceeds Cinema 4D's max path length.

![updatederror](https://github.com/user-attachments/assets/c733784f-5cdd-4c4f-81cc-d6490886c933)

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, N/A

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

