### PR TITLE
chore(dev): fix dev installer scripts, and determine version based off tag

### DIFF
--- a/pipeline/build_installer.sh
+++ b/pipeline/build_installer.sh
@@ -4,4 +4,4 @@
 # Set the -e option
 set -e
 
-hatch run installer:build-installer "$@"
+hatch run installer:build-installer $@

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -5,11 +5,10 @@ import os
 import sys
 import shutil
 import tempfile
-from datetime import datetime
 from typing import Optional
 from pathlib import Path
 
-from common import EvaluationBuildError, run
+from common import EvaluationBuildError, run, get_version_string
 from find_installbuilder import InstallBuilderSelection, get_builder_exe_name
 
 from deps_bundle import build_deps_bundle
@@ -69,6 +68,7 @@ def build_installer(
     install_builder_location: Path,
     installer_platform: str,
     dev: bool,
+    override_installer_version: Optional[str],
 ) -> Path:
     """
     Actually build the installer
@@ -96,9 +96,11 @@ def build_installer(
 
     install_builder_cli = install_builder_location / "bin" / "builder"
     out_dir = workdir / "out"
-    installer_version = os.getenv("INSTALLER_VERSION") if not dev else "00000000"
-    if installer_version is None:
-        raise ValueError("INSTALLER_VERSION environment variable must be set.")
+    root = Path(__file__).resolve().parent.parent
+    if override_installer_version is not None:
+        installer_version = override_installer_version
+    else:
+        installer_version = get_version_string(cwd=root)
     output = run(
         [
             install_builder_cli,
@@ -107,7 +109,7 @@ def build_installer(
             installbuilder_platform,
             "--setvars",
             f"project.outputDirectory={out_dir}",
-            f"project.version={installer_version[:8]}-{datetime.today().date()}",
+            f"project.version={installer_version}",
         ]
     )
     sys.stdout.write(
@@ -137,6 +139,7 @@ def main(
     output_dir: Optional[Path],
     installer_platform: str,
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     with tempfile.TemporaryDirectory() as wd:
         workdir = Path(wd)
@@ -156,6 +159,7 @@ def main(
             install_builder_location=installbuilder_path,
             dev=dev,
             installer_platform=installer_platform,
+            override_installer_version=override_installer_version,
         )
 
         installer_filename = INSTALLER_FILENAMES[installer_platform]

--- a/scripts/build_installer_cli.py
+++ b/scripts/build_installer_cli.py
@@ -88,12 +88,15 @@ def _require_if_all_false_or_unspecified(
     """
 
     def _callback(ctx: click.Context, param: click.Option, value: Any) -> Any:
+        if value is not None:
+            return value
         for other in others:
             if ctx.params.get(other):
                 return value
         all_params = [f"--{_snake_to_kebab(other)}" for other in others]
+        name = _snake_to_kebab(param.name if param.name else "")
         raise click.BadParameter(
-            f"Must specify --{param.name} when none of {', '.join(all_params)} are specified"
+            f"Must specify --{name} when none of {', '.join(all_params)} are specified"
         )
 
     return _callback
@@ -187,6 +190,7 @@ def _not_allowed_if_env_var_set(
     type=Path,
     help="The path to the installer source xml file",
 )
+@click.option("--override-installer-version", type=str, help="Use this as the installer version.")
 def cli(
     install_builder_path: Optional[Path],
     install_builder_s3_bucket: Optional[str],
@@ -197,6 +201,7 @@ def cli(
     platform: str,
     output_dir: Optional[Path],
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     cli_body(
         install_builder_path,
@@ -208,6 +213,7 @@ def cli(
         platform,
         output_dir,
         installer_source_path,
+        override_installer_version,
     )
 
 
@@ -221,6 +227,7 @@ def cli_body(
     platform: str,
     output_dir: Optional[Path],
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     """
     Separate from the command function so we can mock the body out
@@ -235,6 +242,7 @@ def cli_body(
         output_dir,
         platform,
         installer_source_path,
+        override_installer_version,
     )
 
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -2,6 +2,9 @@
 import subprocess
 import sys
 
+from os import PathLike
+from typing import Union, Dict, Optional, List
+
 
 class BadExitCodeError(Exception):
     pass
@@ -15,23 +18,55 @@ class UnsupportedOSError(Exception):
     pass
 
 
-def run(cmd, cwd=None, env=None, echo=True):
+def run(
+    cmd: Union[PathLike, str, List[Union[str, PathLike]]],
+    cwd: Optional[Union[str, PathLike]] = None,
+    env: Optional[Dict[str, str]] = None,
+    echo: bool = True,
+) -> str:
     if echo:
         sys.stdout.write(f"Running cmd: {cmd}\n")
-    kwargs = {
-        "shell": True,
-        "stdout": subprocess.PIPE,
-        "stderr": subprocess.PIPE,
-    }
-    if isinstance(cmd, list):
-        kwargs["shell"] = False
-    if cwd is not None:
-        kwargs["cwd"] = cwd
-    if env is not None:
-        kwargs["env"] = env
-    p = subprocess.Popen(cmd, **kwargs)
+    shell = not isinstance(cmd, list)
+    p = subprocess.Popen(
+        cmd, shell=shell, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     stdout, stderr = p.communicate()
     output = stdout.decode("utf-8") + stderr.decode("utf-8")
+
     if p.returncode != 0:
-        raise BadExitCodeError(f"Bad rc ({p.returncode}) for cmd '{cmd}': {output}")
+        raise BadExitCodeError(
+            f"Process '{str(cmd)}' failed with exit code {p.returncode} and output: {output}"
+        )
+
     return output
+
+
+def get_latest_git_tag(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "describe", "--tags", "--abbrev=0"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_commit_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_git_tag_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    tag = get_latest_git_tag(cwd)
+    result = run(["git", "rev-list", "-n", "1", tag], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_commit_short_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "rev-parse", "--short", "HEAD"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_version_string(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    latest_tag = get_latest_git_tag(cwd)
+    latest_commit_hash = get_latest_commit_hash(cwd)
+    latest_tag_hash = get_latest_git_tag_hash(cwd)
+    if latest_commit_hash == latest_tag_hash:
+        return latest_tag
+    latest_commit_hash_short = get_latest_commit_short_hash()
+    return f"{latest_tag}.{latest_commit_hash_short}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Builds were failing:

```
Usage: build_installer_cli.py [OPTIONS]
Try 'build_installer_cli.py --help' for help.
Error: Invalid value for '--install-builder-license-path': Must specify --install_builder_license_path when none of --dev, --local-dev are specified
```
Was missing the change to return when we have the value (and to pretty up the error message from snake to kebab)

### What was the solution? (How)

pull the changes from Blender, also included the new generation of the installed version file to be the tag rather than the date. I also removed the quotes around the variable expansion, since that's what Blender has and that works. But I don't believe that's necessary

### What is the impact of this change?

### How was this change tested?

built locally, and ran the installer locally. Confirmed version is the tag plus hash of additional commits.

### Was this change documented?
N/A
### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*