### PR TITLE
test: Update integration test expectations for tile rendering support…

### DIFF
--- a/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
@@ -7,6 +7,8 @@ parameterValues:
   value: ''
 - name: ActivateErrorChecking
   value: '1'
+- name: TilesPerAxis
+  value: 2
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -54,6 +54,16 @@ parameterDefinitions:
   allowedValues:
   - '0'
   - '1'
+- name: TilesPerAxis
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles per axis
+    groupLabel: Tile Rendering Settings
+  minValue: 2
+  maxValue: 5
+  default: 2
+  description: The number of tiles across the x and y axis.
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
@@ -7,6 +7,8 @@ parameterValues:
   value: ''
 - name: ActivateErrorChecking
   value: '1'
+- name: TilesPerAxis
+  value: 2
 - name: MainFrames
   value: '1'
 - name: _0123456789abcdef0123456789abcdef0123456789abcdef012345678Frames

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -46,6 +46,16 @@ parameterDefinitions:
   allowedValues:
   - '0'
   - '1'
+- name: TilesPerAxis
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles per axis
+    groupLabel: Tile Rendering Settings
+  minValue: 2
+  maxValue: 5
+  default: 2
+  description: The number of tiles across the x and y axis.
 - name: MainFrames
   type: STRING
   userInterface:

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
@@ -7,6 +7,8 @@ parameterValues:
   value: ''
 - name: ActivateErrorChecking
   value: '1'
+- name: TilesPerAxis
+  value: 2
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -54,6 +54,16 @@ parameterDefinitions:
   allowedValues:
   - '0'
   - '1'
+- name: TilesPerAxis
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles per axis
+    groupLabel: Tile Rendering Settings
+  minValue: 2
+  maxValue: 5
+  default: 2
+  description: The number of tiles across the x and y axis.
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
@@ -7,6 +7,8 @@ parameterValues:
   value: ''
 - name: ActivateErrorChecking
   value: '1'
+- name: TilesPerAxis
+  value: 2
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -54,6 +54,16 @@ parameterDefinitions:
   allowedValues:
   - '0'
   - '1'
+- name: TilesPerAxis
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles per axis
+    groupLabel: Tile Rendering Settings
+  minValue: 2
+  maxValue: 5
+  default: 2
+  description: The number of tiles across the x and y axis.
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
@@ -7,6 +7,8 @@ parameterValues:
   value: ''
 - name: ActivateErrorChecking
   value: '1'
+- name: TilesPerAxis
+  value: 2
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -54,6 +54,16 @@ parameterDefinitions:
   allowedValues:
   - '0'
   - '1'
+- name: TilesPerAxis
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles per axis
+    groupLabel: Tile Rendering Settings
+  minValue: 2
+  maxValue: 5
+  default: 2
+  description: The number of tiles across the x and y axis.
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
@@ -7,6 +7,8 @@ parameterValues:
   value: ''
 - name: ActivateErrorChecking
   value: '1'
+- name: TilesPerAxis
+  value: 2
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -54,6 +54,16 @@ parameterDefinitions:
   allowedValues:
   - '0'
   - '1'
+- name: TilesPerAxis
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles per axis
+    groupLabel: Tile Rendering Settings
+  minValue: 2
+  maxValue: 5
+  default: 2
+  description: The number of tiles across the x and y axis.
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
@@ -11,6 +11,8 @@ parameterValues:
   value: ''
 - name: ActivateErrorChecking
   value: '1'
+- name: TilesPerAxis
+  value: 2
 - name: Frames
   value: '1'
 - name: CondaPackages

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -54,6 +54,16 @@ parameterDefinitions:
   allowedValues:
   - '0'
   - '1'
+- name: TilesPerAxis
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles per axis
+    groupLabel: Tile Rendering Settings
+  minValue: 2
+  maxValue: 5
+  default: 2
+  description: The number of tiles across the x and y axis.
 steps:
 - name: Main
   parameterSpace:


### PR DESCRIPTION
Fixes: *<https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/210>*

This PR is the 2nd of 2 PRs. It updates the expected job bundles in the integration tests to have TilePerAxis and tile rendering support. 
The 1st PR: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/256

### What was the problem/requirement? (What/Why)
Cinema 4D users need tile rendering support to efficiently render large images by breaking them into smaller tiles that can be processed in parallel, reducing memory usage and improving performance.

### What was the solution? (How)
*Added tile rendering configuration options to the Cinema 4D submitter UI
*Implemented a checkbox to enable/disable tile rendering
*Added a spinbox to configure the number of tiles per axis
*Integrated ffmpeg to automatically stitch rendered tiles back into a single output image
*Updated job template generation to include tile rendering parameters
<img width="537" height="675" alt="Tile_Rendering" src="https://github.com/user-attachments/assets/51a7e53d-3252-4e12-8f3d-33c8b246f37e" />

### What is the impact of this change?
*Users can now render large, high-resolution images more efficiently by splitting them into smaller tiles
*Improves performance by enabling parallel processing of image sections
*Maintains output quality with seamless stitching of tiles into a single final image
*This works for windows and linux

### How was this change tested?
*Verified correct job bundle generation with tile rendering parameters
*Tested tile rendering and stitching with various tile counts
*Validated that the final stitched output matches expected quality standards.
*Validated that the OutputPath and MultiPassPath are handled correctly since both can be selected with the same or different path leading to different asset-roots. If both OutputPath and MultiPassPath are selected then the outputs from both will be stitched. This leads to 2 stitched output images, one for the regular output and one for multi-pass outputs.
This can be seen in the image below. 
<img width="1074" height="574" alt="Screenshot 2025-07-17 at 5 08 28 PM" src="https://github.com/user-attachments/assets/d0b02b81-45cd-4479-a808-59b4ae6224d3" />

- Have you run the unit tests?
Yes.
0.07s call     test/unit/deadline_submitter_for_cinema4d/test_submitter.py::test_get_job_template
0.02s call     test/unit/deadline_submitter_for_cinema4d/test_scene.py::test_get_output_directores
0.02s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_on_cleanup::test_handle_errors_on_error_stdout[Project not found-True]
0.02s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_on_cleanup::test_handle_errors_on_error_stdout[Asset missing-True]
====================================================================================== 56 passed in 4.06s =====================

- Have you run the integration tests?
Yes.
424.53s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
93.59s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
77.01s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
74.80s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
73.91s call     test/integ/test_cinema4d.py::test_integ[redshift]
================================================================================ 7 passed in 849.37s (0:14:09) ===========================

- Have you made changes to the submitter?
Yes. I added a checkbox and a spinbox. The checkbox allows the job template to have the tile rendering support and the spinbox allows the tiles per axis information to be passed for ffmpeg. 


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*