### PR TITLE
fix: Partial fix for failures with RS RenderView when opening Cinema 4D submitter

### DIFF
--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -23,18 +23,9 @@ if sys.platform in ["win32", "cygwin"]:
     # Required due to a longstanding bug in C4D to not include the python dll library path required by many compiled libs
     #   Read more here: https://github.com/danbradham/wheels/issues/4#issuecomment-1772721170
     os.add_dll_directory(dll_path)
-elif sys.platform == "darwin": # If MacOS
-    # This path will be replaced when the installer is running
-    sys.path.append("C4D_Submitter_Installation_Dir_To_Replace")
 
 root = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(root, 'modules'))
-
-if 'deadline.cinema4d_submitter' not in sys.modules.keys():
-    import deadline.cinema4d_submitter
-else:
-    import importlib
-    importlib.reload(deadline.cinema4d_submitter)
 
 import c4d
 
@@ -44,8 +35,24 @@ PLUGIN_ID = 1064358
 
 class DeadlineCloudRenderCommand(c4d.plugins.CommandData):
 
-    def Execute(self, doc):
+    def _import_and_show_submitter(self):
+        import deadline.cinema4d_submitter
         deadline.cinema4d_submitter.show_submitter()
+    
+    def _execute_for_mac(self):
+        # This variable will be replaced to a path when the installer is running
+        C4D_MAC_INSTALLATION_PATH = "C4D_Submitter_Installation_Dir_To_Replace"
+        sys.path.append(C4D_MAC_INSTALLATION_PATH)
+        try:
+            self._import_and_show_submitter()
+        finally:
+            sys.path.remove(C4D_MAC_INSTALLATION_PATH)
+
+    def Execute(self, doc):
+        if sys.platform == "darwin":
+            self._execute_for_mac()
+        else:
+            self._import_and_show_submitter()
         return True
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The AWS Deadline Cloud submitter for Cinema 4D caused crashes while opening RS RenderView. 

<img width="1682" alt="Screenshot 2025-04-23 at 4 15 40 PM" src="https://github.com/user-attachments/assets/04a622e3-5fb1-4b1f-8649-4c4d73c5894a" />

<img width="856" alt="Screenshot 2025-04-23 at 4 14 41 PM" src="https://github.com/user-attachments/assets/e927f486-d0cc-4801-b5a2-844b727983e0" />


### What was the solution? (How)

We believe the issue was that Redshift's RenderView was using the submitter Qt modules which caused failures. 

This issue only happens if the PyQt modules are loaded at the beginning. Hence, this solution moves the loading of the modules to after the user clicks the submitter. 

Huge kudos to @ryyakobe  and @epmog  for helping out here! 

This is a partial fix because if the submitter is called before the RS render view this would still be an issue. We are currently in contact with Maxon support for the cleaner solution to this problem.

### What is the impact of this change?

Redshift's RenderView will start working with our submitter installed. 

### How was this change tested?
Tested this on mac and confirmed that it works! 

Also tested it on Windows and confirmed it does not cause any side effects. 

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes. 

- Have you made changes to the submitter?
Yes, but this is in the plugin which does not change our tests. 

### Was this change documented?
No. 

### Is this a breaking change?

No. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*