### PR TITLE
fix: Add timeout for Cinema 4D jobs on EnvExit/Enter.

### DIFF
--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -86,6 +86,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
         onExit:
           command: cinema4d-openjd
           args:
@@ -95,6 +96,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -84,6 +84,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
         onExit:
           command: cinema4d-openjd
           args:
@@ -93,6 +94,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There are no timeouts on EnvExits/Enters which means if there are issues with shutting down of Cinema 4D, the worker would run for a long time. 

### What was the solution? (How)

Add `timeout` as mentioned in [Open JD spec](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md#5-action) to the adaptor yaml.

### What is the impact of this change?

### How was this change tested?

To confirm the adaptor worked as expected, I made changes to the adaptor and then submitted a job. 

Our recently added integration tests, seem to have helped here. It identified the change in the generated output bundle.

```
---
+++
@@ -84,6 +84,7 @@
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
         onExit:
           command: cinema4d-openjd
           args:
@@ -93,6 +94,7 @@
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData
```

And the submitter test failed. 

```
FAILED test/integ/test_cinema4d.py::test_submitter - AssertionError: assert 1 == 0
 +  where 1 = len(['template.yaml'])
```

### Was this change documented?
No

### Is this a breaking change?
No. It was supposed to already enforce a timeout of 10 minutes. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*