### PR TITLE
fix: Open RS renderview during Cinema 4D startup

### DIFF
--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -33,6 +33,12 @@ import c4d
 # Plugin ID generator for DeadlineCloudSubmitter.
 PLUGIN_ID = 1064358
 
+if sys.platform == "darwin":
+    # This command opens the RS renderview panel at
+    # Cinema 4D startup until Maxon fixes the issue 
+    # of Cinema 4D crashing due to PyQt errors on their end.
+    c4d.CallCommand(1038666)
+
 class DeadlineCloudRenderCommand(c4d.plugins.CommandData):
 
     def _import_and_show_submitter(self):


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/208

### What was the problem/requirement? (What/Why)

Cinema 4D could crash if our plugin is opened before the RS render view panel. 

### What was the solution? (How)

This forces our plugin to open and quickly close the RS Render view panel when Cinema 4D starts to ensure that there are no crashes.

Kudos to @epmog  for sharing this idea. Turns out during startup if its called, the RS render view panel would open and close before we can notice and has no noticeable impact. 

### What is the impact of this change?

No Cinema 4D crashes. 

### How was this change tested?
Yes. 

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Has no impact on integration tests. 

- Have you made changes to the submitter?
No

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*