### PR TITLE
fix: sdist failed to install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ destinations = [
 [tool.hatch.build.targets.sdist]
 include = [
     "src/*",
-    "hatch_version_hook.py",
+    "hatch_custom_hook.py",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -202,7 +202,7 @@ class Cinema4DHandler:
         self.doc = c4d.documents.GetActiveDocument()
         self.render_data = self.doc.GetActiveRenderData()
         self.render_data[c4d.RDATA_FRAMESEQUENCE] = c4d.RDATA_FRAMESEQUENCE_MANUAL
-        frame = int(self.render_kwargs.get("frame", data.get("frame")))
+        frame = int(self.render_kwargs.get("frame", data["frame"]))
         fps = self.doc.GetFps()
         self.render_data[c4d.RDATA_FRAMEFROM] = c4d.BaseTime(frame, fps)
         self.render_data[c4d.RDATA_FRAMETO] = c4d.BaseTime(frame, fps)
@@ -294,7 +294,7 @@ class Cinema4DHandler:
         Args:
             data (dict):
         """
-        self.render_kwargs["frame"] = int(data.get("frame", ""))
+        self.render_kwargs["frame"] = int(data["frame"])
 
     def set_scene_file(self, data: dict) -> None:
         """


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running `pip install` with an sdist (compressed or uncompressed) you get:
```
OSError: Build script does not exist: hatch_custom_hook.py
```

### What was the solution? (How)

The `_version.py` are already generated and shipped, but we need to ensure the hook file exists so that the build backend can succeed in generating a whl (it doesn't try to re-generate the package information from vcs). Turns out there was a typo preventing it from being shipped.

### What is the impact of this change?

Working sdists!

### How was this change tested?

Before
```
$ pip install dist/deadline_cloud_for_cinema_4d-0.7.3.post5+gab0cf6f.tar.gz
Processing ./dist/deadline_cloud_for_cinema_4d-0.7.3.post5+gab0cf6f.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-build-env-741mrpe7/overlay/lib/python3.10/site-packages/hatchling/build.py", line 44, in get_requires_for_build_wheel
          return builder.config.dependencies
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/functools.py", line 981, in __get__
          val = self.func(instance)
        File "/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-build-env-741mrpe7/overlay/lib/python3.10/site-packages/hatchling/builders/config.py", line 577, in dependencies
          for dependency in self.dynamic_dependencies:
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/functools.py", line 981, in __get__
          val = self.func(instance)
        File "/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-build-env-741mrpe7/overlay/lib/python3.10/site-packages/hatchling/builders/config.py", line 593, in dynamic_dependencies
          build_hook = build_hook_cls(
        File "/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-build-env-741mrpe7/overlay/lib/python3.10/site-packages/hatchling/builders/hooks/custom.py", line 33, in __new__
          raise OSError(message)
      OSError: Build script does not exist: hatch_custom_hook.py
      [end of output]
```

After 
```
$ pip install dist/deadline_cloud_for_cinema_4d-0.7.3.post5+gab0cf6f.d20250603.tar.gz 
Processing ./dist/deadline_cloud_for_cinema_4d-0.7.3.post5+gab0cf6f.d20250603.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
...
Building wheels for collected packages: deadline-cloud-for-cinema-4d
  Building wheel for deadline-cloud-for-cinema-4d (pyproject.toml) ... done
  Created wheel for deadline-cloud-for-cinema-4d: filename=deadline_cloud_for_cinema_4d-0.7.3.post5+gab0cf6f.d20250603-py3-none-any.whl size=49046 sha256=5273ae5ad8cfb7da65efedc5dcc4151b1b983a479cc83d4f35ecbb965d17b925
Successfully built deadline-cloud-for-cinema-4d
Installing collected packages: deadline-cloud-for-cinema-4d
Successfully installed deadline-cloud-for-cinema-4d-0.7.3.post5+gab0cf6f.d20250603
```



### Was this change documented?

N/A

### Does this PR introduce new dependencies?
N/A

### Is this a breaking change?
Fixing :)

### Does this change impact security?
N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
