### PR TITLE
chore: Update Deadline Cloud dependency to 0.51.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.49.7",
+    "deadline >= 0.51.0,<0.52",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -14,6 +14,7 @@ from qtpy.QtCore import Qt  # type: ignore[attr-defined]
 
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
+from deadline.client.job_bundle.parameters import JobParameter
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
     JobBundlePurpose,
@@ -82,7 +83,7 @@ def show_submitter():
 
 def _get_parameter_values(
     settings: RenderSubmitterUISettings,
-    queue_parameters: list[dict[str, Any]],
+    queue_parameters: list[JobParameter],
     per_take_frames_parameters: bool,
     submit_takes: list[TakeData],
 ) -> list[dict[str, Any]]:
@@ -125,7 +126,7 @@ def _get_parameter_values(
 
     # If we're overriding the adaptor with wheels, remove deadline_cloud_for_cinema4d from the CondaPackages
     if settings.include_adaptor_wheels:
-        conda_param = {}
+        conda_param: Optional[JobParameter] = None
         # Find the CondaPackages parameter definition
         for param in queue_parameters:
             if param["name"] == "CondaPackages":
@@ -422,7 +423,7 @@ def create_job_bundle(
     takes: dict[str, list[TakeData]],
     job_bundle_dir: str,
     asset_references: AssetReferences,
-    queue_parameters: list[dict[str, Any]],
+    queue_parameters: list[JobParameter],
     attachments: AssetReferences,
     temp_dir: Optional[str] = None,
     host_requirements: Optional[dict] = None,
@@ -675,11 +676,11 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         widget: SubmitJobToDeadlineDialog,
         job_bundle_dir: str,
         settings: RenderSubmitterUISettings,
-        queue_parameters: list[dict[str, Any]],
+        queue_parameters: list[JobParameter],
         asset_references: AssetReferences,
         host_requirements: Optional[dict[str, Any]] = None,
         purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
-    ) -> None:
+    ) -> dict[str, Any]:
         """
         Callback function for creating a job bundle when submitting the job.
         """
@@ -693,6 +694,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
             temp_dir,
             host_requirements,
         )
+        return {}
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We need the latest `deadline-cloud` release so that we can use that to add features on our side. 

### What was the solution? (How)

The only change that we needed to do to use the latest changes was on the type hint changes for queue params from `dict` to a `JobParameter`. 

### What is the impact of this change?

No customer impact. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes. Its currently in progress. 

```
test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 
```

- Have you made changes to the submitter?
Yes, but this does not require any changes to the integration tests. Only type hint changes. 

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*