### PR TITLE
chore: Loosen python-semantic-release version requirement.

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,1 @@
-python-semantic-release == 9.19.*
+python-semantic-release == 9.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
python-semantic-release has frequent minor updates that trigger noisy dependabot PRs.

Kudos to @crowecawcaw PR for similar changes to Keyshot. https://github.com/aws-deadline/deadline-cloud-for-keyshot/pull/178

### What was the solution? (How)
Loosen the version requirement.

### What is the impact of this change?
Fewer dependabot PRs while still using the latest version of python-semantic-release.

### How was this change tested?
Builds successfully

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
