### PR TITLE
chore: print adaptor version in session logs when Cinema4D is initialized

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -76,7 +76,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
 
     def _print_adaptor_version(self) -> None:
         """Prints the adaptor version information."""
-        print(f"Deadline Cloud for Cinema4D adaptor version: {adaptor_version}")
+        print(f"Deadline Cloud for Cinema 4D adaptor version: {adaptor_version}")
 
     def __init__(self, *args, **kwargs):
         if sys.platform == "linux" and "path_mapping_data" in kwargs:

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -19,6 +19,8 @@ from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
 from openjd.adaptor_runtime.process import LoggingSubprocess
 from openjd.adaptor_runtime_client import Action
 
+from .._version import version as adaptor_version
+
 _logger = logging.getLogger(__name__)
 
 
@@ -72,6 +74,10 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
     _expected_outputs: int = 1  # Total number of renders to perform.
     _produced_outputs: int = 0  # Counter for tracking number of complete renders.
 
+    def _print_adaptor_version(self) -> None:
+        """Prints the adaptor version information."""
+        print(f"Deadline Cloud for Cinema4D adaptor version: {adaptor_version}")
+
     def __init__(self, *args, **kwargs):
         if sys.platform == "linux" and "path_mapping_data" in kwargs:
             # on Linux, Cinema4D interprets Windows absolute paths as relative paths
@@ -97,6 +103,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                         prefixed_rule["destination_os"] = rule["destination_os"]
                     path_mapping_rules.append(prefixed_rule)
         super().__init__(*args, **kwargs)
+        self._print_adaptor_version()
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -7,6 +7,7 @@ import pytest
 from jsonschema.exceptions import ValidationError
 
 from deadline.cinema4d_adaptor.Cinema4DAdaptor import Cinema4DAdaptor
+from deadline.cinema4d_adaptor._version import version as adaptor_version
 
 REFERENCE_INIT_DATA_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -184,3 +185,15 @@ def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(i
         f"{semantic_version.major}.{semantic_version.minor}. When updating schemas, "
         "both the reference schemas AND the expected version should be updated together."
     )
+
+
+def test_adaptor_prints_version_on_init(init_data, capfd):
+    """
+    Test that the adaptor prints its version during initialization
+    """
+    Cinema4DAdaptor(init_data)
+    captured = capfd.readouterr()
+    expected_output = f"Deadline Cloud for Cinema4D adaptor version: {adaptor_version}"
+    assert (
+        expected_output in captured.out
+    ), f"Expected output to contain {expected_output}, but got {captured.out}"

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -193,7 +193,7 @@ def test_adaptor_prints_version_on_init(init_data, capfd):
     """
     Cinema4DAdaptor(init_data)
     captured = capfd.readouterr()
-    expected_output = f"Deadline Cloud for Cinema4D adaptor version: {adaptor_version}"
+    expected_output = f"Deadline Cloud for Cinema 4D adaptor version: {adaptor_version}"
     assert (
         expected_output in captured.out
     ), f"Expected output to contain {expected_output}, but got {captured.out}"


### PR DESCRIPTION
Fixes: *<https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/209>*

### What was the problem/requirement? (What/Why)
The adaptor version was not being printed in the session logs and this makes it harder to understand which adaptor version customers are working on. 

### What was the solution? (How)
Print the adaptor version when Cinema4D is initialized.

### What is the impact of this change?
Customers will now be able to see what adaptor version they are working on in the session logs. This is useful for debugging.

### How was this change tested?
Uploaded the changes to a conda channel and made sure the adaptor version was being printed after submitting a job. 

- Have you run the unit tests?
Yes. 
test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_on_cleanup::test_handle_errors_on_error_stdout[Asset missing-True]   
0.04s call     test/unit/deadline_submitter_for_cinema4d/test_submitter.py::test_get_job_template
============================================================================== 54 passed in 5.30s =========================

- Have you run the integration tests? 
Yes.
slowest 5 durations ============================================================================== 
118.78s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
87.29s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
84.86s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
74.03s call     test/integ/test_cinema4d.py::test_integ[redshift]
58.10s call     test/integ/test_cinema4d.py::test_integ[physical_textured]
======================================================================== 6 passed in 477.60s (0:07:57) =================================

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*