### PR TITLE
fix: Use the output paths from the scene file instead of the exported scene

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -423,6 +423,7 @@ def create_job_bundle(
     """
 
     original_cinema4d_file = Scene.name()
+    scene_output_path, scene_multi_pass_path = Scene.get_output_paths()
 
     if settings.export_job_bundle_to_temp and temp_dir:
         export_to_temp_folder(temp_dir, asset_references)
@@ -439,7 +440,6 @@ def create_job_bundle(
         submit_takes = takes["current_data_list"]
 
     # Add overrides to asset references and update the paths with C4D render path tokens.
-    scene_output_path, scene_multi_pass_path = Scene.get_output_paths()
     if settings.override_output_path:
         if settings.output_path:
             settings.output_path = Scene.replace_render_path_tokens(settings.output_path)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The PR : https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/243 introduced a bug where the output path was set to a temporary location instead of the output path of the original scene file when relative paths were used. 

### What was the solution? (How)

Updated the code so that the output paths still reference the original Cinema 4D scene file and not the exported one. 

I cut a maintenance ticket: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/248 for this so that we can increase our confidence with the integration tests for this flow. 

### What is the impact of this change?

The output paths do not reference the temporary location. 

### How was this change tested?

- Have you run the unit tests?

Yes

- Have you run the integration tests? (Add your integration test report below)

Yes

```

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes]

=================================================================================================================================== slowest 5 durations =================================================================================================================================== 
474.98s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
109.44s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
88.38s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
84.19s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
83.97s call     test/integ/test_cinema4d.py::test_integ[redshift]
============================================================================================================================== 7 passed in 962.98s (0:16:02) ==============================================================================================================================
```

- Have you made changes to the submitter?

Yes

### Was this change documented?

This is a bug fix. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*