### PR TITLE
fix!: handle custom frame ranges

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -80,7 +80,7 @@ def _get_parameter_values(
     if settings.override_frame_range:
         frame_list = settings.frame_list
     else:
-        frame_list = str(Animation.frame_list())
+        frame_list = Animation.frame_list()
     parameter_values.append({"name": "Frames", "value": frame_list})
 
     # Check for any overlap between the job parameters we've defined and the
@@ -302,7 +302,7 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
 
     # Set the setting defaults that come from the scene
     render_settings.name = Path(Scene.name()).name
-    render_settings.frame_list = str(Animation.frame_list())
+    render_settings.frame_list = Animation.frame_list()
     default_path, multi_path = Scene.get_output_paths()
     render_settings.output_path = default_path
     render_settings.multi_pass_path = multi_path
@@ -338,7 +338,7 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
             renderer_name=renderer_name,
             ui_group_label=f"Take {take_name} Settings ({renderer_name} renderer)",
             frames_parameter_name=None,
-            frame_range=str(Animation.frame_list(take_render_data)),
+            frame_range=Animation.frame_list(take_render_data),
             output_directories=output_directories,
             marked=take.IsChecked(),
         )

--- a/test/deadline_submitter_for_cinema4d/unit/test_scene.py
+++ b/test/deadline_submitter_for_cinema4d/unit/test_scene.py
@@ -167,7 +167,7 @@ class TestFrameRange:
                 "1-100:7",
                 id="start=1, stop=100, step=7",
             ),
-            pytest.param(4, 10, None, "4-10", id="start=1, stop=100, step=None"),
+            pytest.param(4, 10, None, "4-10", id="start=4, stop=10, step=None"),
             pytest.param(6, 14, 2, "6-14:2", id="start=6, stop=14, step=2"),
             pytest.param(1, None, 7, "1", id="start=1, stop=None, step=7"),
             pytest.param(10, 10, 10, "10", id="start=10, stop=10, step=10"),

--- a/test/deadline_submitter_for_cinema4d/unit/test_scene.py
+++ b/test/deadline_submitter_for_cinema4d/unit/test_scene.py
@@ -1,11 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from typing import Optional
-from unittest.mock import patch
+from unittest import mock
 
 import pytest
 
-from deadline.cinema4d_submitter.scene import FrameRange, RendererNames, Scene
+from deadline.cinema4d_submitter.scene import Animation, FrameRange, RendererNames, Scene
 
 
 def test_renderer_names():
@@ -29,7 +29,7 @@ def test_get_output_directores():
     assert doc is not None
 
 
-@patch("c4d.RDATA_RENDERENGINE", 0)
+@mock.patch("c4d.RDATA_RENDERENGINE", 0)
 def test_renderer():
     render_data = {0: 0}
     renderer = Scene.renderer(render_data=render_data)
@@ -37,26 +37,148 @@ def test_renderer():
     assert renderer == "standard"
 
 
-class TestFrameRange:
-    frame_range_params = [(1, 100, 7), (1, 100, None), (1, None, 7), (10, 10, 10), (1, 10, 1)]
+class TestAnimation:
 
-    @pytest.mark.parametrize("start, stop, step", frame_range_params)
-    def test_frame_range_iter(self, start: int, stop: int, step: Optional[int]) -> None:
+    class MockC4d:
+        MOCK_RDATA_FRAMESEQUENCE_CURRENTFRAME = 1000
+        MOCK_RDATA_FRAMESEQUENCE_ALLFRAMES = 1001
+        MOCK_RDATA_FRAMESEQUENCE_PREVIEWRANGE = 1002
+        MOCK_RDATA_FRAMESEQUENCE_MANUAL = 1003
+        MOCK_RDATA_FRAMESEQUENCE_CUSTOM = 1004
+        MOCK_RDATA_FRAMEFROM = 1005
+        MOCK_RDATA_FRAMETO = 1006
+        MOCK_RDATA_FRAMESTEP = 1007
+        MOCK_RDATA_FRAME_RANGE_STRING = 1008
+        MOCK_RDATA_FRAMESEQUENCE = 1009
+
+    class MockGetFrame:
+        def __init__(self, value):
+            self.value = value
+
+        def GetFrame(self, _fps):
+            return self.value
+
+    class MockData:
+
+        def __init__(self):
+            self.frame_spec_type = -1
+
+        def set_frame_spec_type(self, frame_spec_type):
+            self.frame_spec_type = frame_spec_type
+
+        def __getitem__(self, key):
+            return {
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMEFROM: TestAnimation.MockGetFrame(5),
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMETO: TestAnimation.MockGetFrame(12),
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMESTEP: "2",
+                TestAnimation.MockC4d.MOCK_RDATA_FRAME_RANGE_STRING: "3,6-10:2,15-17",
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMESEQUENCE: self.frame_spec_type,
+            }[key]
+
+    @pytest.fixture
+    def mock_c4d(self):
+        with mock.patch("deadline.cinema4d_submitter.scene.c4d") as mock_c4d:
+            mock_c4d.RDATA_FRAMESEQUENCE_CURRENTFRAME = (
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMESEQUENCE_CURRENTFRAME
+            )
+            mock_c4d.RDATA_FRAMESEQUENCE_ALLFRAMES = (
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMESEQUENCE_ALLFRAMES
+            )
+            mock_c4d.RDATA_FRAMESEQUENCE_PREVIEWRANGE = (
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMESEQUENCE_PREVIEWRANGE
+            )
+            mock_c4d.RDATA_FRAMESEQUENCE_MANUAL = (
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMESEQUENCE_MANUAL
+            )
+            mock_c4d.RDATA_FRAMESEQUENCE_CUSTOM = (
+                TestAnimation.MockC4d.MOCK_RDATA_FRAMESEQUENCE_CUSTOM
+            )
+            mock_c4d.RDATA_FRAMEFROM = TestAnimation.MockC4d.MOCK_RDATA_FRAMEFROM
+            mock_c4d.RDATA_FRAMETO = TestAnimation.MockC4d.MOCK_RDATA_FRAMETO
+            mock_c4d.RDATA_FRAMESTEP = TestAnimation.MockC4d.MOCK_RDATA_FRAMESTEP
+            mock_c4d.RDATA_FRAME_RANGE_STRING = TestAnimation.MockC4d.MOCK_RDATA_FRAME_RANGE_STRING
+            mock_c4d.RDATA_FRAMESEQUENCE = TestAnimation.MockC4d.MOCK_RDATA_FRAMESEQUENCE
+            yield mock_c4d
+
+    @pytest.mark.parametrize(
+        "frame_spec_type, expected_output",
+        [
+            pytest.param(
+                "RDATA_FRAMESEQUENCE_CURRENTFRAME",
+                "5",
+            ),
+            pytest.param(
+                "RDATA_FRAMESEQUENCE_ALLFRAMES",
+                "5-12:2",
+            ),
+            pytest.param(
+                "RDATA_FRAMESEQUENCE_PREVIEWRANGE",
+                "5-12:2",
+            ),
+            pytest.param(
+                "RDATA_FRAMESEQUENCE_MANUAL",
+                "5-12:2",
+            ),
+            pytest.param(
+                "RDATA_FRAMESEQUENCE_CUSTOM",
+                "3,6-10:2,15-17",
+            ),
+        ],
+    )
+    def test_get_frame_list_data_input(
+        self,
+        frame_spec_type: str,
+        expected_output: str,
+        mock_c4d: mock.Mock,
+    ) -> None:
         # GIVEN
-        frame_range = FrameRange(start, stop, step)
+        mock_data = TestAnimation.MockData()
+        mock_data.set_frame_spec_type(getattr(mock_c4d, frame_spec_type))
+        mock_c4d.documents.GetActiveDocument.return_value.GetActiveRenderData.return_value = (
+            mock_data
+        )
 
-        # WHEN
-        frames = [f for f in frame_range]
+        assert Animation.frame_list(mock_data) == expected_output
+        assert Animation.frame_list() == expected_output
 
-        # THEN
-        if stop is None:
-            stop = start
-        if step is None:
-            step = 1
-        assert frames == [i for i in range(start, stop + step, step)]
 
-    @pytest.mark.parametrize("start, stop, step", frame_range_params)
-    def test_frame_repr(self, start: int, stop: int, step: Optional[int]) -> None:
+class TestFrameRange:
+    @pytest.mark.parametrize(
+        "start, stop, step, expected_string",
+        [
+            pytest.param(
+                5,
+                7,
+                1,
+                "5-7",
+                id="start=5, stop=7, step=1",
+            ),
+            pytest.param(
+                2,
+                13,
+                3,
+                "2-13:3",
+                id="start=2, stop=13, step=3",
+            ),
+            pytest.param(
+                1,
+                100,
+                7,
+                "1-100:7",
+                id="start=1, stop=100, step=7",
+            ),
+            pytest.param(4, 10, None, "4-10", id="start=1, stop=100, step=None"),
+            pytest.param(6, 14, 2, "6-14:2", id="start=6, stop=14, step=2"),
+            pytest.param(1, None, 7, "1", id="start=1, stop=None, step=7"),
+            pytest.param(10, 10, 10, "10", id="start=10, stop=10, step=10"),
+            pytest.param(17, 17, None, "17", id="start=17, stop=17, step=None"),
+            pytest.param(18, 19, None, "18-19", id="start=18, stop=19, step=None"),
+            pytest.param(15, None, None, "15", id="start=15, stop=None, step=None"),
+        ],
+    )
+    def test_frame_range_repr(
+        self, start: int, stop: Optional[int], step: Optional[int], expected_string: str
+    ) -> None:
         # GIVEN
         frame_range = FrameRange(start, stop, step)
 
@@ -64,9 +186,4 @@ class TestFrameRange:
         fr_repr = repr(frame_range)
 
         # THEN
-        if stop is None or start == stop:
-            assert fr_repr == str(start)
-        elif step is None or step == 1:
-            assert fr_repr == f"{start}-{stop}"
-        else:
-            assert fr_repr == f"{start}-{stop}:{step}"
+        assert fr_repr == expected_string


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Unit test coverage is lacking for the `deadline-cloud-for-cinema-4d integration`. This increases risks of changes mistakenly causing regressions and errors in implementation.

### What was the solution? (How)
Added some unit tests for `cinema4d_submitter/scene.py`. In the process, noticed that the handling of custom frame ranges was incorrect. Added correct handling of custom frame ranges and unit tests.

### What is the impact of this change?
Custom frame ranges will now work!

### How was this change tested?
1. Updated the C4D submitter `scene.py` file on my workstation. 
2. Selected Render > Render Settings > Custom Frames
3. Input `1,4-5,11-20:2`
4. Go to Extensions > AWS Deadline Cloud Submitter > Submit
a) Before change: Frame 0 was sent to Deadline Cloud
b) After change: Frames 1, 4, 5, 11, 13, 15, 17, and 19 were sent to Deadline Cloud

### Was this change documented?
No, N/A

### Is this a breaking change?
Yes, this removes the unused `Scene` `__iter__` method and also requires the `data` argument in `Animation`'s method for `current_frame`, `start_frame`, `end_frame`, and `frame_step`. It also changes the return type of `Animation`s `frame_list` function to a `str` and removes the `extension_padding` function. While we don't know of any use cases where these functions would be called externally, this is technically a breaking change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*