### PR TITLE
fix: Allow Cinema 4D to be rendered on all available machines instead of just windows.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,9 @@ See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4
 - Have you run the integration tests? (Add your integration test report below)
 *delete text ending here* 
 
-- Have you made changes to the submitter? (If yes, please include the results of both the automated tests and any manual tests that you ran)
+- Have you made changes to the submitter?
+If yes, please include the results of both the automated tests and any manual tests that you ran.
+Also, check if there is a change to the `integ_test_helpers.py` file within cinema4d_submitter as a result of your submitter change.
 *delete text ending here* 
 
 ### Was this change documented?

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -46,11 +46,6 @@ parameterDefinitions:
   description: Multi-pass image output
 steps:
 - name: Render
-  hostRequirements:
-    attributes:
-    - name: attr.worker.os.family
-      anyOf:
-      - windows
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -13,7 +13,6 @@ from qtpy.QtCore import Qt  # type: ignore[attr-defined]
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.submission import AssetReferences
-from deadline.client.ui.dataclasses import HostRequirements, OsRequirements
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
     JobBundlePurpose,
     SubmitJobToDeadlineDialog,
@@ -547,9 +546,6 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
         parent=parent,
         f=f,
         show_host_requirements_tab=True,
-        host_requirements=HostRequirements(
-            os_requirements=OsRequirements(operating_systems=[OsRequirements.WINDOWS])
-        ),
     )
 
     return submitter_dialog

--- a/src/deadline/cinema4d_submitter/integ_test_helpers.py
+++ b/src/deadline/cinema4d_submitter/integ_test_helpers.py
@@ -68,17 +68,6 @@ def sample_queue_params() -> list:
     ]
 
 
-def sample_host_requirements() -> dict:
-    """
-    This is an example of host_requirements for a submission.
-    """
-    return {
-        "attributes": [
-            {"name": "attr.worker.os.family", "anyOf": ["windows"]},
-        ]
-    }
-
-
 def internal_create_job_bundle(job_bundle_dir: str):
     """
     This function mimics the call that Cinema 4D submitter does to generate the job bundle.
@@ -101,5 +90,4 @@ def internal_create_job_bundle(job_bundle_dir: str):
         asset_references=auto_detected_attachments,
         queue_parameters=sample_queue_params(),
         attachments=attachments,
-        host_requirements=sample_host_requirements(),
     )

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -45,11 +45,6 @@ parameterDefinitions:
   description: Multi-pass image output
 steps:
 - name: Main
-  hostRequirements:
-    attributes:
-    - name: attr.worker.os.family
-      anyOf:
-      - windows
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -45,11 +45,6 @@ parameterDefinitions:
   description: Multi-pass image output
 steps:
 - name: Main
-  hostRequirements:
-    attributes:
-    - name: attr.worker.os.family
-      anyOf:
-      - windows
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -45,11 +45,6 @@ parameterDefinitions:
   description: Multi-pass image output
 steps:
 - name: Main
-  hostRequirements:
-    attributes:
-    - name: attr.worker.os.family
-      anyOf:
-      - windows
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -45,11 +45,6 @@ parameterDefinitions:
   description: Multi-pass image output
 steps:
 - name: Main
-  hostRequirements:
-    attributes:
-    - name: attr.worker.os.family
-      anyOf:
-      - windows
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -45,11 +45,6 @@ parameterDefinitions:
   description: Multi-pass image output
 steps:
 - name: Main
-  hostRequirements:
-    attributes:
-    - name: attr.worker.os.family
-      anyOf:
-      - windows
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -45,11 +45,6 @@ parameterDefinitions:
   description: Multi-pass image output
 steps:
 - name: Main
-  hostRequirements:
-    attributes:
-    - name: attr.worker.os.family
-      anyOf:
-      - windows
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We have had some customers that have been using Linux workers and the default of "Windows" makes it hard for artists to render using Linux. 

### What was the solution? (How)

We removed the setting that defaults customers to use Windows in this PR. 

### What is the impact of this change?

Customers that use Linux don't have to change host requirements every time they submit their renders. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes

I also had to update the tests because the submitter had changes. 

- Have you made changes to the submitter? (If yes, please include the results of both the automated tests and any manual tests that you ran)
Yes. 

I tried running the submitter on Cinema 4D directly and that works. 

![image](https://github.com/user-attachments/assets/114b3db5-82ec-41aa-a5d4-0932b91d1eaa)

```

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 16%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 33%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 50%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 66%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 83%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 

============================================================================================================================================================================================================= slowest 5 durations ============================================================================================================================================================================================================= 
108.44s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
88.01s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
86.45s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
83.88s call     test/integ/test_cinema4d.py::test_integ[redshift]
58.55s call     test/integ/test_cinema4d.py::test_integ[physical]
======================================================================================================================================================================================================== 6 passed in 484.25s (0:08:04) ========================================================================================================================================================================================================
```

### Was this change documented?
Yes

### Is this a breaking change?
I don't think this is a breaking change because older adaptors will still work with these submitter changes. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*