### PR TITLE
feat: Remember last used output paths and take selection for job submissions

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -415,12 +415,24 @@ def create_job_bundle(
         submit_takes = takes["current_data_list"]
 
     # Add overrides to asset references and update the paths with C4D render path tokens.
-    if settings.output_path:
-        settings.output_path = Scene.replace_render_path_tokens(settings.output_path)
-        asset_references.output_directories.add(os.path.dirname(settings.output_path))
-    if settings.multi_pass_path:
-        settings.multi_pass_path = Scene.replace_render_path_tokens(settings.multi_pass_path)
-        asset_references.output_directories.add(os.path.dirname(settings.multi_pass_path))
+    scene_output_path, scene_multi_pass_path = Scene.get_output_paths()
+    if settings.override_output_path:
+        if settings.output_path:
+            settings.output_path = Scene.replace_render_path_tokens(settings.output_path)
+            asset_references.output_directories.add(os.path.dirname(settings.output_path))
+    else:
+        if scene_output_path:
+            settings.output_path = Scene.replace_render_path_tokens(scene_output_path)
+            asset_references.output_directories.add(os.path.dirname(scene_output_path))
+
+    if settings.override_multi_pass_path:
+        if settings.multi_pass_path:
+            settings.multi_pass_path = Scene.replace_render_path_tokens(settings.multi_pass_path)
+            asset_references.output_directories.add(os.path.dirname(settings.multi_pass_path))
+    else:
+        if scene_multi_pass_path:
+            settings.multi_pass_path = Scene.replace_render_path_tokens(scene_multi_pass_path)
+            asset_references.output_directories.add(os.path.dirname(scene_multi_pass_path))
 
     # # Check if there are multiple frame ranges across the takes
     first_frame_range = submit_takes[0].frame_range

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -113,7 +113,12 @@ class RenderSubmitterUISettings:
                 obj = {
                     field.name: getattr(self, field.name)
                     for field in dataclasses.fields(self)
-                    if field.metadata.get("sticky") and field.name != "timeouts"
+                    if field.metadata.get("sticky")
+                    and field.name != "timeouts"
+                    and not (
+                        (field.name == "output_path" and not self.override_output_path)
+                        or (field.name == "multi_pass_path" and not self.override_multi_pass_path)
+                    )
                 }
                 obj["timeouts"] = self.timeouts.to_sticky_settings_dict()
                 json.dump(obj, fh, indent=1)

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -51,15 +51,17 @@ class RenderSubmitterUISettings:
     description: str = field(default="", metadata={"sticky": True})
 
     override_frame_range: bool = field(default=False, metadata={"sticky": True})
+    override_output_path: bool = field(default=False, metadata={"sticky": True})
+    override_multi_pass_path: bool = field(default=False, metadata={"sticky": True})
     frame_list: str = field(default="", metadata={"sticky": True})
-    output_path: str = field(default="")
-    multi_pass_path: str = field(default="")
+    output_path: str = field(default="", metadata={"sticky": True})
+    multi_pass_path: str = field(default="", metadata={"sticky": True})
 
     input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
     output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
 
-    take_selection: TakeSelection = field(default=TakeSelection.MAIN)
+    take_selection: TakeSelection = field(default=TakeSelection.MAIN, metadata={"sticky": True})
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}
     )
@@ -87,6 +89,9 @@ class RenderSubmitterUISettings:
                         if name in sticky_fields:
                             if name == "timeouts":
                                 self.timeouts.update_from_sticky_settings(value)
+                            # Convert take_selection int to TakeSelection enum to access its data
+                            elif name == "take_selection":
+                                self.take_selection = TakeSelection(value)
                             else:
                                 setattr(self, name, value)
             except (OSError, json.JSONDecodeError):

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -114,13 +114,13 @@ class RenderSubmitterUISettings:
                     field.name: getattr(self, field.name)
                     for field in dataclasses.fields(self)
                     if field.metadata.get("sticky")
-                    and field.name != "timeouts"
-                    and not (
-                        (field.name == "output_path" and not self.override_output_path)
-                        or (field.name == "multi_pass_path" and not self.override_multi_pass_path)
-                    )
+                    and field.name not in ["timeouts", "output_path", "multi_pass_path"]
                 }
                 obj["timeouts"] = self.timeouts.to_sticky_settings_dict()
+                if self.override_output_path:
+                    obj["output_path"] = self.output_path
+                if self.override_multi_pass_path:
+                    obj["multi_pass_path"] = self.multi_pass_path
                 json.dump(obj, fh, indent=1)
         except OSError as e:
             traceback.print_exc()

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -140,10 +140,10 @@ class SceneSettingsWidget(QWidget):
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 
     def _configure_settings(self, settings):
-        self.op_path_chck.setChecked(False)
-        self.op_path_txt.setEnabled(False)
-        self.op_multi_path_chck.setChecked(False)
-        self.op_multi_path_txt.setEnabled(False)
+        self.op_path_chck.setChecked(settings.override_output_path)
+        self.op_path_txt.setEnabled(settings.override_output_path)
+        self.op_multi_path_chck.setChecked(settings.override_multi_pass_path)
+        self.op_multi_path_txt.setEnabled(settings.override_multi_pass_path)
         self.op_path_txt.setText(settings.output_path)
         self.op_multi_path_txt.setText(settings.multi_pass_path)
         self.frame_override_chck.setChecked(settings.override_frame_range)
@@ -163,6 +163,9 @@ class SceneSettingsWidget(QWidget):
         """
         settings.output_path = self.op_path_txt.text()
         settings.multi_pass_path = self.op_multi_path_txt.text()
+
+        settings.override_output_path = self.op_path_chck.isChecked()
+        settings.override_multi_pass_path = self.op_multi_path_chck.isChecked()
 
         settings.override_frame_range = self.frame_override_chck.isChecked()
         settings.frame_list = self.frame_override_txt.text()


### PR DESCRIPTION
Fixes: *< (https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/95) >*

### What was the problem/requirement? (What/Why)
The fields output_path, multi_pass_path, and take_selection in the submitter's job specific settings do not have sticky settings which can be inconvenient. The fields override_output_path and override_multi_pass_path do not exist and they would be useful in order to save checkbox checked states. 

### What was the solution? (How)
Add sticky settings to output_path, multi_pass_output, and take_selection. 
Create two new boolean fields, override_output_path and override_multi_pass_path, with sticky metadata to track checkbox states. For override_output_path and override_multi_pass_path, if the checkbox is unchecked the default render settings paths will be used for the job. 

### What is the impact of this change?
Customers will have settings that are saved and reused between submissions.

### How was this change tested?
* Built the package with the changes and verified that settings persist after closing and reopening Cinema 4D.
* Tested with existing settings files to ensure backward compatibility is maintained.
* Examined the JSON settings file to confirm that the new fields are being properly saved.
* Tested edge cases such as enabling/disabling checkboxes and changing paths multiple times.
* Ran unit tests:
  * 0.02s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_on_cleanup::test_handle_errors_on_error_stdout[Project not found-True]
============================================================ 53 passed in 4.58s ============================================================ 
* Ran integration tests:
  * =========================================================== slowest 5 durations ============================================================ 
109.25s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
82.20s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
78.92s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
75.83s call     test/integ/test_cinema4d.py::test_integ[redshift]
54.39s call     test/integ/test_cinema4d.py::test_integ[physical]
====================================================== 6 passed in 456.20s (0:07:36) =======================================================

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*