### PR TITLE
fix: use backslashes for Windows paths in submitter installer

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,7 +50,8 @@ from any directory of this repository:
 * `hatch shell` - Enter a shell environment that will have Python set up to import your development version of this package.
 * `hatch env prune` - Delete all of your isolated workspace [environments](https://hatch.pypa.io/1.12/environment/)
    for this package.
-* `hatch run installer:build-installer --local-dev --platform <PLATFORM> [--install-builder-path <LOCATION> --output-dir <DIR>]` - To build a local submitter installer. 
+* `hatch run installer:build-installer --local-dev --platform <PLATFORM> [--install-builder-path <LOCATION> --output-dir <DIR>]` - To build a local submitter installer.
+    * platform can be `windows` or `macos`
 * `hatch run test-installer` - To run tests against your locally built installer. 
 
 Note: Hatch uses [environments](https://hatch.pypa.io/1.12/environment/) to isolate the Python development workspace

--- a/install_builder/deadline-cloud-for-cinema-4d.xml
+++ b/install_builder/deadline-cloud-for-cinema-4d.xml
@@ -82,7 +82,17 @@
                 <setInstallerVariable name="cinema_4d_submitter_installdir" value="${installdir}"/>
             </actionList>
             <elseActionList>
-                <setInstallerVariable name="cinema_4d_submitter_installdir" value="${installdir}/Submitters/Cinema4D"/>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="windows"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="cinema_4d_submitter_installdir" value="${installdir}\Submitters\Cinema4D"/>
+                    </actionList>
+                    <elseActionList>
+                        <setInstallerVariable name="cinema_4d_submitter_installdir" value="${installdir}/Submitters/Cinema4D"/>
+                    </elseActionList>
+                </if>
             </elseActionList>
         </if>
     </readyToInstallActionList>
@@ -100,13 +110,13 @@
             <actionList>
                 <!-- Windows-specific actions -->
                 <createDirectory>
-                    <path>${cinema_4d_submitter_installdir}/cinema_4d_plugins</path>
+                    <path>${cinema_4d_submitter_installdir}\cinema_4d_plugins</path>
                     <ruleList>
-                        <fileTest condition="not_exists" path="${cinema_4d_submitter_installdir}/cinema_4d_plugins"/>
+                        <fileTest condition="not_exists" path="${cinema_4d_submitter_installdir}\cinema_4d_plugins"/>
                     </ruleList>
                 </createDirectory>
                 <copyFile>
-                    <destination>${cinema_4d_submitter_installdir}/cinema_4d_plugins/DeadlineCloud.pyp</destination>
+                    <destination>${cinema_4d_submitter_installdir}\cinema_4d_plugins\DeadlineCloud.pyp</destination>
                     <origin>${installdir}/tmp/c4d_deps/DeadlineCloud.pyp</origin>
                 </copyFile>
                 <fnAddPathEnvironmentVariable>
@@ -119,7 +129,7 @@
                 <fnAddPathEnvironmentVariable>
                     <progressText>Setting g_additionalModulePath</progressText>
                     <name>g_additionalModulePath</name>
-                    <value>${cinema_4d_submitter_installdir}/cinema_4d_plugins</value>
+                    <value>${cinema_4d_submitter_installdir}\cinema_4d_plugins</value>
                     <scope>${installscope}</scope>
                     <insertAt>end</insertAt>
                 </fnAddPathEnvironmentVariable>


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/272

### What was the problem/requirement? (What/Why)
The installer env variables use forward slashes instead of backslashes on Windows, leading to unexpected environment variable values. 

### What was the solution? (How)
Updated the env vars to use backslashes on Windows.

### How was this change tested?
`hatch run installer:build-installer --local-dev --platform windows`

Ran the `DeadlineCloudSubmitterForCinema4D.exe` in the following scenarios:
* User install over an existing user install: successfully submitted a job
* User install after previous installed removed: successfully submitted a job
* System install after previous install removed: successfully submitted a job (requires permission updates to the installation folder to allow installing the GUI modules)
* System install over an existing system install: successfully submitted a job
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*