### PR TITLE
chore: remove an outdated note from the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,9 +25,6 @@ See the "Integration Tests" subsection of the
 [Running Submitter Tests](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/DEVELOPMENT.md#running-submitter-tests)
 section of DEVELOPMENT.md for information on these tests.
 
-```
-Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
-```
 *delete text ending here*
 
 ### Was this change documented?


### PR DESCRIPTION
Updated the pull request template to remove references to `test-job-bundle-results.txt`. This was copied from `deadline-cloud-for-maya` and doesn't apply to `deadline-cloud-for-cinema-4d`.