### PR TITLE
chore: update pyproject metadata to production

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 # https://pypi.org/classifiers/
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Cinema 4D integration is already production-grade, but the [PyPi metadata](https://pypi.org/project/deadline-cloud-for-cinema-4d/) doesn't reflect that. Updated the metadata.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*