### PR TITLE
fix: Avoid current take from overriding other takes in submission

### DIFF
--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -185,10 +185,6 @@ class Scene:
         if doc is None:
             doc = c4d.documents.GetActiveDocument()
 
-        if take is None:
-            take_data = doc.GetTakeData()
-            take = take_data.GetCurrentTake()
-
         if render_data is None:
             render_data = Scene.get_render_data(doc=doc, take=take)
 
@@ -197,8 +193,9 @@ class Scene:
             "_rData": render_data,
             "_rBc": render_data.GetDataInstance(),
             "_frame": doc.GetTime().GetFrame(doc.GetFps()),
-            "_take": take,
         }
+        if take:
+            render_path_data["_take"] = take
 
         return c4d.modules.tokensystem.FilenameConvertTokens(path, render_path_data)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

While testing the takes feature, I noticed that multiple takes would be overridden to point to the current take. This is because there was a bug introduced in https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/183/files 

### What was the solution? (How)

Modify the code to how it was before, i.e. only replace the take if it was supplied. 

### What is the impact of this change?

Current take does not override all the other takes submitted. 

### How was this change tested?

I manually ran the tests and confirmed that it worked. 

#### Before

Earlier the paths would get overridden so even if 4 files are downloaded, the files would get overridden. 

![Screenshot 2025-03-11 at 2 02 47 PM](https://github.com/user-attachments/assets/42bd180b-05c9-4478-ba1c-a5cac14f811d)

#### After

Here's an example of submission with take in the folder name. 

![Screenshot 2025-03-11 at 1 43 59 PM](https://github.com/user-attachments/assets/dec7828b-a765-4311-997b-fef31bd3134f)

Here's an example of submission with take in the file name. 

![Screenshot 2025-03-11 at 1 46 09 PM](https://github.com/user-attachments/assets/600d6578-9a39-4c78-aa79-e01f7ffaad6d)

I'll be adding integration tests for this to ensure we don't hit this issue again. 

- Have you run the unit tests?
Yes

### Was this change documented?
No change, just a bug fix. 

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*