### PR TITLE
feat!: Allow deactivating error checking in the Cinema4D adaptor

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -73,6 +73,9 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
     # Will be optionally changed after the scene is set.
     _expected_outputs: int = 1  # Total number of renders to perform.
     _produced_outputs: int = 0  # Counter for tracking number of complete renders.
+    _deactivate_error_checking: int = (
+        0  # 0=activate, 1=deactivate - controls whether error regex callbacks are added
+    )
 
     def _print_adaptor_version(self) -> None:
         """Prints the adaptor version information."""
@@ -107,7 +110,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
-        return SemanticVersion(major=0, minor=1)
+        return SemanticVersion(major=0, minor=2)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:
@@ -275,7 +278,13 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                 re.compile(r".*Rendering was internally aborted.*", re.IGNORECASE),
                 re.compile(r'.*Cannot find procedure "rsPreference".*', re.IGNORECASE),
             ]
-            callback_list.append(RegexCallback(error_regexes, self._handle_error))
+
+            # Only add error regexes if error checking is not deactivated
+            if not self._deactivate_error_checking:
+                _logger.warning("Adding error regexes to callback list")
+                callback_list.append(RegexCallback(error_regexes, self._handle_error))
+            else:
+                _logger.warning("NOT adding error regexes to callback list")
 
             insufficient_ram_regexes = re.compile(r".*Failed to allocate mem.*", re.IGNORECASE)
             callback_list.append(
@@ -455,6 +464,8 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         """
         self.validators.init_data.validate(self.init_data)
 
+        self._deactivate_error_checking = int(self.init_data.get("deactivate_error_checking", "0"))
+
         self.update_status(progress=0, status_message="Initializing Cinema4D")
         self._initialize_maxon_assets_db_connection()
         self._start_cinema4d_server_thread()
@@ -481,7 +492,6 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         This starts a render in Cinema4D for the given frame, scene and layer(s) and
         performs a busy wait until the render completes.
         """
-
         self.validators.run_data.validate(run_data)
 
         if not self._cinema4d_is_running:

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -279,7 +279,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                 re.compile(r'.*Cannot find procedure "rsPreference".*', re.IGNORECASE),
             ]
 
-            # Only add error regexes if error checking is not deactivated
+            # Only add error regexes if error checking is activated
             if self._activate_error_checking:
                 _logger.warning("Adding error regexes to callback list")
                 callback_list.append(RegexCallback(error_regexes, self._handle_error))

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -281,7 +281,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
 
             # Only add error regexes if error checking is activated
             if self._activate_error_checking:
-                _logger.warning("Adding error regexes to callback list")
+                _logger.info("Adding error regexes to callback list")
                 callback_list.append(RegexCallback(error_regexes, self._handle_error))
             else:
                 _logger.warning("NOT adding error regexes to callback list")

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -73,8 +73,8 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
     # Will be optionally changed after the scene is set.
     _expected_outputs: int = 1  # Total number of renders to perform.
     _produced_outputs: int = 0  # Counter for tracking number of complete renders.
-    _deactivate_error_checking: int = (
-        0  # 0=activate, 1=deactivate - controls whether error regex callbacks are added
+    _activate_error_checking: int = (
+        1  # 0=deactivate, 1=activate - controls whether error regex callbacks are added
     )
 
     def _print_adaptor_version(self) -> None:
@@ -280,7 +280,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
             ]
 
             # Only add error regexes if error checking is not deactivated
-            if not self._deactivate_error_checking:
+            if self._activate_error_checking:
                 _logger.warning("Adding error regexes to callback list")
                 callback_list.append(RegexCallback(error_regexes, self._handle_error))
             else:
@@ -464,7 +464,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         """
         self.validators.init_data.validate(self.init_data)
 
-        self._deactivate_error_checking = int(self.init_data.get("deactivate_error_checking", "0"))
+        self._activate_error_checking = int(self.init_data.get("activate_error_checking", "1"))
 
         self.update_status(progress=0, status_message="Initializing Cinema4D")
         self._initialize_maxon_assets_db_connection()

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
@@ -5,7 +5,8 @@
         "scene_file": { "type": "string" },
         "take": { "type": "string" },
         "output_path": { "type": "string" },
-        "multi_pass_path": { "type": "string" }
+        "multi_pass_path": { "type": "string" },
+        "deactivate_error_checking": { "type": "string" }
     },
     "required": [ "scene_file" ]
 }

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
@@ -6,7 +6,7 @@
         "take": { "type": "string" },
         "output_path": { "type": "string" },
         "multi_pass_path": { "type": "string" },
-        "deactivate_error_checking": { "type": "string" }
+        "activate_error_checking": { "type": "string" }
     },
     "required": [ "scene_file" ]
 }

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -43,7 +43,7 @@ REFERENCE_INIT_DATA_SCHEMA = {
         "take": {"type": "string"},
         "output_path": {"type": "string"},
         "multi_pass_path": {"type": "string"},
-        "deactivate_error_checking": {"type": "string"},
+        "activate_error_checking": {"type": "string"},
     },
     "required": ["scene_file"],
 }
@@ -69,7 +69,7 @@ def init_data() -> dict:
         "take": "Main",
         "output_path": "C:\\Users\\user123\\test_render",
         "multi_pass_path": "",
-        "deactivate_error_checking": "0",
+        "activate_error_checking": "1",
     }
 
 
@@ -227,20 +227,20 @@ def test_adaptor_prints_version_on_init(init_data, capfd):
     ), f"Expected output to contain {expected_output}, but got {captured.out}"
 
 
-@pytest.mark.parametrize("deactivate_error_checking", [0, 1])
-def test_deactivate_error_checking(init_data: dict, deactivate_error_checking: int) -> None:
+@pytest.mark.parametrize("activate_error_checking", [0, 1])
+def test_activate_error_checking(init_data: dict, activate_error_checking: int) -> None:
     """
-    Tests that the deactivate_error_checking configuration controls whether error-handling
+    Tests that the activate_error_checking configuration controls whether error-handling
     regex callbacks are included in the adaptor's callback list.
 
-    When deactivate_error_checking=0 (activate): Error regexes should be present
-    When deactivate_error_checking=1 (deactivate): Error regexes should be absent
+    When activate_error_checking=0 (deactivate): Error regexes should be absent
+    When activate_error_checking=1 (activate): Error regexes should be present
     """
     # GIVEN:
-    init_data["deactivate_error_checking"] = str(deactivate_error_checking)
+    init_data["activate_error_checking"] = str(activate_error_checking)
     adaptor = Cinema4DAdaptor(init_data)
     # Manually set the private variable to fix timing issue (normally set in on_start())
-    adaptor._deactivate_error_checking = deactivate_error_checking
+    adaptor._activate_error_checking = activate_error_checking
 
     # WHEN:
     callbacks = adaptor._get_regex_callbacks()
@@ -251,11 +251,11 @@ def test_deactivate_error_checking(init_data: dict, deactivate_error_checking: i
         EXPECTED_ERROR_REGEXES == regex_callback.regex_list for regex_callback in callbacks
     )
 
-    if deactivate_error_checking == 0:
+    if activate_error_checking == 1:
         assert (
             error_checking_present
-        ), "Error checking should be activated when deactivate_error_checking=0"
+        ), "Error checking should be activated when activate_error_checking=1"
     else:
         assert (
             not error_checking_present
-        ), "Error checking should be deactivated when deactivate_error_checking=1"
+        ), "Error checking should be deactivated when activate_error_checking=0"

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
+
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -8,6 +10,30 @@ from jsonschema.exceptions import ValidationError
 
 from deadline.cinema4d_adaptor.Cinema4DAdaptor import Cinema4DAdaptor
 from deadline.cinema4d_adaptor._version import version as adaptor_version
+
+# Expected error regex patterns - should match those in the adaptor
+EXPECTED_ERROR_REGEXES = [
+    re.compile(r".*Document not found.*", re.IGNORECASE),
+    re.compile(r".*Project not found.*", re.IGNORECASE),
+    re.compile(r".*Error rendering project.*", re.IGNORECASE),
+    re.compile(r".*Error loading project.*", re.IGNORECASE),
+    re.compile(r".*Error rendering document.*", re.IGNORECASE),
+    re.compile(r".*Error loading document.*", re.IGNORECASE),
+    re.compile(r".*Rendering failed.*", re.IGNORECASE),
+    re.compile(r".*Asset missing.*", re.IGNORECASE),
+    re.compile(r".*Asset Error.*", re.IGNORECASE),
+    re.compile(r".*Invalid License.*", re.IGNORECASE),
+    re.compile(r".*licensing error.*", re.IGNORECASE),
+    re.compile(r".*License Check error.*", re.IGNORECASE),
+    re.compile(r".*Files cannot be written.*", re.IGNORECASE),
+    re.compile(r".*Enter Registration Data.*", re.IGNORECASE),
+    re.compile(r".*Unable to write file.*", re.IGNORECASE),
+    re.compile(r".*\[rlm\] abort_on_license_fail enabled.*", re.IGNORECASE),
+    re.compile(r".*RenderDocument failed with return code.*", re.IGNORECASE),
+    re.compile(r".*Frame rendering aborted.*", re.IGNORECASE),
+    re.compile(r".*Rendering was internally aborted.*", re.IGNORECASE),
+    re.compile(r'.*Cannot find procedure "rsPreference".*', re.IGNORECASE),
+]
 
 REFERENCE_INIT_DATA_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -17,6 +43,7 @@ REFERENCE_INIT_DATA_SCHEMA = {
         "take": {"type": "string"},
         "output_path": {"type": "string"},
         "multi_pass_path": {"type": "string"},
+        "deactivate_error_checking": {"type": "string"},
     },
     "required": ["scene_file"],
 }
@@ -42,6 +69,7 @@ def init_data() -> dict:
         "take": "Main",
         "output_path": "C:\\Users\\user123\\test_render",
         "multi_pass_path": "",
+        "deactivate_error_checking": "0",
     }
 
 
@@ -152,7 +180,7 @@ def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(i
     """
     # Expected version for these reference schemas
     EXPECTED_MAJOR = 0
-    EXPECTED_MINOR = 1
+    EXPECTED_MINOR = 2
 
     # Get the current version from the adaptor
     adapter = Cinema4DAdaptor(init_data)
@@ -197,3 +225,37 @@ def test_adaptor_prints_version_on_init(init_data, capfd):
     assert (
         expected_output in captured.out
     ), f"Expected output to contain {expected_output}, but got {captured.out}"
+
+
+@pytest.mark.parametrize("deactivate_error_checking", [0, 1])
+def test_deactivate_error_checking(init_data: dict, deactivate_error_checking: int) -> None:
+    """
+    Tests that the deactivate_error_checking configuration controls whether error-handling
+    regex callbacks are included in the adaptor's callback list.
+
+    When deactivate_error_checking=0 (activate): Error regexes should be present
+    When deactivate_error_checking=1 (deactivate): Error regexes should be absent
+    """
+    # GIVEN:
+    init_data["deactivate_error_checking"] = str(deactivate_error_checking)
+    adaptor = Cinema4DAdaptor(init_data)
+    # Manually set the private variable to fix timing issue (normally set in on_start())
+    adaptor._deactivate_error_checking = deactivate_error_checking
+
+    # WHEN:
+    callbacks = adaptor._get_regex_callbacks()
+
+    # THEN: Check if error checking callback is present based on configuration
+    # Check if error checking callback is present by comparing regex patterns
+    error_checking_present = any(
+        EXPECTED_ERROR_REGEXES == regex_callback.regex_list for regex_callback in callbacks
+    )
+
+    if deactivate_error_checking == 0:
+        assert (
+            error_checking_present
+        ), "Error checking should be activated when deactivate_error_checking=0"
+    else:
+        assert (
+            not error_checking_present
+        ), "Error checking should be deactivated when deactivate_error_checking=1"

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 
 import pytest
@@ -11,29 +10,6 @@ from jsonschema.exceptions import ValidationError
 from deadline.cinema4d_adaptor.Cinema4DAdaptor import Cinema4DAdaptor
 from deadline.cinema4d_adaptor._version import version as adaptor_version
 
-# Expected error regex patterns - should match those in the adaptor
-EXPECTED_ERROR_REGEXES = [
-    re.compile(r".*Document not found.*", re.IGNORECASE),
-    re.compile(r".*Project not found.*", re.IGNORECASE),
-    re.compile(r".*Error rendering project.*", re.IGNORECASE),
-    re.compile(r".*Error loading project.*", re.IGNORECASE),
-    re.compile(r".*Error rendering document.*", re.IGNORECASE),
-    re.compile(r".*Error loading document.*", re.IGNORECASE),
-    re.compile(r".*Rendering failed.*", re.IGNORECASE),
-    re.compile(r".*Asset missing.*", re.IGNORECASE),
-    re.compile(r".*Asset Error.*", re.IGNORECASE),
-    re.compile(r".*Invalid License.*", re.IGNORECASE),
-    re.compile(r".*licensing error.*", re.IGNORECASE),
-    re.compile(r".*License Check error.*", re.IGNORECASE),
-    re.compile(r".*Files cannot be written.*", re.IGNORECASE),
-    re.compile(r".*Enter Registration Data.*", re.IGNORECASE),
-    re.compile(r".*Unable to write file.*", re.IGNORECASE),
-    re.compile(r".*\[rlm\] abort_on_license_fail enabled.*", re.IGNORECASE),
-    re.compile(r".*RenderDocument failed with return code.*", re.IGNORECASE),
-    re.compile(r".*Frame rendering aborted.*", re.IGNORECASE),
-    re.compile(r".*Rendering was internally aborted.*", re.IGNORECASE),
-    re.compile(r'.*Cannot find procedure "rsPreference".*', re.IGNORECASE),
-]
 
 REFERENCE_INIT_DATA_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -245,17 +221,17 @@ def test_activate_error_checking(init_data: dict, activate_error_checking: int) 
     # WHEN:
     callbacks = adaptor._get_regex_callbacks()
 
-    # THEN: Check if error checking callback is present based on configuration
-    # Check if error checking callback is present by comparing regex patterns
-    error_checking_present = any(
-        EXPECTED_ERROR_REGEXES == regex_callback.regex_list for regex_callback in callbacks
+    # THEN: Check if `error_regexes` corresponding callback is present based on configuration
+    # `error_regexes` has the callback function called `_handle_error`.
+    has_handle_error_callback = any(
+        regex_callback.callback == adaptor._handle_error for regex_callback in callbacks
     )
 
     if activate_error_checking == 1:
         assert (
-            error_checking_present
+            has_handle_error_callback
         ), "Error checking should be activated when activate_error_checking=1"
     else:
         assert (
-            not error_checking_present
+            not has_handle_error_callback
         ), "Error checking should be deactivated when activate_error_checking=0"


### PR DESCRIPTION
Fixes: *<https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/193>*

This PR is the 2nd of a set of PRs. The other 2 PRs are the following: 
1st: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/244
3rd: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/246

Key changes this PR brings:
Since a checkbox that allows user to deactivate error checking was added in the first PR, we also need to make changes to the adaptor:
* Add a class variable _activate_error_checking to store the setting.
* Update the on_start() method to read this setting from init_data.
* Modify the _get_regex_callbacks() method to conditionally include error regexes based on this setting.
* Add a unit test

### What was the problem/requirement? (What/Why)
Implement a solution to deactivate automatic error checking during rendering to provide users with more control over the rendering process.

### What was the solution? (How)
Add a checkbox that allows user to activate and deactivate error checking.
 
The checkbox is shown in the image below highlighted by the red box!
<img width="538" height="727" alt="Activate_Error_Checking_checkbox" src="https://github.com/user-attachments/assets/7e9605f4-5ef0-4e87-8f54-4178e38ccb9d" />

### What is the impact of this change?
Customers will be able to have more control over the rendering process. 

### How was this change tested?
* Tested rendering workflows with error checking activated (default behavior).
* Tested rendering workflows with error checking deactivated.
* Verified that error messages are properly caught when error checking is activated.
* Verified that error messages are ignored when error checking is deactivate.
* Tested backward compatibility with existing jobs that don't have this setting.

- Have you run the unit tests?
Yes.
0.03s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::test_adaptor_rejects_malformed_init_data
0.03s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_on_cleanup::test_handle_errors_on_error_stdout[Project not found-True]
======================================================================= 56 passed in 4.08s ======================================

- Have you run the integration tests?
Yes.
432.28s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
88.41s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
77.87s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
75.99s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
74.46s call     test/integ/test_cinema4d.py::test_integ[redshift]
================================================================== 7 passed in 857.94s (0:14:17) ================================


- Have you made changes to the submitter?
Yes, I added a checkbox that allows customers to deactivate automatic error checking.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*