### PR TITLE
feat: Bundle scene and assets before submission.

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 import re
+import tempfile
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
@@ -56,10 +57,12 @@ def show_submitter():
             app = QtWidgets.QApplication([])
             app.setQuitOnLastWindowClosed(False)
             app.aboutToQuit.connect(app.deleteLater)
-        app.setStyleSheet(C4D_STYLE)
-        w = _show_submitter(None)
-        w.setStyleSheet(C4D_STYLE)
-        w.exec_()
+        # Create a temporary directory that will be automatically cleaned up after submission
+        with tempfile.TemporaryDirectory(prefix="c4d_job_bundle_") as temp_dir:
+            app.setStyleSheet(C4D_STYLE)
+            w = _show_submitter(temp_dir, None)
+            w.setStyleSheet(C4D_STYLE)
+            w.exec_()
     except Exception:
         print("Deadline UI launch failed")
         import traceback
@@ -408,6 +411,7 @@ def create_job_bundle(
     asset_references: AssetReferences,
     queue_parameters: list[dict[str, Any]],
     attachments: AssetReferences,
+    temp_dir: Optional[str] = None,
     host_requirements: Optional[dict] = None,
 ):
     """
@@ -417,6 +421,11 @@ def create_job_bundle(
     a job bundle for submission. It handles different take selection modes, manages
     frame ranges, and prepares job templates with the necessary parameters.
     """
+
+    original_cinema4d_file = Scene.name()
+
+    if settings.export_job_bundle_to_temp and temp_dir:
+        export_to_temp_folder(temp_dir, asset_references)
 
     submit_takes = takes["main_data_list"]
     job_bundle_path = Path(job_bundle_dir)
@@ -475,6 +484,13 @@ def create_job_bundle(
     save_job_bundle_files(job_bundle_path, job_template, parameter_values, asset_references)
 
     # Save Sticky Settings
+    if settings.export_job_bundle_to_temp:
+        # Restore the original Cinema4DFile to be the active document.
+        doc = c4d.documents.LoadDocument(
+            original_cinema4d_file, c4d.SCENEFILTER_OBJECTS | c4d.SCENEFILTER_MATERIALS
+        )
+        c4d.documents.InsertBaseDocument(doc)
+        c4d.documents.SetActiveDocument(doc)
     settings.input_filenames = sorted(attachments.input_filenames)
     settings.input_directories = sorted(attachments.input_directories)
 
@@ -575,13 +591,54 @@ def get_conda_packages() -> str:
     return f"cinema4d={c4d_major_version}.* cinema4d-openjd={adaptor_version}.*"
 
 
-def _show_submitter(parent=None, f=Qt.WindowFlags()):
+def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> None:
+    """
+    Exports the current Cinema 4D project to a temporary folder and updates the asset references.
+
+    Args:
+        temp_dir: Path to the temporary directory
+        queue_parameters: List of queue parameters to update
+        asset_references: Asset references to update
+
+    Returns:
+        The original Cinema4DFile value, or None if no export was performed
+    """
+
+    doc = c4d.documents.GetActiveDocument()
+
+    # Save the project to the temporary directory
+    temp_file_path = os.path.join(temp_dir, doc.GetDocumentName())
+    c4d.documents.SaveProject(
+        doc,
+        c4d.SAVEPROJECT_ASSETS | c4d.SAVEPROJECT_SCENEFILE,
+        temp_file_path,
+        [],
+        [],
+    )
+
+    # Get all files within the temp directory
+    temp_assets = set()
+    for root, _, files in os.walk(temp_dir):
+        for file in files:
+            file_path = os.path.join(root, file)
+            temp_assets.add(os.path.normpath(file_path))
+
+    # Add all assets to the asset references
+    asset_references.input_filenames = temp_assets
+
+
+def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
     """
     Creates and returns a submission dialog for rendering jobs.
 
     This function initializes render settings, processes takes from the active document,
     sets up attachments, and configures a submission dialog with necessary callbacks
     and requirements for job submission.
+
+    Args:
+        temp_dir: Path to a temporary directory for job bundle export
+        parent: The parent widget
+        f: Window flags
     """
 
     render_settings = initialize_render_settings()
@@ -614,6 +671,7 @@ def _show_submitter(parent=None, f=Qt.WindowFlags()):
             asset_references,
             queue_parameters,
             widget.job_attachments.attachments,
+            temp_dir,
             host_requirements,
         )
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -485,12 +485,16 @@ def create_job_bundle(
 
     # Save Sticky Settings
     if settings.export_job_bundle_to_temp:
+        # Close temporary document
+        c4d.documents.KillDocument(c4d.documents.GetActiveDocument())
+
         # Restore the original Cinema4DFile to be the active document.
         doc = c4d.documents.LoadDocument(
             original_cinema4d_file, c4d.SCENEFILTER_OBJECTS | c4d.SCENEFILTER_MATERIALS
         )
         c4d.documents.InsertBaseDocument(doc)
         c4d.documents.SetActiveDocument(doc)
+
     settings.input_filenames = sorted(attachments.input_filenames)
     settings.input_directories = sorted(attachments.input_directories)
 

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -65,6 +65,7 @@ class RenderSubmitterUISettings:
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}
     )
+    export_job_bundle_to_temp: bool = field(default=True, metadata={"sticky": True})
 
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -65,7 +65,7 @@ class RenderSubmitterUISettings:
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}
     )
-    export_job_bundle_to_temp: bool = field(default=True, metadata={"sticky": True})
+    export_job_bundle_to_temp: bool = field(default=False, metadata={"sticky": True})
 
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -143,7 +143,7 @@ class SceneSettingsWidget(QWidget):
         export_layout.addWidget(self.export_job_bundle_chck)
 
         warning_label = QLabel(
-            "⚠️ This option temporarily uses additional disk space and takes longer to submit, "
+            "This option temporarily uses additional disk space and takes longer to submit, "
             "but it bundles the scene with its assets and fixes the paths to increase the likelihood of successful jobs."
         )
         warning_label.setWordWrap(True)

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -134,17 +134,17 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(self.timeout_settings_box, 5, 0, 1, 2)
 
         # Create a group box for the export job bundle option
-        export_group_box = QGroupBox("Job Bundle Export Options", self)
+        export_group_box = QGroupBox("Cinema 4D submission options", self)
         export_layout = QVBoxLayout(export_group_box)
 
         self.export_job_bundle_chck = QCheckBox(
-            "Export job bundle to temporary folder before submission", self
+            "Save Cinema 4D project with Assets before submission", self
         )
         export_layout.addWidget(self.export_job_bundle_chck)
 
         warning_label = QLabel(
-            "This option temporarily uses additional disk space and takes longer to submit, "
-            "but it bundles the scene with its assets and fixes the paths to increase the likelihood of successful jobs."
+            "Prevents missing file errors during rendering by creating a temporary copy of your project with all assets "
+            "and fixing file paths before submission. Uses more disk space and submission time."
         )
         warning_label.setWordWrap(True)
         export_layout.addWidget(warning_label)

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -7,12 +7,14 @@ from qtpy.QtWidgets import (  # type: ignore
     QComboBox,
     QFileDialog,
     QGridLayout,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
     QPushButton,
     QSizePolicy,
     QSpacerItem,
+    QVBoxLayout,
     QWidget,
 )
 
@@ -131,11 +133,29 @@ class SceneSettingsWidget(QWidget):
         self.timeout_settings_box = TimeoutTableWidget(timeouts=settings.timeouts, parent=self)
         lyt.addWidget(self.timeout_settings_box, 5, 0, 1, 2)
 
+        # Create a group box for the export job bundle option
+        export_group_box = QGroupBox("Job Bundle Export Options", self)
+        export_layout = QVBoxLayout(export_group_box)
+
+        self.export_job_bundle_chck = QCheckBox(
+            "Export job bundle to temporary folder before submission", self
+        )
+        export_layout.addWidget(self.export_job_bundle_chck)
+
+        warning_label = QLabel(
+            "⚠️ This option temporarily uses additional disk space and takes longer to submit, "
+            "but it bundles the scene with its assets and fixes the paths to increase the likelihood of successful jobs."
+        )
+        warning_label.setWordWrap(True)
+        export_layout.addWidget(warning_label)
+
+        lyt.addWidget(export_group_box, 6, 0, 1, 2)
+
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 6, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 7, 0)
 
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 
@@ -153,6 +173,8 @@ class SceneSettingsWidget(QWidget):
         index = self.layers_box.findData(settings.take_selection)
         if index >= 0:
             self.layers_box.setCurrentIndex(index)
+
+        self.export_job_bundle_chck.setChecked(settings.export_job_bundle_to_temp)
 
         if self.developer_options:
             self.include_adaptor_wheels.setChecked(settings.include_adaptor_wheels)
@@ -173,6 +195,8 @@ class SceneSettingsWidget(QWidget):
         settings.take_selection = self.layers_box.currentData()
 
         self.timeout_settings_box.update_settings(settings.timeouts)
+
+        settings.export_job_bundle_to_temp = self.export_job_bundle_chck.isChecked()
 
         if self.developer_options:
             settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/226

### What was the problem/requirement? (What/Why)

We have had issues where the submissions would fail due to incorrect path mapping. We confirmed with Maxon and they recommend always submitting the job after bundling it up using "Save Project With Assets" feature in Cinema 4D. 

### What was the solution? (How)

This updates the submitter to use the "Save Project With Assets" feature in Cinema 4D and then submit the scenes. 

### What is the impact of this change?

Customers have less chances of failures. 

### How was this change tested?

Ran multiple jobs to confirm they work. 

Here's how it will look in the UI. 

<img width="548" alt="image" src="https://github.com/user-attachments/assets/3f0baa35-5e52-435e-8ede-178f8fdc3b79" />



- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes. 

```

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 

=================================================================================================================================== slowest 5 durations =================================================================================================================================== 
470.21s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
110.74s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
90.96s call     test/integ/test_cinema4d.py::test_integ[redshift]
88.33s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
84.76s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
============================================================================================================================== 7 passed in 973.72s (0:16:13) ==============================================================================================================================
```

- Have you made changes to the submitter?
Yes

### Was this change documented?

This is a Github feature that was requested. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*