### PR TITLE
feat!: Allow deactivating automatic error checking in Cinema4D jobs

### DIFF
--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -44,14 +44,14 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: DeactivateErrorChecking
+- name: ActivateErrorChecking
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Deactivate automatic error checking
+    label: Activate automatic error checking
     groupLabel: Cinema4D Settings
-  description: Don't fail when errors occur.
-  default: '0'
+  description: Fail when errors occur.
+  default: '1'
   allowedValues:
   - '0'
   - '1'
@@ -78,7 +78,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -44,6 +44,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: DeactivateErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Deactivate automatic error checking
+    groupLabel: Cinema4D Settings
+  description: Don't fail when errors occur.
+  default: '0'
+  allowedValues:
+  - '0'
+  - '1'
 steps:
 - name: Render
   parameterSpace:
@@ -67,6 +78,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -80,7 +80,7 @@ def _get_parameter_values(
     parameter_values.append({"name": "OutputPath", "value": settings.output_path})
     parameter_values.append({"name": "MultiPassPath", "value": settings.multi_pass_path})
     parameter_values.append(
-        {"name": "DeactivateErrorChecking", "value": settings.deactivate_error_checking}
+        {"name": "ActivateErrorChecking", "value": settings.activate_error_checking}
     )
 
     if per_take_frames_parameters:
@@ -197,7 +197,7 @@ def _get_job_template(
             # Update the init data of the step
             init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
             init_data["data"] = (
-                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\ndeactivate_error_checking: '{{Param.DeactivateErrorChecking}}'"
+                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'"
                 % take_data.name
             )
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -18,7 +18,6 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint
     JobBundlePurpose,
     SubmitJobToDeadlineDialog,
 )
-from .template_timeout_patcher import add_timeouts_to_job_template
 
 from ._version import version_tuple as adaptor_version_tuple
 from .assets import AssetIntrospector
@@ -28,6 +27,7 @@ from .data_classes import (
 from .scene import Animation, Scene
 from .style import C4D_STYLE
 from .takes import TakeSelection
+from .template_timeout_patcher import add_timeouts_to_job_template
 from .ui.components.scene_settings_tab import SceneSettingsWidget
 
 LOADED = False
@@ -79,6 +79,9 @@ def _get_parameter_values(
     parameter_values.append({"name": "Cinema4DFile", "value": Scene.name()})
     parameter_values.append({"name": "OutputPath", "value": settings.output_path})
     parameter_values.append({"name": "MultiPassPath", "value": settings.multi_pass_path})
+    parameter_values.append(
+        {"name": "DeactivateErrorChecking", "value": settings.deactivate_error_checking}
+    )
 
     if per_take_frames_parameters:
         for take_data in submit_takes:
@@ -194,7 +197,7 @@ def _get_job_template(
             # Update the init data of the step
             init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
             init_data["data"] = (
-                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'"
+                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\ndeactivate_error_checking: '{{Param.DeactivateErrorChecking}}'"
                 % take_data.name
             )
 

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from deadline.client.ui.dataclasses.timeouts import TimeoutEntry, TimeoutTableEntries
 
 from .takes import TakeSelection  # type: ignore
+from .error_checking import ErrorChecking
 from datetime import timedelta
 
 RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
@@ -62,6 +63,9 @@ class RenderSubmitterUISettings:
     output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
 
     take_selection: TakeSelection = field(default=TakeSelection.MAIN, metadata={"sticky": True})
+    deactivate_error_checking: str = field(
+        default=ErrorChecking.ACTIVATE.value, metadata={"sticky": True}
+    )
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}
     )

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -64,7 +64,7 @@ class RenderSubmitterUISettings:
 
     take_selection: TakeSelection = field(default=TakeSelection.MAIN, metadata={"sticky": True})
     deactivate_error_checking: str = field(
-        default=ErrorChecking.ACTIVATE.value, metadata={"sticky": True}
+        default=ErrorChecking.DEACTIVATE.value, metadata={"sticky": True}
     )
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -63,8 +63,8 @@ class RenderSubmitterUISettings:
     output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
 
     take_selection: TakeSelection = field(default=TakeSelection.MAIN, metadata={"sticky": True})
-    deactivate_error_checking: str = field(
-        default=ErrorChecking.DEACTIVATE.value, metadata={"sticky": True}
+    activate_error_checking: str = field(
+        default=ErrorChecking.ACTIVATE.value, metadata={"sticky": True}
     )
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}

--- a/src/deadline/cinema4d_submitter/error_checking.py
+++ b/src/deadline/cinema4d_submitter/error_checking.py
@@ -3,5 +3,5 @@ from enum import Enum
 
 
 class ErrorChecking(Enum):
-    ACTIVATE = "0"
-    DEACTIVATE = "1"
+    DEACTIVATE = "0"
+    ACTIVATE = "1"

--- a/src/deadline/cinema4d_submitter/error_checking.py
+++ b/src/deadline/cinema4d_submitter/error_checking.py
@@ -1,0 +1,7 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from enum import Enum
+
+
+class ErrorChecking(Enum):
+    ACTIVATE = "0"
+    DEACTIVATE = "1"

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -16,8 +16,10 @@ from qtpy.QtWidgets import (  # type: ignore
     QWidget,
 )
 
-from ...takes import TakeSelection
 from deadline.client.ui.widgets.job_timeouts_widget import TimeoutTableWidget
+
+from ...takes import TakeSelection
+from ...error_checking import ErrorChecking
 
 """
 UI widgets for the Scene Settings tab.
@@ -128,14 +130,17 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(self.frame_override_txt, 4, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)
 
+        self.deactivate_error_checking_chck = QCheckBox("Deactivate automatic error checking", self)
+        lyt.addWidget(self.deactivate_error_checking_chck, 5, 0)
+
         self.timeout_settings_box = TimeoutTableWidget(timeouts=settings.timeouts, parent=self)
-        lyt.addWidget(self.timeout_settings_box, 5, 0, 1, 2)
+        lyt.addWidget(self.timeout_settings_box, 6, 0, 1, 2)
 
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 6, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 7, 0)
 
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 
@@ -149,6 +154,9 @@ class SceneSettingsWidget(QWidget):
         self.frame_override_chck.setChecked(settings.override_frame_range)
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)
+        self.deactivate_error_checking_chck.setChecked(
+            bool(int(settings.deactivate_error_checking))
+        )
 
         index = self.layers_box.findData(settings.take_selection)
         if index >= 0:
@@ -171,6 +179,12 @@ class SceneSettingsWidget(QWidget):
         settings.frame_list = self.frame_override_txt.text()
 
         settings.take_selection = self.layers_box.currentData()
+
+        settings.deactivate_error_checking = (
+            ErrorChecking.DEACTIVATE.value
+            if self.deactivate_error_checking_chck.isChecked()
+            else ErrorChecking.ACTIVATE.value
+        )
 
         self.timeout_settings_box.update_settings(settings.timeouts)
 

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -130,8 +130,8 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(self.frame_override_txt, 4, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)
 
-        self.deactivate_error_checking_chck = QCheckBox("Deactivate automatic error checking", self)
-        lyt.addWidget(self.deactivate_error_checking_chck, 5, 0)
+        self.activate_error_checking_chck = QCheckBox("Activate automatic error checking", self)
+        lyt.addWidget(self.activate_error_checking_chck, 5, 0)
 
         self.timeout_settings_box = TimeoutTableWidget(timeouts=settings.timeouts, parent=self)
         lyt.addWidget(self.timeout_settings_box, 6, 0, 1, 2)
@@ -154,9 +154,7 @@ class SceneSettingsWidget(QWidget):
         self.frame_override_chck.setChecked(settings.override_frame_range)
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)
-        self.deactivate_error_checking_chck.setChecked(
-            bool(int(settings.deactivate_error_checking))
-        )
+        self.activate_error_checking_chck.setChecked(bool(int(settings.activate_error_checking)))
 
         index = self.layers_box.findData(settings.take_selection)
         if index >= 0:
@@ -180,10 +178,10 @@ class SceneSettingsWidget(QWidget):
 
         settings.take_selection = self.layers_box.currentData()
 
-        settings.deactivate_error_checking = (
-            ErrorChecking.DEACTIVATE.value
-            if self.deactivate_error_checking_chck.isChecked()
-            else ErrorChecking.ACTIVATE.value
+        settings.activate_error_checking = (
+            ErrorChecking.ACTIVATE.value
+            if self.activate_error_checking_chck.isChecked()
+            else ErrorChecking.DEACTIVATE.value
         )
 
         self.timeout_settings_box.update_settings(settings.timeouts)

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -154,13 +154,13 @@ class SceneSettingsWidget(QWidget):
         warning_label.setWordWrap(True)
         export_layout.addWidget(warning_label)
 
-        lyt.addWidget(export_group_box, 6, 0, 1, 2)
+        lyt.addWidget(export_group_box, 7, 0, 1, 2)
 
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 7, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 8, 0)
 
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 


### PR DESCRIPTION
Fixes: *<https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/193>*

This PR is the 1st of a set of PRs. The other 2 PRs are the following: 
2nd: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/245
3rd: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/246

Key changes this PR brings:
* Add a checkbox labeled "Activate automatic error checking" in the job specific settings of the submitter.
* Set the default value to True (error checking activated) for backward compatibility.
* Update the _configure_settings() method to initialize the checkbox state from settings.
* Update the update_settings() method to save the checkbox state to settings.

### What was the problem/requirement? (What/Why)
Implement a solution to deactivate automatic error checking during rendering to provide users with more control over the rendering process.

### What was the solution? (How)
Add a checkbox that allows user to activate and deactivate error checking.
 
The checkbox is shown in the image below highlighted by the red box!
<img width="538" height="727" alt="Activate_Error_Checking_checkbox" src="https://github.com/user-attachments/assets/075a9cd3-5805-402d-b0a1-3dbc3f5f23b5" />

### What is the impact of this change?
Customers will be able to have more control over the rendering process. 

### How was this change tested?
* Tested rendering workflows with error checking activated (default behavior).
* Tested rendering workflows with error checking deactivated.
* Verified that error messages are properly caught when error checking is activated.
* Verified that error messages are ignored when error checking is deactivate.
* Tested backward compatibility with existing jobs that don't have this setting.

- Have you run the unit tests?
Yes.
0.03s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::test_adaptor_rejects_malformed_init_data
0.03s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_on_cleanup::test_handle_errors_on_error_stdout[Project not found-True]
======================================================================= 56 passed in 4.08s ======================================

- Have you run the integration tests?
Yes.
432.28s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
88.41s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
77.87s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
75.99s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
74.46s call     test/integ/test_cinema4d.py::test_integ[redshift]
================================================================== 7 passed in 857.94s (0:14:17) ================================


- Have you made changes to the submitter?
Yes, I added a checkbox that allows customers to deactivate automatic error checking.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*