### PR TITLE
docs: Update README.md so that customers use the latest Mac submitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ It automatically determines the files required based on the loaded scene, allows
 The submitter includes your settings, such as Redshift plugin settings and multi-pass paths, in the submission to Deadline Cloud.
 
 There are two installation options:
-1. Windows-only: the [official Deadline Cloud submitter installer][deadline-cloud-submitter]
-2. Windows or Mac: manual installation
+1. The [official Deadline Cloud submitter installer][deadline-cloud-submitter] (Recommended)
+2. Manual installation
 
 After installing, you can access the submitter in the Cinema 4D interface via `Extensions` > `AWS Deadline Cloud Submitter`.
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We released the Mac installers for Cinema 4D recently and now it is part of the current integrated submitter that is released in Deadline Cloud. This meant the docs were outdated. 

### What was the solution? (How)

Update the docs so that customers can know that they can use the Mac installers. 

### What is the impact of this change?

Customers can use the installer instead of manually creating the `.command` files. 

### How was this change tested?

Just a doc change. Hence, nothing was tested. 

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*