### PR TITLE
feat: prepopulate Windows host requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.49.*",
+    "deadline >= 0.49.5",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -13,6 +13,7 @@ from qtpy.QtCore import Qt  # type: ignore[attr-defined]
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.submission import AssetReferences
+from deadline.client.ui.dataclasses import HostRequirements, OsRequirements
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
     JobBundlePurpose,
     SubmitJobToDeadlineDialog,
@@ -444,6 +445,9 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
         parent=parent,
         f=f,
         show_host_requirements_tab=True,
+        host_requirements=HostRequirements(
+            os_requirements=OsRequirements(operating_systems=[OsRequirements.WINDOWS])
+        ),
     )
 
     return submitter_dialog


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/105

### What was the problem/requirement? (What/Why)
Since Windows is the only currently supported operating system for the Deadline Cloud integration, there is currently a default host requirement of Windows. However, this host requirement does not appear in the submitter host requirements tab. 

### What was the solution? (How)
With the @Ahuge's awesome feature to prepopulate the host requirements, we can now prepopulate the Windows OS for Cinema 4D!

### What is the impact of this change?
The host requirements tab defaults now match the defaults of Cinema 4D.

### How was this change tested?
Installed the submitter on Windows via the manual instructions in the README:
```
set SUBMITTER_LOCATION=%APPDATA%\DeadlineCloudSubmitter
"C:\Program Files\Maxon Cinema 4D 2025\resource\modules\python\libs\win64\python.exe" -m ensurepip
"C:\Program Files\Maxon Cinema 4D 2025\resource\modules\python\libs\win64\python.exe" -m pip install deadline-cloud-for-cinema-4d "deadline[gui]" -t %SUBMITTER_LOCATION%
md %SUBMITTER_LOCATION%\cinema_4d_plugins
curl https://raw.githubusercontent.com/aws-deadline/deadline-cloud-for-cinema-4d/refs/heads/mainline/deadline_cloud_extension/DeadlineCloud.pyp -o %SUBMITTER_LOCATION%\cinema_4d_plugins\DeadlineCloud.pyp
if not defined C4DPYTHONPATH311 (setx C4DPYTHONPATH311 %SUBMITTER_LOCATION%) else (setx C4DPYTHONPATH311 %SUBMITTER_LOCATION%;%C4DPYTHONPATH311%)
if not defined g_additionalModulePath (setx g_additionalModulePath %SUBMITTER_LOCATION%\cinema_4d_plugins) else (setx g_additionalModulePath %SUBMITTER_LOCATION%\cinema_4d_plugins;%g_additionalModulePath%)
```
Replaced `%APPDATA%\DeadlineCloudSubmitter\deadline\cinema4d_submitter\cinema4d_render_submitter.py` with the version updated in this PR.

Opened the AWS Deadline Cloud submitter and confirmed that the host requirements were pre-filled:

![image](https://github.com/user-attachments/assets/ce8238eb-a75a-4cbc-bc05-e96808b9ffd5)

Submitted the job and confirmed it rendered successfully.

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*