### PR TITLE
chore: Rename typo from BuildInstallers to BuildInstaller.

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -28,9 +28,9 @@ on:
         - mainline
 
 jobs:
-  BuildInstallers:
+  BuildInstaller:
     if: (github.repository == 'aws-deadline/deadline-cloud-for-cinema-4d')
-    name: Build Installers
+    name: Build Installer
     uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
     secrets: inherit
     with:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was a typo of "BuildInstallers" instead of "BuildInstaller" in the job name 

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

Compared with the yml file in Blender and made similar changes. https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/.github/workflows/build_installers.yml

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*