### PR TITLE
fix: add support for Redshift path mapping

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -241,7 +241,7 @@ For redshift licensing, set the environment variable by using `$env:redshift_LIC
    1. `set C4D_PYTHON=<Cinema 4D location>` on Windows Command or `$env:C4D_PYTHON = <Cinema 4D location>` on Windows Powershell.
       1. The default location for `Cinema 4D` on Windows is `C:\Program Files\Maxon Cinema 4D 2025\`. This location would be automatically used if the directory exists.
 2. For running the adaptor tests, we would need to install `pywin32` to the installation paths as its an adaptor dependency.
-   2.1 Run `pip install pywin32==308 -t <your Python site-packages location>`. 
+   2.1 Run `pip install pywin32==308 -t %C4D_PYTHON%\resource\modules\python\libs\win64\lib\site-packages`.
    During my testing, pywin32's version 308 was required because of other dependencies requiring this version.
 3. Run `hatch run integ:test`
 

--- a/depsBundle.sh
+++ b/depsBundle.sh
@@ -8,4 +8,4 @@
 
 set -xeuo pipefail
 
-python3 scripts/depsBundle.py
+python3 scripts/deps_bundle.py

--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -12,7 +12,7 @@ ADAPTOR_NAME=deadline-cloud-for-$APP_WITH_HYPEN
 
 SCRIPTDIR=$(realpath $(dirname $0))
 
-SOURCE=0
+SOURCE=1
 # Python 3.11 is for https://vfxplatform.com/ CY2024
 PYTHON_VERSION=3.11
 CONDA_PLATFORM=win-64

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -35,7 +35,7 @@ class Cinema4DClient(ClientInterface):
 
     def __init__(self, server_path: str) -> None:
         super().__init__(server_path=server_path)
-        self.actions.update(Cinema4DHandler(lambda path: self.map_path(path)).action_dict)
+        self.actions.update(Cinema4DHandler(self.map_path, self.path_mapping_rules).action_dict)
 
     def close(self, args: Optional[dict] = None) -> None:
         sys.exit(0)

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -2,7 +2,14 @@
 from __future__ import annotations
 
 import os
+import re
+import traceback
+from pathlib import Path
 from typing import Any, Callable, Dict
+
+from openjd.adaptor_runtime.adaptors import PathMappingRule
+from openjd.adaptor_runtime._utils import secure_open
+
 
 try:
     import c4d  # type: ignore
@@ -34,7 +41,11 @@ class Cinema4DHandler:
     render_kwargs: Dict[str, Any]
     map_path: Callable[[str], str]
 
-    def __init__(self, map_path: Callable[[str], str]) -> None:
+    def __init__(
+        self,
+        map_path: Callable[[str], str],
+        path_mapping_rules: Callable[[], list[PathMappingRule]],
+    ) -> None:
         """
         Constructor for the c4dpy handler. Initializes action_dict and render variables
         """
@@ -49,22 +60,89 @@ class Cinema4DHandler:
         self.render_kwargs = {}
         self.take = "Main"
         self.map_path = map_path
+        self.path_mapping_rules = path_mapping_rules
 
     def _remap_assets(self) -> None:
         """
         Asset references in the .c4d files are not automatically re-mapped if they are
         absolute paths. This function remaps the asset references to the new paths.
         """
+        self._set_c4d_native_asset_pathmap()
+        self._set_redshift_pathmap()
+
+    def _set_c4d_native_asset_pathmap(self) -> None:
         asset_list: list[Dict[str, Any]] = []
         c4d.documents.GetAllAssetsNew(
             self.doc, allowDialogs=False, lastPath="", assetList=asset_list
         )
         for asset in asset_list:
-            asset_owner = asset.get("owner")
-            asset_param_id = asset.get("paramId")
-            asset_filename = asset.get("filename")
-            if asset_owner and asset_param_id and asset_filename:
-                asset_owner[asset_param_id] = self.map_path(asset_filename)
+            owner = asset.get("owner")
+            param_id = asset.get("paramId")
+            filename = asset.get("filename")
+            node_space = asset.get("nodeSpace")
+            node_path = asset.get("nodePath")
+            if owner and param_id and filename:
+                if param_id != -1:
+                    try:
+                        # C4D classic assets have a param ID other than -1
+                        owner[param_id] = self.map_path(filename)
+                    except Exception as e:
+                        print(
+                            f"WARNING: asset with asset owner '{owner}', paramId {param_id}, filename "
+                            f"'{filename}', nodeSpace '{node_space}', and nodePath '{node_path}' could not be path "
+                            f"mapped. Error: {e} {traceback.format_exc()}"
+                        )
+
+    # Redshift path mapping
+    def _set_redshift_pathmap(self) -> None:
+        rules = self.path_mapping_rules()
+        if not rules:
+            print("No path mapping rules found")
+            return
+
+        print(f"Path mapping rules: {rules}")
+
+        redshift_rules: list[tuple[str, str]] = [
+            (rule.source_path.replace("\\", "/"), rule.destination_path.replace("\\", "/"))
+            for rule in rules
+        ]
+
+        # "C:/Users/AUser/Directory" "/sessions/session-abcd/"
+        redshift_rule_regex = re.compile(r"\"([^\"]*)\"\s+\"([^\"]*)\"")
+
+        # Collect any additional rules if REDSHIFT_PATHOVERRIDE_FILE is already set
+        if existing_rule_file_path := os.getenv("REDSHIFT_PATHOVERRIDE_FILE"):
+            print(
+                f"Found existing REDSHIFT_PATHOVERRIDE_FILE environment variable: {existing_rule_file_path}"
+            )
+            try:
+                with secure_open(
+                    existing_rule_file_path, "r", encoding="utf-8"
+                ) as existing_rule_file:
+                    redshift_rules.extend(redshift_rule_regex.findall(existing_rule_file.read()))
+            except FileNotFoundError:
+                print(
+                    f"The file pointed to by the REDSHIFT_PATHOVERRIDE_FILE environment variable does not exist at: {existing_rule_file_path}"
+                )
+
+        # Collect any additional rules if REDSHIFT_PATHOVERRIDE_STRING is already set
+        if existing_rule_str := os.getenv("REDSHIFT_PATHOVERRIDE_STRING"):
+            print(f"Found existing REDSHIFT_PATHOVERRIDE_STRING: {existing_rule_str}")
+            redshift_rules.extend(redshift_rule_regex.findall(existing_rule_str))
+
+        # Redshift expects double quoted space delimited "source" "destination" pairs
+        # example: "C:/Users/AUser/Directory" "/sessions/session-abcd/"
+        # https://help.maxon.net/r3d/maya/en-us/Content/html/Redshift+Environment+Variables.html
+        formatted_rules = "\n".join([f'"{rule[0]}" "{rule[1]}"' for rule in redshift_rules])
+        # Write all rules to a new temp override file and point to it
+        new_pathmap_file_path = Path(os.getcwd(), "new_redshift_pathmap_override.txt")
+        print(f"Writing path mapping rules: {formatted_rules}")
+        with secure_open(
+            new_pathmap_file_path, open_mode="w", encoding="utf-8"
+        ) as new_pathmap_file:
+            new_pathmap_file.write(formatted_rules)
+        print(f"Setting REDSHIFT_PATHOVERRIDE_FILE to: {str(new_pathmap_file_path)}")
+        os.environ["REDSHIFT_PATHOVERRIDE_FILE"] = str(new_pathmap_file_path)
 
     def start_render(self, data: dict) -> None:
         self.doc = c4d.documents.GetActiveDocument()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/206

### What was the problem/requirement? (What/Why)
The Cinema 4D integration was failing (either erroring out or silently not path mapping) when Redshift assets were used with Globalized file paths.

### What was the solution? (How)
Per [this forum post](https://developers.maxon.net/forum/topic/14388/change-textures-path-from-getallassetnew-in-the-new-node-editor), the current `owner[param_id] = mapped_path` command is meaningless for Redshift assets.

Instead, to map Redshift assets, we can use the Redshift Environment Variables to set the path mapping: https://help.maxon.net/c4d/de-de/Subsystems/Default/Content/html/Redshift+Environment+Variables.html

### What is the impact of this change?
Redshift assets can now use globalized file names without breaking the render.

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes

- Have you made changes to the submitter?
No

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*