### PR TITLE
fix: Replace backslashes to frontslashes for Mac to Win submissions.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -87,25 +87,39 @@ class Cinema4DClient(ClientInterface):
 
             # If submission was not from Mac (i.e. not posix source format), just do normal path mapping
             if not has_posix_format:
-                return super().map_path(path)
+                mapped_path = super().map_path(path)
+                print(f"Using normal path mapping (non-POSIX): '{path}' -> '{mapped_path}'")
+                return mapped_path
 
-            print("Source path format is POSIX and rendering on Windows")
-            print(f"Path before conversion: {path}")
+            print(
+                "Found POSIX format rule, converting path separators for Mac to Windows compatibility"
+            )
+            print(f"Original path: '{path}'")
 
             # Convert backslashes to forward slashes for consistency with POSIX paths.
             # This is safe because:
             # 1. When submitting from Mac, backslashes can only appear as path separators
             # 2. Windows accepts both '\' and '/' as valid path separators
             converted_path = path.replace("\\", "/")
-            print(f"Path after replacing backslashes: {converted_path}")
+            print(f"Converted path: '{converted_path}'")
 
-            # Then get the mapped path using parent implementation
-            return super().map_path(converted_path)
+            # Try path mapping with converted path
+            mapped_path = super().map_path(converted_path)
+
+            # If mapped path is the same as converted path, mapping failed
+            # so try with original path instead
+            if mapped_path == converted_path:
+                print("Path mapping with converted path failed (no rules matched)")
+                mapped_path = super().map_path(path)
+                print(f"Using original path mapping: '{path}' -> '{mapped_path}'")
+                return mapped_path
+
+            print(f"Successfully mapped converted path: '{converted_path}' -> '{mapped_path}'")
+            return mapped_path
 
         except Exception as e:
             print(f"Error during path mapping: {str(e)}")
-            # If anything goes wrong during our path conversion,
-            # fall back to parent implementation with original path
+            # If anything goes wrong, fall back to parent implementation with original path
             return super().map_path(path)
 
 

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -43,6 +43,71 @@ class Cinema4DClient(ClientInterface):
     def graceful_shutdown(self, signum: int, frame: FrameType | None):
         sys.exit(0)
 
+    def map_path(self, path: str) -> str:
+        """
+        Maps a path using the path mapping rules from the server.
+
+        When submitting jobs from Mac, Cinema 4D's c4d.GetAllAssetsNew() API can sometimes return paths
+        with backslashes ('\') instead of forward slashes ('/'). For example, it might return
+        '\path\to\file\my_attachments' instead of the expected '/path/to/file/my_attachments'.
+
+        To handle this, when running on Windows with posix source path format, we convert any backslashes
+        to forward slashes before applying path mapping rules. This is safe because Windows accepts both
+        '\' and '/' as valid path separators.
+
+        Args:
+            path (str): The path to be mapped
+
+        Returns:
+            str: The mapped path
+
+        Raises:
+            RuntimeError: If path mapping rules cannot be retrieved
+            ValueError: If path is empty or None
+        """
+        if not path:
+            raise ValueError("Path cannot be empty or None")
+
+        # If not running on Windows, just do normal path mapping
+        if not sys.platform.startswith("win"):
+            return super().map_path(path)
+
+        try:
+            # Get path mapping rules
+            rules = self.path_mapping_rules()
+            if not rules:
+                print("Warning: No path mapping rules found")
+                return super().map_path(path)
+
+            # Check if any rule has posix format
+            has_posix_format = any(
+                rule.source_path_format and rule.source_path_format.lower() == "posix"
+                for rule in rules
+            )
+
+            # If submission was not from Mac (i.e. not posix source format), just do normal path mapping
+            if not has_posix_format:
+                return super().map_path(path)
+
+            print("Source path format is POSIX and rendering on Windows")
+            print(f"Path before conversion: {path}")
+
+            # Convert backslashes to forward slashes for consistency with POSIX paths.
+            # This is safe because:
+            # 1. When submitting from Mac, backslashes can only appear as path separators
+            # 2. Windows accepts both '\' and '/' as valid path separators
+            converted_path = path.replace("\\", "/")
+            print(f"Path after replacing backslashes: {converted_path}")
+
+            # Then get the mapped path using parent implementation
+            return super().map_path(converted_path)
+
+        except Exception as e:
+            print(f"Error during path mapping: {str(e)}")
+            # If anything goes wrong during our path conversion,
+            # fall back to parent implementation with original path
+            return super().map_path(path)
+
 
 def main():
     server_path = os.environ.get("CINEMA4D_ADAPTOR_SERVER_PATH")


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/216

### What was the problem/requirement? (What/Why)

When submitting Cinema 4D jobs from Mac to Windows render nodes, path mapping fails because Cinema 4D's `c4d.GetAllAssetsNew()` API incorrectly returns paths with backslashes instead of forward slashes. For example, it returns `\path\to\file\my_attachments` instead of `/path/to/file/my_attachments`. This causes issues when these paths need to be mapped on Windows workers. 

### What was the solution? (How)

Modified the `map_path` method in `Cinema4DClient` to:
1. Check if we're running on Windows and have POSIX source path format (source path format is POSIX if submitted from Mac)
2. Convert backslashes to forward slashes before applying path mapping rules. 

### What is the impact of this change?

Customers that are submitting from Mac don't have issues with path mapping. 

### How was this change tested?

- Have you run the unit tests?
Yes and confirmed that it was successful. 

- Have you run the integration tests? 
Yes. 

```
test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 16%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 33%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 50%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 66%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 83%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
```

- Also built conda packages with latest changes and confirmed that it path maps as expected. (Running the tests as we speak)

```
2025/05/23 15:14:22-05:00 ADAPTOR_OUTPUT: STDOUT: Found POSIX format rule, converting path separators for Mac to Windows compatibility
2025/05/23 15:14:22-05:00 ADAPTOR_OUTPUT: STDOUT: Original path: 'C:\Sessions\session-003\assetroot-823\Downloads\example_with_light\example.jpg'
2025/05/23 15:14:22-05:00 ADAPTOR_OUTPUT: STDOUT: Converted path: 'C:/Sessions/session-003/assetroot-823/Downloads/example_with_light/example.jpg'
2025/05/23 15:14:22-05:00 ADAPTOR_OUTPUT: STDOUT: Path mapping with converted path failed (no rules matched)
2025/05/23 15:14:22-05:00 ADAPTOR_OUTPUT: STDOUT: Using original path mapping: 'C:\Sessions\session-003\assetroot-823\Downloads\example_with_light\example.jpg' -> 'C:\Sessions\session-003\assetroot-823\Downloads\example_with_light\example.jpg'

...
2025/05/23 15:17:52-05:00 ADAPTOR_OUTPUT: STDOUT: Original path: '\Users\my_user_id\Desktop\checkerboard\large_checkerboard2.bmp'
2025/05/23 15:17:52-05:00 ADAPTOR_OUTPUT: STDOUT: Converted path: '/Users/my_user_id/Desktop/checkerboard/large_checkerboard2.bmp'
2025/05/23 15:17:52-05:00 ADAPTOR_OUTPUT: STDOUT: Requesting Path Mapping for path '/Users/my_user_id/Desktop/checkerboard/large_checkerboard2.bmp'.
2025/05/23 15:17:52-05:00 ADAPTOR_OUTPUT: STDOUT: Mapped path '/Users/my_user_id/Desktop/checkerboard/large_checkerboard2.bmp' to 'C:\Sessions\session-da55\assetroot-8237\Desktop\checkerboard\large_checkerboard2.bmp'.
2025/05/23 15:17:52-05:00 ADAPTOR_OUTPUT: STDOUT: Successfully mapped converted path: '/Users/my_user_id/Desktop/checkerboard/large_checkerboard2.bmp' -> 'C:\Sessions\session-da55\assetroot-8237\Desktop\checkerboard\large_checkerboard2.bmp'

```

- Have you made changes to the submitter?
No

### Was this change documented?

Yes updated all the docstrings for the python functions modified. 

### Is this a breaking change?

No. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*