### PR TITLE
fix: Reduce logging for path mapping.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_client.py
@@ -88,20 +88,17 @@ class Cinema4DClient(ClientInterface):
             # If submission was not from Mac (i.e. not posix source format), just do normal path mapping
             if not has_posix_format:
                 mapped_path = super().map_path(path)
-                print(f"Using normal path mapping (non-POSIX): '{path}' -> '{mapped_path}'")
                 return mapped_path
 
             print(
                 "Found POSIX format rule, converting path separators for Mac to Windows compatibility"
             )
-            print(f"Original path: '{path}'")
 
             # Convert backslashes to forward slashes for consistency with POSIX paths.
             # This is safe because:
             # 1. When submitting from Mac, backslashes can only appear as path separators
             # 2. Windows accepts both '\' and '/' as valid path separators
             converted_path = path.replace("\\", "/")
-            print(f"Converted path: '{converted_path}'")
 
             # Try path mapping with converted path
             mapped_path = super().map_path(converted_path)
@@ -109,9 +106,7 @@ class Cinema4DClient(ClientInterface):
             # If mapped path is the same as converted path, mapping failed
             # so try with original path instead
             if mapped_path == converted_path:
-                print("Path mapping with converted path failed (no rules matched)")
                 mapped_path = super().map_path(path)
-                print(f"Using original path mapping: '{path}' -> '{mapped_path}'")
                 return mapped_path
 
             print(f"Successfully mapped converted path: '{converted_path}' -> '{mapped_path}'")

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -77,10 +77,6 @@ class Cinema4DHandler:
             # whether we have done owner[param_id] = mapped_path
             attempted_basic_path_mapping_approach = False
             try:
-                print(
-                    f"Attempting to update path for asset with owner '{owner}', paramId '{param_id}', "
-                    f"new filename '{mapped_path}', nodeSpace '{node_space}', and nodePath '{node_path}'."
-                )
                 success = self._pathmap_recognized_types(
                     owner, param_id, node_space, node_path, mapped_path
                 )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We had verbose logging for path mapping that added noise to the logs leading to more confusion. 

### What was the solution? (How)

Some of the log lines are repeated (in the `map_path` function itself or not required for happy paths). Hence, removed those. 

### What is the impact of this change?

Less verbose logs. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
No (I only removed print statements so the core logic hasn't changed much). 

- Have you made changes to the submitter?
No

### Was this change documented?

Yes

### Is this a breaking change?

No, only changes the log lines. Does not impact the core logic. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*