### PR TITLE
fix: Save project with assets feature raises exception if all the paths to assets are not found.

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -601,21 +601,17 @@ def get_conda_packages() -> str:
 def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> None:
     """
     Exports the current Cinema 4D project to a temporary folder and updates the asset references.
+    If SaveProject fails due to missing asset paths, an exception will be returned.
 
     Args:
         temp_dir: Path to the temporary directory
-        queue_parameters: List of queue parameters to update
         asset_references: Asset references to update
-
-    Returns:
-        The original Cinema4DFile value, or None if no export was performed
     """
-
     doc = c4d.documents.GetActiveDocument()
 
     # Save the project to the temporary directory
     temp_file_path = os.path.join(temp_dir, doc.GetDocumentName())
-    c4d.documents.SaveProject(
+    save_success = c4d.documents.SaveProject(
         doc,
         c4d.SAVEPROJECT_ASSETS | c4d.SAVEPROJECT_SCENEFILE,
         temp_file_path,
@@ -623,6 +619,12 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
         [],
     )
 
+    if not save_success:
+        raise RuntimeError(
+            "Exporting the scene failed. Please fix all the paths for your assets in your scene in Cinema 4D's Window menu bar > Project Asset Inspector."
+        )
+
+    # If we get here, save was successful
     # Get all files within the temp directory
     temp_assets = set()
     for root, _, files in os.walk(temp_dir):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I found that during submission using the bundle option, if there are missing assets then Cinema 4D's `c4d.documents.SaveProject` would return "False". In such a case, it would be nice to notify customers to fix their scene file. 

### What was the solution? (How)

In cases where we get "False" from `c4d.documents.SaveProject` we would show case this to customers so that they can fix their scene. 

### What is the impact of this change?

Better customer experience. 

### How was this change tested?

Ran this manually in both Mac and Windows and confirmed that it works. 

<img width="538" height="323" alt="image" src="https://github.com/user-attachments/assets/2fa8ecaf-77fb-444b-a1fb-25407a14284e" />


- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)

Yes 

```
test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 

=============================================================== slowest 5 durations =============================================================== 
485.82s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
114.62s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
90.62s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
88.79s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
83.58s call     test/integ/test_cinema4d.py::test_integ[redshift]
========================================================== 7 passed in 987.65s (0:16:27) =========================================================
```

- Have you made changes to the submitter?

Yes. But, there is no change required for `integ_test_helpers` due to this change. 

### Was this change documented?

This is customer experience improvement and does not require any doc changes. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*