### PR TITLE
fix: Path mapping issues on Linux with save project with assets

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -57,8 +57,18 @@ def show_submitter():
             app = QtWidgets.QApplication([])
             app.setQuitOnLastWindowClosed(False)
             app.aboutToQuit.connect(app.deleteLater)
+
+        # Get the scene file's directory path to create the temporary directory
+        # in the same location as the original scene file. This ensures consistent
+        # path resolution across platforms and avoids path mapping errors,
+        # particularly on Linux systems.
+        scene = c4d.documents.GetActiveDocument()
+        scene_dir_path = scene.GetDocumentPath()
+
         # Create a temporary directory that will be automatically cleaned up after submission
-        with tempfile.TemporaryDirectory(prefix="c4d_job_bundle_") as temp_dir:
+        with tempfile.TemporaryDirectory(
+            prefix="scene_with_assets_", dir=scene_dir_path
+        ) as temp_dir:
             app.setStyleSheet(C4D_STYLE)
             w = _show_submitter(temp_dir, None)
             w.setStyleSheet(C4D_STYLE)

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -143,7 +143,7 @@ class SceneSettingsWidget(QWidget):
         export_layout = QVBoxLayout(export_group_box)
 
         self.export_job_bundle_chck = QCheckBox(
-            "Save Cinema 4D project with Assets before submission", self
+            "Save Cinema 4D project with assets before submission", self
         )
         export_layout.addWidget(self.export_job_bundle_chck)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I found that while running the bundle submit option in Cinema 4D on Linux, the outputs failed to sync. 

```
2025/07/16 10:19:27-07:00 Uploading output files to Job Attachments
2025/07/16 10:19:27-07:00 ----------------------------------------------
2025/07/16 10:19:27-07:00 Started syncing outputs using Job Attachments
2025/07/16 10:19:27-07:00 Found 0 files (Output directory /sessions/session-12fcxxxx/assetroot-3751axxx/output does not exist.)
2025/07/16 10:19:27-07:00 Summary Statistics for file uploads:
Processed 0 files totaling 0 B.
Skipped re-processing 0 files totaling 0 B.
Total processing time of 0.0 seconds at 0 B/s.
```

This was only reproducible on Linux workers, Windows workers didn't have this issue. 

### What was the solution? (How)

Upon further investigation, I figured out that the temporary directory that we used was the system directory (something similar to `var/folders/pl//T/c4d_job_bundle_`) and because the default option (the one without bundling) worked without any issues, I suspect it is because of either the permissions or an issue with the job attachments path mapping. 

To workaround this issue, I modified the code so that the temporary directory is created in the directory of the scene file. This is also less confusing for customers as the exported scene is in a familiar location rather than system directory. 

This resulted in successful outputs. 

### What is the impact of this change?

Outputs are generated correctly even on Linux. 

### How was this change tested?

I tested this on Linux and confirmed the jobs now succeed. I also confirmed that the jobs succeed in Windows with this change.

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)

```

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 

=============================================================== slowest 5 durations =============================================================== 
486.39s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
118.81s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
91.26s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
91.07s call     test/integ/test_cinema4d.py::test_integ[redshift]
86.61s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
========================================================= 7 passed in 1003.65s (0:16:43) ==========================================================
```


- Have you made changes to the submitter?

Yes, but this does not change the tests. 

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*