### PR TITLE
fix: Add better messaging when Redshift runs out of memory.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -240,10 +240,12 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         if not self._regex_callbacks:
             callback_list = []
 
-            _cinema4d_license_error = "RuntimeError: Error encountered when initializing Cinema4D"
-
             completed_regexes = [re.compile(".*Finished Rendering.*")]
+            callback_list.append(RegexCallback(completed_regexes, self._handle_complete))
+
             progress_regexes = [re.compile(".*Progress ([0-9]+)%.*")]
+            callback_list.append(RegexCallback(progress_regexes, self._handle_progress))
+
             error_regexes = [
                 re.compile(r".*Document not found.*", re.IGNORECASE),
                 re.compile(r".*Project not found.*", re.IGNORECASE),
@@ -266,15 +268,13 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                 re.compile(r".*Rendering was internally aborted.*", re.IGNORECASE),
                 re.compile(r'.*Cannot find procedure "rsPreference".*', re.IGNORECASE),
             ]
-
-            callback_list.append(RegexCallback(completed_regexes, self._handle_complete))
-            callback_list.append(RegexCallback(progress_regexes, self._handle_progress))
             callback_list.append(RegexCallback(error_regexes, self._handle_error))
 
+            insufficient_ram_regexes = re.compile(r".*Failed to allocate mem.*", re.IGNORECASE)
             callback_list.append(
                 RegexCallback(
-                    [re.compile(_cinema4d_license_error)],
-                    self._handle_license_error,
+                    [re.compile(insufficient_ram_regexes)],
+                    self._handle_insufficient_ram,
                 )
             )
 
@@ -323,16 +323,23 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         """
         self._exc_info = RuntimeError(f"Cinema4D Encountered an Error: {match.group(0)}")
 
-    def _handle_license_error(self, match: re.Match) -> None:
+    def _handle_insufficient_ram(self, match: re.Match) -> None:
         """
-        Callback for stdout that indicates an license error.
+        Handle insufficient RAM errors during Redshift rendering.
+
         Args:
-            match (re.Match): The match object from the regex pattern that was matched the message
+            match (re.Match): The match object containing the failed memory allocation size
 
         Raises:
-            RuntimeError: Always raises a runtime error to halt the adaptor.
+            RuntimeError: Raised when RAM allocation fails
         """
-        self._exc_info = RuntimeError(match.group(0))
+        message = (
+            "Redshift requires more RAM to render. "
+            "Please increase your worker's RAM to at least double of worker's "
+            f"GPU VRAM. Error: {match.group(0)}"
+        )
+
+        self._exc_info = RuntimeError(message)
 
     def _add_deadline_openjd_paths(self) -> None:
         # Add the openjd namespace directory to PYTHONPATH, so that adaptor_runtime_client

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -335,8 +335,9 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         """
         message = (
             "Redshift requires more RAM to render. "
-            "Please increase your worker's RAM to at least double of worker's "
-            f"GPU VRAM. Error: {match.group(0)}"
+            "Please increase the worker's RAM to at least double the worker's GPU VRAM. For more info: "
+            "https://help.maxon.net/c4d/s26/de-de/Content/_REDSHIFT_/html/Dealing+with+Out-Of-RAM+situations.html. "
+            f"Error: {match.group(0)}"
         )
 
         self._exc_info = RuntimeError(message)

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -103,9 +103,11 @@ class TestCinema4DAdaptor_on_cleanup:
 
         # THEN
         assert match is not None
-        assert (
-            str(adaptor._exc_info)
-            == f"Redshift requires more RAM to render. Please increase your worker's RAM to at least double of worker's GPU VRAM. Error: {stdout}"
+        assert str(adaptor._exc_info) == (
+            "Redshift requires more RAM to render. "
+            "Please increase the worker's RAM to at least double the worker's GPU VRAM. For more info: "
+            "https://help.maxon.net/c4d/s26/de-de/Content/_REDSHIFT_/html/Dealing+with+Out-Of-RAM+situations.html. "
+            f"Error: {stdout}"
         )
 
 

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -24,7 +24,6 @@ def init_data() -> dict:
 
 
 class TestCinema4DAdaptor_on_cleanup:
-
     @pytest.mark.parametrize(
         "stdout,error_expected",
         [
@@ -79,6 +78,35 @@ class TestCinema4DAdaptor_on_cleanup:
             assert str(adaptor._exc_info) == f"Cinema4D Encountered an Error: {stdout}"
         else:
             assert match is None
+
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            # Redshift errors should provide better message.
+            ("Failed to allocate mem( 1045504 bytes)"),
+        ],
+    )
+    def test_handle_insufficient_ram_on_stdout(self, init_data: dict, stdout: str) -> None:
+        """Tests that the _handle_insufficient_ram method throws a error runtime error correctly"""
+        # GIVEN
+        adaptor = Cinema4DAdaptor(init_data)
+        regex_callbacks = adaptor._get_regex_callbacks()
+        # Currently the callback for insufficient RAM is at index 3
+        regexes = regex_callbacks[3].regex_list
+
+        # WHEN
+        for regex in regexes:
+            match = regex.search(stdout)
+            if match:
+                adaptor._handle_insufficient_ram(match)
+                break
+
+        # THEN
+        assert match is not None
+        assert (
+            str(adaptor._exc_info)
+            == f"Redshift requires more RAM to render. Please increase your worker's RAM to at least double of worker's GPU VRAM. Error: {stdout}"
+        )
 
 
 def test_adaptor_rejects_malformed_init_data():


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/175

### What was the problem/requirement? (What/Why)

We needed to improve our messaging when Cinema 4D with Redshift hits errors with insufficient memory . 

### What was the solution? (How)

This adds a regex that detects when we hit an issue and provides a better message for customers indicating them to increase their RAM size on their worker. 

### What is the impact of this change?

Better customer experience.

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run integration tests?
Yes

Here's the output from the tests. 

```
test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 16%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 33%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 50%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 66%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 83%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
```

Also I tested this out in an SMF instance and the error was detected accurately. 
<img width="1607" alt="Screenshot 2025-04-06 at 12 00 43 PM" src="https://github.com/user-attachments/assets/68ddad16-48e6-42d8-a854-aed585ad12b9" />



### Was this change documented?

No documentation change. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*