### PR TITLE
fix: Change allowedValues order to go with openjd checkbox specificat…

### DIFF
--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -53,8 +53,8 @@ parameterDefinitions:
   description: Fail when errors occur.
   default: '1'
   allowedValues:
-  - '0'
   - '1'
+  - '0'
 steps:
 - name: Render
   parameterSpace:

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -52,8 +52,8 @@ parameterDefinitions:
   description: Fail when errors occur.
   default: '1'
   allowedValues:
-  - '0'
   - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -44,8 +44,8 @@ parameterDefinitions:
   description: Fail when errors occur.
   default: '1'
   allowedValues:
-  - '0'
   - '1'
+  - '0'
 - name: MainFrames
   type: STRING
   userInterface:

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -52,8 +52,8 @@ parameterDefinitions:
   description: Fail when errors occur.
   default: '1'
   allowedValues:
-  - '0'
   - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -52,8 +52,8 @@ parameterDefinitions:
   description: Fail when errors occur.
   default: '1'
   allowedValues:
-  - '0'
   - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -52,8 +52,8 @@ parameterDefinitions:
   description: Fail when errors occur.
   default: '1'
   allowedValues:
-  - '0'
   - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -52,8 +52,8 @@ parameterDefinitions:
   description: Fail when errors occur.
   default: '1'
   allowedValues:
-  - '0'
   - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -52,8 +52,8 @@ parameterDefinitions:
   description: Fail when errors occur.
   default: '1'
   allowedValues:
-  - '0'
   - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Activate Automatic Error Checking checkbox uses "1" or "0" for checked and unchecked. However, currently if you resubmit a job in the DCM the checkbox will appear unchecked even though the setting states it should be checked. ("1"). 

### What was the solution? (How)
From [openjd specifications](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md#21-jobstringparameterdefinition): Valid pairs are ["true", "false"], ["yes", "no"], ["on", "off"], and ["1", "0"]. Currently, the job template lists the allowed values in the reverse order ["0", "1"]. For all valid pairs of allowed values, there is an expectation that each one follows the format [truthyValue, falseyValue]. This led to seeing the checkbox unchecked on the resubmit job page even though the setting signified that it should be checked. Overall, the solution is to reverse the order to "1" first and "0" second. 

### What is the impact of this change?
When you resubmit a job in the DCM the Activate Automatic Error Checking checkbox will reflect the correct checkbox state as set in the settings. 

### How was this change tested?
I submitted a job and made sure that if the setting is checked the resubmit job page in the DCM also had Activate Automatic Error Checking checked. I did the same for unchecked.

- Have you run the unit tests?
3s call     test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::test_adaptor_prints_version_on_init
0.03s call     test/unit/deadline_submitter_for_cinema4d/test_submitter.py::test_get_job_template
0.02s setup    test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_on_cleanup::test_handle_errors_on_error_stdout[Error rendering document-True]

- Have you run the integration tests? (Add your integration test report below)
431.37s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
95.28s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
91.75s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
83.22s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
81.37s call     test/integ/test_cinema4d.py::test_integ[redshift]
========================================================================== 7 passed in 893.64s (0:14:53) ================

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*