### PR TITLE
test: unit test for integration_data_interface_version

### DIFF
--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -1,10 +1,31 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
+import json
+from pathlib import Path
 
 import pytest
 from jsonschema.exceptions import ValidationError
 
 from deadline.cinema4d_adaptor.Cinema4DAdaptor import Cinema4DAdaptor
+
+REFERENCE_INIT_DATA_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "scene_file": {"type": "string"},
+        "take": {"type": "string"},
+        "output_path": {"type": "string"},
+        "multi_pass_path": {"type": "string"},
+    },
+    "required": ["scene_file"],
+}
+
+REFERENCE_RUN_DATA_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {"frame": {"type": "number"}},
+    "required": ["frame"],
+}
 
 
 @pytest.fixture
@@ -121,3 +142,45 @@ def test_adaptor_rejects_malformed_run_data(init_data: dict):
     adapter = Cinema4DAdaptor(init_data)
     with pytest.raises(ValidationError):
         adapter.on_run({"invalid": "data"})
+
+
+def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(init_data):
+    """
+    Test to validate that if the init data or run data schema are changed, we also bump the
+    integration_data_interface_version
+    """
+    # Expected version for these reference schemas
+    EXPECTED_MAJOR = 0
+    EXPECTED_MINOR = 1
+
+    # Get the current version from the adaptor
+    adapter = Cinema4DAdaptor(init_data)
+    semantic_version = adapter.integration_data_interface_version
+
+    # Obtain current schema files
+    root_directory_path = Path(__file__).parent.parent.parent.parent.parent
+    schema_path = root_directory_path.joinpath(
+        "src", "deadline", "cinema4d_adaptor", "Cinema4DAdaptor", "schemas"
+    )
+    init_data_path = schema_path.joinpath("init_data.schema.json")
+    run_data_path = schema_path.joinpath("run_data.schema.json")
+
+    # Assert current schemas to reference schemas
+    with init_data_path.open() as init_data_schema_file:
+        init_data_schema = json.load(init_data_schema_file)
+        assert (
+            init_data_schema == REFERENCE_INIT_DATA_SCHEMA
+        ), "If the init_data.schema.json is changed, the integration_data_interface_version must be bumped"
+
+    with run_data_path.open() as run_data_schema_file:
+        run_data_schema = json.load(run_data_schema_file)
+        assert (
+            run_data_schema == REFERENCE_RUN_DATA_SCHEMA
+        ), "If the run_data.schema.json is changed, the integration_data_interface_version must be bumped"
+
+    # Assert that the semantic version matches the expected version
+    assert semantic_version.major == EXPECTED_MAJOR and semantic_version.minor == EXPECTED_MINOR, (
+        f"Expected version {EXPECTED_MAJOR}.{EXPECTED_MINOR} but got "
+        f"{semantic_version.major}.{semantic_version.minor}. When updating schemas, "
+        "both the reference schemas AND the expected version should be updated together."
+    )


### PR DESCRIPTION
Fixes: *<(https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/168) >*

### What was the problem/requirement? (What/Why)
When the init_data.schema.yaml or run_data.schema.yaml is changed, the adaptor's integration_data_interface_version should also be increased. 

### What was the solution? (How)
Add a unit test the checks if init_data.schema.yaml or run_data.schema.yaml is changed. If it is changed then an error message will show indicating that the integration_data_interface_version should be increased.

### What is the impact of this change?
Adding this test allows for the integration_data_interface_version to be increased.

### How was this change tested?
Ran hatch tests.

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*