### PR TITLE
fix: Use RDATA_FRAMESEQUENCE_CUSTOM only if it exists.

### DIFF
--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -92,7 +92,10 @@ class Animation:
         frame_spec_type = data[c4d.RDATA_FRAMESEQUENCE]
         if frame_spec_type == c4d.RDATA_FRAMESEQUENCE_CURRENTFRAME:
             return str(FrameRange(start=cls.current_frame(data)))
-        if frame_spec_type == c4d.RDATA_FRAMESEQUENCE_CUSTOM:
+        if (
+            hasattr(c4d, "RDATA_FRAMESEQUENCE_CUSTOM")
+            and frame_spec_type == c4d.RDATA_FRAMESEQUENCE_CUSTOM
+        ):
             return cls.custom_frames(data)
         return str(
             FrameRange(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was an issue in https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/152/files as the `RDATA_FRAMESEQUENCE_CUSTOM` is a new variable and does not exist on Cinema 4D 2024 or older releases of Cinema 4D 2025. 

### What was the solution? (How)

We first check if the attribute exists before doing a `c4d.RDATA_FRAMESEQUENCE_CUSTOM` and this should avoid the errors. 

### What is the impact of this change?

Customers can work on Cinema4D 2024 versions as well. 

### How was this change tested?

@joel-wong-aws helped me run the tests manually as my UI elements were broken. 

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*