### PR TITLE
test: Fix typo in test_installer.

### DIFF
--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -32,7 +32,7 @@ def _is_admin() -> bool:
 
 @pytest.fixture(scope="session")
 def installer_path():
-    path = "DeadlineCloudForCinema4dSubmitter-{platform}-installer.{ext}"
+    path = "DeadlineCloudForCinema4DSubmitter-{platform}-installer.{ext}"
 
     if platform.system() == "Darwin":
         path = os.path.join(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Fix typo in the test installer. The installers are named `DeadlineCloudForCinema4DSubmitter` with capital 'D'.  As both Windows and MacOS are case insensitive systems the tests still passed. 

### What was the solution? (How)

Updated the test to reduce confusions. 

### What is the impact of this change?

No impact. Only reduces confusion. 

### How was this change tested?

Ran `hatch run test-installer` to verify everything worked. 

```

test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::TestWindows::test_user_permissions
test/installer/test_installer.py::TestUserInstall::test_install 
[gw1] [  7%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw1] [ 15%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw1] [ 23%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw1] [ 30%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing
[gw1] [ 38%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing
[gw1] [ 46%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
[gw3] [ 76%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestUserInstall::test_uninstall
[gw2] [ 84%] PASSED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions
[gw2] [ 92%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions
[gw3] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

================================================================================================================================================================================================== warnings summary ================================================================================================================================================================================================== 
test\installer\test_installer.py:466
  D:\Users\pattatk\GithubRepos\deadline-cloud-for-cinema-4d\test\installer\test_installer.py:466: SyntaxWarning: invalid escape sequence '\*'
    """Assumes that the Windows SDK is installed so we can find signtool:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================================================================================================ slowest 5 durations ================================================================================================================================================================================================= 
67.52s setup    test/installer/test_installer.py::TestWindows::test_user_permissions
67.52s setup    test/installer/test_installer.py::TestUserInstall::test_install
54.33s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
19.75s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
9.45s call     test/installer/test_installer.py::test_default_location
================================================================================================================================================================================ 4 passed, 9 skipped, 1 warning in 144.20s (0:02:24) =================================================================================================================================================================================
```

### Was this change documented?

No

### Is this a breaking change?

No

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*