### PR TITLE
fix: Remove 'CRITICAL: Stop' from error regexes in adaptor. 

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -245,7 +245,6 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
             completed_regexes = [re.compile(".*Finished Rendering.*")]
             progress_regexes = [re.compile(".*Progress ([0-9]+)%.*")]
             error_regexes = [
-                re.compile(r".*CRITICAL: Stop.*", re.IGNORECASE),
                 re.compile(r".*Document not found.*", re.IGNORECASE),
                 re.compile(r".*Project not found.*", re.IGNORECASE),
                 re.compile(r".*Error rendering project.*", re.IGNORECASE),

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -28,8 +28,8 @@ class TestCinema4DAdaptor_on_cleanup:
     @pytest.mark.parametrize(
         "stdout,error_expected",
         [
-            # Only critical stop errors should fail the job
-            ("CRITICAL: Stop [ge_file.cpp(1172)]", True),
+            # Critical stops should not fail the job.
+            ("CRITICAL: Stop [ge_file.cpp(1172)]", False),
             # Any string with substring "Error:" should fail the job
             ("Redshift Error: Maxon licensing error: User not logged in (7)", True),
             # This error can be printed but the jobs are still successful.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We had some customers jobs which failed because they had "CRITICAL: Stop" in their logs. 

### What was the solution? (How)

We previously had [a bug report](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/51) about adding critical stop regex for our error regexes. The correct regex pattern we needed to check for was "Files cannot be written," which we have since added [in this PR](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/136/files).
Hence, removing this regex. 

Also cut a feature request ticket for [adding an option to deactivate automatic error checking in logs.](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/193)

### What is the impact of this change?

Jobs with Critical stops will not fail. 

### How was this change tested?

- Have you run the unit tests?
Updated the unit tests. 

### Was this change documented?
No

### Is this a breaking change?

Nope this was just a bug. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*