### PR TITLE
chore: Refactor the Cinema 4D submitter for tests.

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -297,21 +297,27 @@ def _prompt_save_current_document():
     return True
 
 
-def _show_submitter(parent=None, f=Qt.WindowFlags()):
-
+def initialize_render_settings() -> RenderSubmitterUISettings:
+    """
+    Initialize the render settings with defaults that come from the scene.
+    """
     render_settings = RenderSubmitterUISettings()
-
-    # Set the setting defaults that come from the scene
     render_settings.name = Path(Scene.name()).name
     render_settings.frame_list = Animation.frame_list()
     default_path, multi_path = Scene.get_output_paths()
     render_settings.output_path = default_path
     render_settings.multi_pass_path = multi_path
-
-    # Load the sticky settings
     render_settings.load_sticky_settings(Scene.name())
+    return render_settings
 
-    doc = c4d.documents.GetActiveDocument()
+
+def get_takes_from_doc(doc: Any) -> dict[str, list[TakeData]]:
+    """
+    Extracts and organizes take data from the given Cinema 4D document.
+
+    Recursively processes all takes in the document, including the main take and its children,
+    collecting rendering information and organizing them into different categories.
+    """
     take_data = doc.GetTakeData()
     main_take = take_data.GetMainTake()
     current_take = take_data.GetCurrentTake()
@@ -348,7 +354,159 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
             current_data_list = [take_data]
         if take.IsChecked():
             marked_data_list.append(take_data)
-    main_data_list = [take_data_list[0]]
+
+    return {
+        "take_data_list": take_data_list,
+        "current_data_list": current_data_list,
+        "marked_data_list": marked_data_list,
+        "main_data_list": [take_data_list[0]],
+    }
+
+
+def save_job_bundle_files(
+    job_bundle_path: Path,
+    job_template: dict,
+    parameter_values: list[dict[str, Any]],
+    asset_references: AssetReferences,
+) -> None:
+    """
+    This function saves the generated template/parameter_values/asset_references
+    into the job bundle path.
+    All the files are saved with UTF-8 encoding.
+    """
+    with open(job_bundle_path / "template.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump(job_template, f, indent=1)
+
+    with open(job_bundle_path / "parameter_values.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump({"parameterValues": parameter_values}, f, indent=1)
+
+    with open(job_bundle_path / "asset_references.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump(asset_references.to_dict(), f, indent=1)
+
+
+def create_job_bundle(
+    settings: RenderSubmitterUISettings,
+    takes: dict[str, list[TakeData]],
+    job_bundle_dir: str,
+    asset_references: AssetReferences,
+    queue_parameters: list[dict[str, Any]],
+    attachments: AssetReferences,
+    host_requirements: Optional[dict] = None,
+):
+    """
+    Creates a job bundle and saves sticky settings for rendering.
+
+    This function processes the render settings, takes, and asset references to create
+    a job bundle for submission. It handles different take selection modes, manages
+    frame ranges, and prepares job templates with the necessary parameters.
+    """
+
+    submit_takes = takes["main_data_list"]
+    job_bundle_path = Path(job_bundle_dir)
+    if settings.take_selection == TakeSelection.MAIN:
+        submit_takes = takes["main_data_list"]
+    elif settings.take_selection == TakeSelection.ALL:
+        submit_takes = takes["take_data_list"]
+    elif settings.take_selection == TakeSelection.MARKED:
+        submit_takes = takes["marked_data_list"]
+    elif settings.take_selection == TakeSelection.CURRENT:
+        submit_takes = takes["current_data_list"]
+
+    # Add overrides to asset references
+    if settings.output_path:
+        asset_references.output_directories.add(os.path.dirname(settings.output_path))
+    if settings.multi_pass_path:
+        asset_references.output_directories.add(os.path.dirname(settings.multi_pass_path))
+
+    # # Check if there are multiple frame ranges across the takes
+    first_frame_range = submit_takes[0].frame_range
+    per_take_frames_parameters = not settings.override_frame_range and any(
+        take.frame_range != first_frame_range for take in submit_takes
+    )
+
+    # If there are multiple frame ranges and we're not overriding the range,
+    # then we create per-take Frames parameters.
+    if per_take_frames_parameters:
+        for take_data in submit_takes:
+            take_data.frames_parameter_name = f"{take_data.display_name}Frames"
+
+    renderers: set[str] = {take_data.renderer_name for take_data in submit_takes}
+    job_template = _get_job_template(settings, renderers, submit_takes)
+    parameter_values = _get_parameter_values(settings, renderers, queue_parameters)
+
+    # If "HostRequirements" is provided, inject it into each of the "Step"
+    if host_requirements:
+        # for each step in the template, append the same host requirements.
+        for step in job_template["steps"]:
+            step["hostRequirements"] = host_requirements
+
+    save_job_bundle_files(job_bundle_path, job_template, parameter_values, asset_references)
+
+    # Save Sticky Settings
+    settings.input_filenames = sorted(attachments.input_filenames)
+    settings.input_directories = sorted(attachments.input_directories)
+
+    settings.save_sticky_settings(Scene.name())
+
+
+def setup_auto_detected_attachments(take_data_list: list[TakeData]) -> AssetReferences:
+    """
+    Set up automatically detected attachments from the scene and takes.
+    """
+    auto_detected_attachments = AssetReferences()
+    introspector = AssetIntrospector()
+
+    # Get scene assets
+    auto_detected_attachments.input_filenames = set(
+        os.path.normpath(path) for path in introspector.parse_scene_assets()
+    )
+
+    # Add output directories from takes
+    for take_data in take_data_list:
+        auto_detected_attachments.output_directories.update(take_data.output_directories)
+
+    return auto_detected_attachments
+
+
+def setup_attachments(render_settings: RenderSubmitterUISettings) -> AssetReferences:
+    """
+    Create AssetReferences from render settings.
+    """
+    return AssetReferences(
+        input_filenames=set(render_settings.input_filenames),
+        input_directories=set(render_settings.input_directories),
+        output_directories=set(render_settings.output_directories),
+    )
+
+
+def get_conda_packages() -> str:
+    """
+    Get the required conda packages string based on C4D version.
+    """
+    c4d_major_version = str(c4d.GetC4DVersion())[:4]
+    adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
+    return f"cinema4d={c4d_major_version}.* cinema4d-openjd={adaptor_version}.*"
+
+
+def _show_submitter(parent=None, f=Qt.WindowFlags()):
+    """
+    Creates and returns a submission dialog for rendering jobs.
+
+    This function initializes render settings, processes takes from the active document,
+    sets up attachments, and configures a submission dialog with necessary callbacks
+    and requirements for job submission.
+    """
+
+    render_settings = initialize_render_settings()
+
+    doc = c4d.documents.GetActiveDocument()
+
+    takes = get_takes_from_doc(doc)
+
+    auto_detected_attachments = setup_auto_detected_attachments(takes["take_data_list"])
+    attachments = setup_attachments(render_settings)
+
+    conda_packages = get_conda_packages()
 
     def on_create_job_bundle_callback(
         widget: SubmitJobToDeadlineDialog,
@@ -359,79 +517,18 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
         host_requirements: Optional[dict[str, Any]] = None,
         purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
     ) -> None:
-        submit_takes = main_data_list
-        job_bundle_path = Path(job_bundle_dir)
-        if settings.take_selection == TakeSelection.MAIN:
-            submit_takes = main_data_list
-        if settings.take_selection == TakeSelection.ALL:
-            submit_takes = take_data_list
-        if settings.take_selection == TakeSelection.MARKED:
-            submit_takes = marked_data_list
-        if settings.take_selection == TakeSelection.CURRENT:
-            submit_takes = current_data_list
-
-        # Add overrides to asset references
-        if settings.output_path:
-            asset_references.output_directories.add(os.path.dirname(settings.output_path))
-        if settings.multi_pass_path:
-            asset_references.output_directories.add(os.path.dirname(settings.multi_pass_path))
-
-        # # Check if there are multiple frame ranges across the takes
-        first_frame_range = submit_takes[0].frame_range
-        per_take_frames_parameters = not settings.override_frame_range and any(
-            take.frame_range != first_frame_range for take in submit_takes
+        """
+        Callback function for creating a job bundle when submitting the job.
+        """
+        create_job_bundle(
+            settings,
+            takes,
+            job_bundle_dir,
+            asset_references,
+            queue_parameters,
+            widget.job_attachments.attachments,
+            host_requirements,
         )
-
-        # If there are multiple frame ranges and we're not overriding the range,
-        # then we create per-take Frames parameters.
-        if per_take_frames_parameters:
-            for take_data in submit_takes:
-                take_data.frames_parameter_name = f"{take_data.display_name}Frames"
-
-        renderers: set[str] = {take_data.renderer_name for take_data in submit_takes}
-        job_template = _get_job_template(settings, renderers, submit_takes)
-        parameter_values = _get_parameter_values(settings, renderers, queue_parameters)
-
-        # If "HostRequirements" is provided, inject it into each of the "Step"
-        if host_requirements:
-            # for each step in the template, append the same host requirements.
-            for step in job_template["steps"]:
-                step["hostRequirements"] = host_requirements
-
-        with open(job_bundle_path / "template.yaml", "w", encoding="utf8") as f:
-            deadline_yaml_dump(job_template, f, indent=1)
-
-        with open(job_bundle_path / "parameter_values.yaml", "w", encoding="utf8") as f:
-            deadline_yaml_dump({"parameterValues": parameter_values}, f, indent=1)
-
-        with open(job_bundle_path / "asset_references.yaml", "w", encoding="utf8") as f:
-            deadline_yaml_dump(asset_references.to_dict(), f, indent=1)
-
-        # Save Sticky Settings
-        attachments: AssetReferences = widget.job_attachments.attachments
-        settings.input_filenames = sorted(attachments.input_filenames)
-        settings.input_directories = sorted(attachments.input_directories)
-        settings.input_filenames = sorted(attachments.input_filenames)
-
-        settings.save_sticky_settings(Scene.name())
-
-    auto_detected_attachments = AssetReferences()
-    introspector = AssetIntrospector()
-    auto_detected_attachments.input_filenames = set(
-        os.path.normpath(path) for path in introspector.parse_scene_assets()
-    )
-
-    for take_data in take_data_list:
-        auto_detected_attachments.output_directories.update(take_data.output_directories)
-    attachments = AssetReferences(
-        input_filenames=set(render_settings.input_filenames),
-        input_directories=set(render_settings.input_directories),
-        output_directories=set(render_settings.output_directories),
-    )
-
-    c4d_major_version = str(c4d.GetC4DVersion())[:4]
-    adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
-    conda_packages = f"cinema4d={c4d_major_version}.* cinema4d-openjd={adaptor_version}.*"
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are working on adding integration tests that can automate our release process. 

Unfortunately, our submitter was tightly coupled and hence made testing difficult. 

### What was the solution? (How)

This improves on our submitter code by refactoring it into smaller functions that can be relatively easily tested. 

For more information on how our tests would look, take a look here: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/compare/mainline...karthikbekalp:deadline-cloud-for-cinema-4d:integp1 

### What is the impact of this change?

Improves our code so that it can be tested more efficiently. This is a refactor so there is no customer changes. 

### How was this change tested?

I ran our Job bundle output tests. Additionally, I also compared the outputs of the physical render without my changes to ensure there are no changes between the `template.yaml`, `parameter_values.yaml` or the `asset_references.yaml`. 

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Yes. 

<img width="775" alt="Screenshot 2025-02-05 at 10 38 05 AM" src="https://github.com/user-attachments/assets/f4e5f4a5-fd9c-4375-a3d3-5edc7becb58d" />


### Was this change documented?
No, this is just a refactor. 

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*