### PR TITLE
docs: Update pip to use quotes to escape shell interpretations of special characters. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It automatically determines the files required based on the loaded scene, allows
 
 ```
 pip install deadline-cloud-for-cinema-4d
-pip install deadline[gui]
+pip install "deadline[gui]"
 ```
 
 2. Set up the `C4DPYTHONPATH311` environment variable:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some customers had issues with running `pip install deadline[gui]`. This is because sometimes shells can misinterpret square brackets.

### What was the solution? (How)

Updated the docs to say `pip install "deadline[gui]"` instead. This should send the whole string to pip without treating the special characters differently. 

### What is the impact of this change?

Some of our customers had issues with installing our adaptors using Github instructions, hence updating this. 

### How was this change tested?

Ran this in multiple OSes and confirmed that it works. 

### Is this a breaking change?
No just a docs update. 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*