### PR TITLE
chore: Update the CHANGELOG.md for yanking 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.7.0 (2025-02-03)
 
+**This release has been pulled from PyPI. The use of this release can cause the submitter to fail on Cinema 4D 2024.5.1 version. Downgrade to 0.6.1 or upgrade to the next release if available.**
+
 ### BREAKING CHANGES
 * handle custom frame ranges (#152) ([`c1b1d38`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/c1b1d38bc850c7cfdf421ae3d7b680fb2d54d9f2))
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We encountered an issue where older Cinema 4D versions like Cinema 4D 2025.0.2 or Cinema 4D 2024.5.1 don't have the variable `RDATA_FRAMESEQUENCE_CUSTOM` which would cause the submitter to crash on these versions. 

### What was the solution? (How)

We yanked the CInema 4D 0.7.0 release from PyPI and we are now updating the CHANGELOG.md to suggest that. 

### What is the impact of this change?

Customers using Cinema 4D 2024.5.1 will be able to use the submitter. 

### How was this change tested?

No tests, just a doc change. 

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*