### PR TITLE
fix: Add exception handling while opening RS render view.

### DIFF
--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -34,10 +34,13 @@ import c4d
 PLUGIN_ID = 1064358
 
 if sys.platform == "darwin":
-    # This command opens the RS renderview panel at
-    # Cinema 4D startup until Maxon fixes the issue 
-    # of Cinema 4D crashing due to PyQt errors on their end.
-    c4d.CallCommand(1038666)
+    try:
+        # This command opens the RS renderview panel at
+        # Cinema 4D startup until Maxon fixes the issue 
+        # of Cinema 4D crashing due to PyQt errors on their end.
+        c4d.CallCommand(1038666)
+    except Exception as e:
+        print(f"Failed to open RS renderview panel: {e}")
 
 class DeadlineCloudRenderCommand(c4d.plugins.CommandData):
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Discussed offline with @epmog  and @joel-wong-aws  and there is a possibility that in case of an unknown failure from `c4d.CallCommand(1038666)` could cause issues. 

### What was the solution? (How)

Bundled the `CallCommand` into a simple try - except block to ensure any failures don't crash our plugin. 

### What is the impact of this change?

More robust exception handling. 

### How was this change tested?

Manually tested this on Cinema 4D 2024 and 2025 and confirmed that there are no issues. 

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
No, but this does not change anything. 

- Have you made changes to the submitter?
No

### Was this change documented?
No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*