### PR TITLE
chore: build_installer was referencing the wrong command

### DIFF
--- a/pipeline/build_installer.sh
+++ b/pipeline/build_installer.sh
@@ -4,4 +4,4 @@
 # Set the -e option
 set -e
 
-hatch run installer:build_installer "$@"
+hatch run installer:build-installer "$@"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

```
/bin/sh: build_installer: command not found
```

### What was the solution? (How)

It's defined as `build-installer`, I don't see any other references like that in the repo.

### What is the impact of this change?

the script runs

### How was this change tested?

Ran the script to build installers, and ran the tests:

```
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw1] [  7%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw1] [ 15%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw5] [ 23%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [ 30%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw4] [ 38%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::test_default_location 
[gw8] [ 46%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw3] [ 53%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw6] [ 76%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 84%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 92%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

========================================================= slowest 5 durations =========================================================
13.40s setup    test/installer/test_installer.py::TestUserInstall::test_install
13.34s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
12.47s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
3.69s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
3.03s call     test/installer/test_installer.py::test_default_location
==================================================== 4 passed, 9 skipped in 16.95s ====================================================
```

### Was this change documented?

N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*