### PR TITLE
fix: use semi-colon as separator in g_additionalModulePath

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -413,7 +413,8 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         if not module_path:
             new_module_path = plugin_dir
         else:
-            new_module_path = plugin_dir + os.pathsep + module_path
+            # This has to use semicolons because that's what C4D requires, even on Linux
+            new_module_path = f"{plugin_dir};{module_path}"
         os.environ[module_path_key] = new_module_path
 
         arguments = [c4d_exe, "-nogui", "-DeadlineCloudClient"]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When trying to run Cinema 4D on Linux, I noticed that the `g_additionalModulePath` env var was not being handled correctly, and was concatenating two separate paths. Upon investigation, I discovered that Cinema 4D uses semicolons for path separators in `g_additionalModulePath`, even on Linux.

### What was the solution? (How)
Updated the env var accordingly.

### What is the impact of this change?
Easier to use the adaptor on Linux.

### How was this change tested?
I've been running Cinema 4D on Linux with the adaptor myself; this is something I needed to get it working.

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
No, N/A - the integration tests only work on Windows, and this is a no-op for that OS.

- Have you made changes to the submitter?
No

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*