### PR TITLE
ci: add pr labeling

### DIFF
--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,0 +1,31 @@
+name: On Opened PR
+
+on:
+  workflow_run:
+    workflows: ["Record PR"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  get-pr-details:
+    permissions:
+      actions: read # download PR artifact
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: aws-deadline/.github/.github/workflows/reusable_extract_pr_details.yml@mainline
+    with:
+      record_pr_workflow_id: ${{ github.event.workflow_run.id }}
+      artifact_name: "pr-info"
+      workflow_origin: ${{ github.repository }}
+
+  label-pr:
+    needs: get-pr-details
+    if: ${{ needs.get-pr-details.outputs.pr_action == 'opened' || needs.get-pr-details.outputs.pr_action == 'reopened' }}
+    uses: aws-deadline/.github/.github/workflows/reusable_label_pr.yml@mainline
+    with:
+      pr_number: ${{ needs.get-pr-details.outputs.pr_number }}
+      label_name: "waiting-on-maintainers"
+    permissions:
+      pull-requests: write

--- a/.github/workflows/record_pr.yml
+++ b/.github/workflows/record_pr.yml
@@ -1,0 +1,9 @@
+name: Record PR
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  call-record-workflow:
+    uses: aws-deadline/.github/.github/workflows/reusable_record_pr_details.yml@mainline


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to label and opened/re-opened PRs with `waiting-on-maintainers` this uses re-usable workflows merged here: https://github.com/aws-deadline/.github/pull/46

### What was the solution? (How)
Add two workflows:

1. record_pr.yml to obtain the pr details to get the pr number.
2. on_opened_pr.yml which is meant to run when PRs are opened or re-opened. We are adding the ability to add a label called `waiting-on-maintainers` here.

### What is the impact of this change?
Opened and Reopened PRs will get labeled

### How was this change tested?

Tested in a fork of deadline-cloud-for-blender:

* [Record PR](https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/16381206074)
* [On Opened PR](https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/16381215812)

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*