### PR TITLE
fix: remap assets per session instead of per frame

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -241,7 +241,8 @@ For redshift licensing, set the environment variable by using `$env:redshift_LIC
    1. `set C4D_LOCATION=<Cinema 4D location>` on Windows Command or `$env:C4D_LOCATION = <Cinema 4D location>` on Windows Powershell.
       1. The default location for `Cinema 4D` on Windows is `C:\Program Files\Maxon Cinema 4D 2025\`. This location would be automatically used if the directory exists.
 2. For running the adaptor tests, we would need to install `pywin32` to the installation paths as its an adaptor dependency.
-   2.1 Run `pip install pywin32==308 -t <your Python site-packages location>`. 
-   During my testing, pywin32's version 308 was required because of other dependencies requiring this version.
+   2.1 Run `pip install pywin32==308 -t <your Python site-packages location>`
+       * e.g. `pip install pywin32==308 -t "C:\Program Files\Maxon Cinema 4D 2025\resource\modules\python\libs\win64\lib\site-packages"`
+   During testing, pywin32's version 308 was required because of other dependencies requiring this version.
 3. Run `hatch run integ:test`
 

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -199,7 +199,6 @@ class Cinema4DHandler:
         return True
 
     def start_render(self, data: dict) -> None:
-        self.doc = c4d.documents.GetActiveDocument()
         self.render_data = self.doc.GetActiveRenderData()
         self.render_data[c4d.RDATA_FRAMESEQUENCE] = c4d.RDATA_FRAMESEQUENCE_MANUAL
         frame = int(self.render_kwargs.get("frame", data["frame"]))
@@ -217,8 +216,6 @@ class Cinema4DHandler:
             self.render_data[c4d.RDATA_MULTIPASS_FILENAME] = self.map_path(
                 self.render_data[c4d.RDATA_MULTIPASS_FILENAME]
             )
-
-        self._remap_assets()
 
         bm = bitmaps.MultipassBitmap(
             int(self.render_data[c4d.RDATA_XRES]),
@@ -325,3 +322,5 @@ class Cinema4DHandler:
 
             c4d.documents.InsertBaseDocument(doc)
             c4d.documents.SetActiveDocument(doc)
+            self.doc = doc
+            self._remap_assets()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/259

### What was the problem/requirement? (What/Why)
Currently, path mapping is done once per task in the Cinema 4D integration. This is redundant because each task in a given session has the same assets. Instead, we should pathmap once per session. For users with many assets, this can save hours of render time.

### What was the solution? (How)
Move the asset remapping to the `set_scene_file` step, which is run once per session.

### What is the impact of this change?
Customers with short frame render times and many assets have reported that the path mapping time exceeds the actual render time! For them, this will result in hours of saved render time.

### How was this change tested?

I rebuilt this in a Conda package, resubmitted a job with globalized textures, and confirmed that it rendered correctly on Deadline Cloud service managed fleets.

- Have you run the unit tests?
Yes

- Have you made changes to the submitter?
No

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*