### PR TITLE
test: Update integration test expectations for ActivateErrorChecking p…

### DIFF
--- a/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical\generated_bundle\renders\physical
 - name: MultiPassPath
   value: ''
+- name: DeactivateErrorChecking
+  value: '0'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical\generated_bundle\renders\physical
 - name: MultiPassPath
   value: ''
-- name: DeactivateErrorChecking
-  value: '0'
+- name: ActivateErrorChecking
+  value: '1'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -43,6 +43,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: DeactivateErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Deactivate automatic error checking
+    groupLabel: Cinema4D Settings
+  description: Don't fail when errors occur.
+  default: '0'
+  allowedValues:
+  - '0'
+  - '1'
 steps:
 - name: Main
   parameterSpace:
@@ -65,6 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -43,14 +43,14 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: DeactivateErrorChecking
+- name: ActivateErrorChecking
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Deactivate automatic error checking
+    label: Activate automatic error checking
     groupLabel: Cinema4D Settings
-  description: Don't fail when errors occur.
-  default: '0'
+  description: Fail when errors occur.
+  default: '1'
   allowedValues:
   - '0'
   - '1'
@@ -76,7 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical_multi_takes\generated_bundle\renders\physical_multi_takes_$take
 - name: MultiPassPath
   value: ''
+- name: DeactivateErrorChecking
+  value: '0'
 - name: MainFrames
   value: '1'
 - name: _0123456789abcdef0123456789abcdef0123456789abcdef012345678Frames

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical_multi_takes\generated_bundle\renders\physical_multi_takes_$take
 - name: MultiPassPath
   value: ''
-- name: DeactivateErrorChecking
-  value: '0'
+- name: ActivateErrorChecking
+  value: '1'
 - name: MainFrames
   value: '1'
 - name: _0123456789abcdef0123456789abcdef0123456789abcdef012345678Frames

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -35,6 +35,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: DeactivateErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Deactivate automatic error checking
+    groupLabel: Cinema4D Settings
+  description: Don't fail when errors occur.
+  default: '0'
+  allowedValues:
+  - '0'
+  - '1'
 - name: MainFrames
   type: STRING
   userInterface:
@@ -177,6 +188,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -243,6 +255,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdei1234'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -306,6 +319,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeh1234'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -369,6 +383,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -432,6 +447,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -495,6 +511,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef789abcdeg'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -558,6 +575,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef789abcdef'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -621,6 +639,7 @@ steps:
           take: 'abcdef124'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -684,6 +703,7 @@ steps:
           take: 'abcdef123'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -747,6 +767,7 @@ steps:
           take: '{}|:test!@#$%^&*()_'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -810,6 +831,7 @@ steps:
           take: 'he llo'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -873,6 +895,7 @@ steps:
           take: 'hello'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -936,6 +959,7 @@ steps:
           take: '0'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -999,6 +1023,7 @@ steps:
           take: 'B'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -1062,6 +1087,7 @@ steps:
           take: 'A'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -35,14 +35,14 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: DeactivateErrorChecking
+- name: ActivateErrorChecking
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Deactivate automatic error checking
+    label: Activate automatic error checking
     groupLabel: Cinema4D Settings
-  description: Don't fail when errors occur.
-  default: '0'
+  description: Fail when errors occur.
+  default: '1'
   allowedValues:
   - '0'
   - '1'
@@ -188,7 +188,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -255,7 +255,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdei1234'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -319,7 +319,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeh1234'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -383,7 +383,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -447,7 +447,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -511,7 +511,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef789abcdeg'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -575,7 +575,7 @@ steps:
           take: '0123456789abcdef0123456789abcdef0123456789abcdef789abcdef'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -639,7 +639,7 @@ steps:
           take: 'abcdef124'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -703,7 +703,7 @@ steps:
           take: 'abcdef123'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -767,7 +767,7 @@ steps:
           take: '{}|:test!@#$%^&*()_'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -831,7 +831,7 @@ steps:
           take: 'he llo'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -895,7 +895,7 @@ steps:
           take: 'hello'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -959,7 +959,7 @@ steps:
           take: '0'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -1023,7 +1023,7 @@ steps:
           take: 'B'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -1087,7 +1087,7 @@ steps:
           take: 'A'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical_textured\generated_bundle\renders\physical_textured
 - name: MultiPassPath
   value: ''
+- name: DeactivateErrorChecking
+  value: '0'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical_textured\generated_bundle\renders\physical_textured
 - name: MultiPassPath
   value: ''
-- name: DeactivateErrorChecking
-  value: '0'
+- name: ActivateErrorChecking
+  value: '1'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -43,6 +43,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: DeactivateErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Deactivate automatic error checking
+    groupLabel: Cinema4D Settings
+  description: Don't fail when errors occur.
+  default: '0'
+  allowedValues:
+  - '0'
+  - '1'
 steps:
 - name: Main
   parameterSpace:
@@ -65,6 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -43,14 +43,14 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: DeactivateErrorChecking
+- name: ActivateErrorChecking
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Deactivate automatic error checking
+    label: Activate automatic error checking
     groupLabel: Cinema4D Settings
-  description: Don't fail when errors occur.
-  default: '0'
+  description: Fail when errors occur.
+  default: '1'
   allowedValues:
   - '0'
   - '1'
@@ -76,7 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift\generated_bundle\renders\redshift
 - name: MultiPassPath
   value: ''
+- name: DeactivateErrorChecking
+  value: '0'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift\generated_bundle\renders\redshift
 - name: MultiPassPath
   value: ''
-- name: DeactivateErrorChecking
-  value: '0'
+- name: ActivateErrorChecking
+  value: '1'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -43,6 +43,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: DeactivateErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Deactivate automatic error checking
+    groupLabel: Cinema4D Settings
+  description: Don't fail when errors occur.
+  default: '0'
+  allowedValues:
+  - '0'
+  - '1'
 steps:
 - name: Main
   parameterSpace:
@@ -65,6 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -43,14 +43,14 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: DeactivateErrorChecking
+- name: ActivateErrorChecking
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Deactivate automatic error checking
+    label: Activate automatic error checking
     groupLabel: Cinema4D Settings
-  description: Don't fail when errors occur.
-  default: '0'
+  description: Fail when errors occur.
+  default: '1'
   allowedValues:
   - '0'
   - '1'
@@ -76,7 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift_takes\generated_bundle\renders\redshift_takes_$take
 - name: MultiPassPath
   value: ''
-- name: DeactivateErrorChecking
-  value: '0'
+- name: ActivateErrorChecking
+  value: '1'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift_takes\generated_bundle\renders\redshift_takes_$take
 - name: MultiPassPath
   value: ''
+- name: DeactivateErrorChecking
+  value: '0'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -43,6 +43,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: DeactivateErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Deactivate automatic error checking
+    groupLabel: Cinema4D Settings
+  description: Don't fail when errors occur.
+  default: '0'
+  allowedValues:
+  - '0'
+  - '1'
 steps:
 - name: Main
   parameterSpace:
@@ -65,6 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -43,14 +43,14 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: DeactivateErrorChecking
+- name: ActivateErrorChecking
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Deactivate automatic error checking
+    label: Activate automatic error checking
     groupLabel: Cinema4D Settings
-  description: Don't fail when errors occur.
-  default: '0'
+  description: Fail when errors occur.
+  default: '1'
   allowedValues:
   - '0'
   - '1'
@@ -76,7 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
@@ -5,8 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift_textured\generated_bundle\renders\redshift_textured
 - name: MultiPassPath
   value: ''
-- name: DeactivateErrorChecking
-  value: '0'
+- name: ActivateErrorChecking
+  value: '1'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
@@ -5,6 +5,8 @@ parameterValues:
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift_textured\generated_bundle\renders\redshift_textured
 - name: MultiPassPath
   value: ''
+- name: DeactivateErrorChecking
+  value: '0'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -43,6 +43,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: DeactivateErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Deactivate automatic error checking
+    groupLabel: Cinema4D Settings
+  description: Don't fail when errors occur.
+  default: '0'
+  allowedValues:
+  - '0'
+  - '1'
 steps:
 - name: Main
   parameterSpace:
@@ -65,6 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -43,14 +43,14 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: DeactivateErrorChecking
+- name: ActivateErrorChecking
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Deactivate automatic error checking
+    label: Activate automatic error checking
     groupLabel: Cinema4D Settings
-  description: Don't fail when errors occur.
-  default: '0'
+  description: Fail when errors occur.
+  default: '1'
   allowedValues:
   - '0'
   - '1'
@@ -76,7 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
@@ -9,8 +9,8 @@ parameterValues:
     redshift_textured-_\u20BF_\u0119_\xF1_\u03B2_\u0411_\u062A"
 - name: MultiPassPath
   value: ''
-- name: DeactivateErrorChecking
-  value: '0'
+- name: ActivateErrorChecking
+  value: '1'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
@@ -9,6 +9,8 @@ parameterValues:
     redshift_textured-_\u20BF_\u0119_\xF1_\u03B2_\u0411_\u062A"
 - name: MultiPassPath
   value: ''
+- name: DeactivateErrorChecking
+  value: '0'
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -43,6 +43,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: DeactivateErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Deactivate automatic error checking
+    groupLabel: Cinema4D Settings
+  description: Don't fail when errors occur.
+  default: '0'
+  allowedValues:
+  - '0'
+  - '1'
 steps:
 - name: Main
   parameterSpace:
@@ -65,6 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
+          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -43,14 +43,14 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: DeactivateErrorChecking
+- name: ActivateErrorChecking
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Deactivate automatic error checking
+    label: Activate automatic error checking
     groupLabel: Cinema4D Settings
-  description: Don't fail when errors occur.
-  default: '0'
+  description: Fail when errors occur.
+  default: '1'
   allowedValues:
   - '0'
   - '1'
@@ -76,7 +76,7 @@ steps:
           take: 'Main'
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
-          deactivate_error_checking: '{{Param.DeactivateErrorChecking}}'
+          activate_error_checking: '{{Param.ActivateErrorChecking}}'
       actions:
         onEnter:
           command: cinema4d-openjd


### PR DESCRIPTION
Fixes: *<https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/193>*

This PR is the 3rd of a set of PRs. The other 2 PRs are the following: 
1st: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/244
2nd: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/245

Key changes this PR brings:
The previous 2 PRs change the generated job bundle. DeactivateErrorChecking must be added to parameter_values.yaml and template.yaml in expected_job_bundle in order for the integration tests to pass.

### What was the problem/requirement? (What/Why)
Implement a solution to deactivate automatic error checking during rendering to provide users with more control over the rendering process.

### What was the solution? (How)
Add a checkbox that allows user to activate and deactivate error checking.
 
The checkbox is shown in the image below highlighted by the red box!
<img width="538" height="727" alt="Activate_Error_Checking_checkbox" src="https://github.com/user-attachments/assets/e6912212-2062-4d89-8d98-e915b256fb6d" />

### What is the impact of this change?
Customers will be able to have more control over the rendering process. 

### How was this change tested?
* Tested rendering workflows with error checking activated (default behavior).
* Tested rendering workflows with error checking deactivated.
* Verified that error messages are properly caught when error checking is activated.
* Verified that error messages are ignored when error checking is deactivate.
* Tested backward compatibility with existing jobs that don't have this setting.

- Have you run the unit tests?
Yes.
0.03s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::test_adaptor_rejects_malformed_init_data
0.03s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_on_cleanup::test_handle_errors_on_error_stdout[Project not found-True]
======================================================================= 56 passed in 4.08s ======================================

- Have you run the integration tests?
Yes.
432.28s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
88.41s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
77.87s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
75.99s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
74.46s call     test/integ/test_cinema4d.py::test_integ[redshift]
================================================================== 7 passed in 857.94s (0:14:17) ================================


- Have you made changes to the submitter?
Yes, I added a checkbox that allows customers to deactivate automatic error checking.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*