### PR TITLE
fix: Replace C4D tokens with values in paths.

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -412,10 +412,12 @@ def create_job_bundle(
     elif settings.take_selection == TakeSelection.CURRENT:
         submit_takes = takes["current_data_list"]
 
-    # Add overrides to asset references
+    # Add overrides to asset references and update the paths with C4D render path tokens.
     if settings.output_path:
+        settings.output_path = Scene.replace_render_path_tokens(settings.output_path)
         asset_references.output_directories.add(os.path.dirname(settings.output_path))
     if settings.multi_pass_path:
+        settings.multi_pass_path = Scene.replace_render_path_tokens(settings.multi_pass_path)
         asset_references.output_directories.add(os.path.dirname(settings.multi_pass_path))
 
     # # Check if there are multiple frame ranges across the takes

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -139,19 +139,13 @@ class Scene:
             take_data = doc.GetTakeData()
             take = take_data.GetCurrentTake()
         render_data = Scene.get_render_data(doc=doc, take=take)
-        rbc = render_data.GetDataInstance()
-        rpd = {
-            "_doc": doc,
-            "_rData": render_data,
-            "_rBc": rbc,
-            "_frame": doc.GetTime().GetFrame(doc.GetFps()),
-        }
-        if take:
-            rpd["_take"] = take
+
         image_paths = set()
         if render_data[c4d.RDATA_SAVEIMAGE]:
             path = render_data[c4d.RDATA_PATH]
-            xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
+            xpath = Scene.replace_render_path_tokens(
+                path, doc=doc, take=take, render_data=render_data
+            )
             if not os.path.isabs(xpath):
                 if xpath.startswith("./"):
                     xpath = xpath[2:]
@@ -159,7 +153,9 @@ class Scene:
             image_paths.add(os.path.dirname(os.path.normpath(xpath)))
         if render_data[c4d.RDATA_MULTIPASS_SAVEIMAGE]:
             path = render_data[c4d.RDATA_MULTIPASS_FILENAME]
-            xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
+            xpath = Scene.replace_render_path_tokens(
+                path, doc=doc, take=take, render_data=render_data
+            )
             if not os.path.isabs(xpath):
                 if xpath.startswith("./"):
                     xpath = xpath[2:]
@@ -182,6 +178,31 @@ class Scene:
         return render_data
 
     @staticmethod
+    def replace_render_path_tokens(path, doc=None, take=None, render_data=None):
+        """
+        Replaces tokens in a path with actual values from scene and render data
+        """
+        if doc is None:
+            doc = c4d.documents.GetActiveDocument()
+
+        if take is None:
+            take_data = doc.GetTakeData()
+            take = take_data.GetCurrentTake()
+
+        if render_data is None:
+            render_data = Scene.get_render_data(doc=doc, take=take)
+
+        render_path_data = {
+            "_doc": doc,
+            "_rData": render_data,
+            "_rBc": render_data.GetDataInstance(),
+            "_frame": doc.GetTime().GetFrame(doc.GetFps()),
+            "_take": take,
+        }
+
+        return c4d.modules.tokensystem.FilenameConvertTokens(path, render_path_data)
+
+    @staticmethod
     def get_output_paths(take=None) -> Tuple[str, str]:
         """
         Returns the default and multi-pass output paths.
@@ -189,20 +210,14 @@ class Scene:
         doc = c4d.documents.GetActiveDocument()
         doc_path = doc.GetDocumentPath()
         render_data = Scene.get_render_data(doc=doc, take=take)
-        render_base_container_instance = render_data.GetDataInstance()
-        rpd = {
-            "_doc": doc,
-            "_rData": render_data,
-            "_rBc": render_base_container_instance,
-            "_frame": doc.GetTime().GetFrame(doc.GetFps()),
-        }
-        if take:
-            rpd["_take"] = take
+
         default_out = ""
         multi_out = ""
         if render_data[c4d.RDATA_SAVEIMAGE]:
             path = render_data[c4d.RDATA_PATH]
-            xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
+            xpath = Scene.replace_render_path_tokens(
+                path, doc=doc, take=take, render_data=render_data
+            )
             if not os.path.isabs(xpath):
                 if xpath.startswith("./"):
                     xpath = xpath[2:]
@@ -210,7 +225,9 @@ class Scene:
             default_out = os.path.normpath(xpath)
         if render_data[c4d.RDATA_MULTIPASS_SAVEIMAGE]:
             path = render_data[c4d.RDATA_MULTIPASS_FILENAME]
-            xpath = c4d.modules.tokensystem.FilenameConvertTokens(path, rpd)
+            xpath = Scene.replace_render_path_tokens(
+                path, doc=doc, take=take, render_data=render_data
+            )
             if not os.path.isabs(xpath):
                 if xpath.startswith("./"):
                     xpath = xpath[2:]


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/176

### What was the problem/requirement? (What/Why)

Cinema 4D submitter did not replace the C4D tokens in the override output paths and the asset references before submitting. 

This was only observed in override output paths and not during regular submissions. 

This meant that if customers added c4d tokens like $prj within a path for example: C:/my/scene/location/$prj/my_scene then the substitution of the value of "prj" never takes place. 

### What was the solution? (How)

I investigated how the CInema 4D tokens worked and it looks like the paths were updated to resolve the tokens when receiving from Cinema 4D but the substitution does not occur when submitted using the Override output path. 

I also investigated if we can solve the issue for customers with old submitters as well but considering this would require non-trivial changes to job attachments, we will only be updating for submitters for now. 

### What is the impact of this change?

The override and the asset references are updated to refer to the path after cinema 4d token substitutions. 

### How was this change tested?

I tested it manually by submitting the jobs.

Here's the parameter values before my change:

```
parameterValues:
...
- name: OutputPath
  value: D:\Users\karthikbekalp\Desktop\BigFreakingScene\$prj_$res_$take\my_scene
- name: MultiPassPath
  value: D:\Users\karthikbekalp\Desktop\BigFreakingScene\$prj_$res_$take
...
```

Here's the parameter values after my change:

```
parameterValues:
...
- name: OutputPath
  value: D:\Users\karthikbekalp\Desktop\BigFreakingScene\test_1280x720_New_Take\my_scene
- name: MultiPassPath
  value: D:\Users\karthikbekalp\Desktop\BigFreakingScene\test_1280x720_New_Take
...
```


- Have you run the unit tests?

Yes

### Was this change documented?

No

### Is this a breaking change?


No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*