### PR TITLE
fix: Execute passes for scenes to fix pyro caching issue

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -315,6 +315,13 @@ class Cinema4DHandler:
         if doc is None:
             print("Error: LoadDocument failed: %s" % scene_file)
         else:
-            doc.ExecutePasses(None, True, True, True, c4d.BUILDFLAGS_NONE)
+            # Build animations, caches and expressions for all frames in the document.
+            # This is essential for dynamic content like Pyro simulations (fluid/smoke effects)
+            # which would otherwise render as blank. The parameters ensure all necessary
+            # elements (animation, expressions, caches) are processed.
+            doc.ExecutePasses(
+                bt=None, animation=True, expressions=True, caches=True, flags=c4d.BUILDFLAGS_NONE
+            )
+
             c4d.documents.InsertBaseDocument(doc)
             c4d.documents.SetActiveDocument(doc)

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -315,5 +315,6 @@ class Cinema4DHandler:
         if doc is None:
             print("Error: LoadDocument failed: %s" % scene_file)
         else:
+            doc.ExecutePasses(None, True, True, True, c4d.BUILDFLAGS_NONE)
             c4d.documents.InsertBaseDocument(doc)
             c4d.documents.SetActiveDocument(doc)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We had an issue with Pyro scenes with caches that didn't render correctly. 

### What was the solution? (How)

The issue was two-fold: 

1. Turns out that for Pyro scenes with cache. It is important to run `ExecutePasses` before rendering the scene. Only then would it render the animation with the caches. Hence, added that fix. 
2. We need to fix how the submissions work currently. Maxon (the company behind Cinema 4D) recommends using "Save Project with Assets" settings to ensure the renders work correctly. This is the issue detailed here: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/226

### What is the impact of this change?

Customer can render pyro scenes now when submitting using the "Save Project with Assets" feature. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes

```
test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 16%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 33%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 50%] PASSED test/integ/test_cinema4d.py::test_integ[redshift]
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 66%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes]
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 83%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured]
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
```

I've also submitted various Pyro scenes from the asset library to confirm they work now which previously used to give us blank renders:
 
![PyroSceneWIthAssets0087](https://github.com/user-attachments/assets/6a26767d-91fd-46f6-a8e9-3c3873a63392)


![BurningPanWithAssets0135](https://github.com/user-attachments/assets/1ff1820d-b333-4a29-a3e2-43b5de2db9d4)

![EngineExhaustWithAssets0017](https://github.com/user-attachments/assets/50bdd844-4124-41b8-a86f-17fa191acac2)

Also confirmed that adding this `ExecutePasses` statement does not affect other scenes. 

![s 0150](https://github.com/user-attachments/assets/6464a58a-ec2f-4678-8f26-fb98e632930c)

- Have you made changes to the submitter?
No

### Was this change documented?
No

### Is this a breaking change?

No. It was a bug and it didn't work earlier. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*