### PR TITLE
fix: upgrade deadline version to fix bug where submitter stays open after submission

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.51.0,<0.52",
+    "deadline >= 0.51.1,<0.52",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Cinema 4D submitter was previously staying open after job submission due to a Deadline Cloud library bug. That has been fixed [here](https://github.com/aws-deadline/deadline-cloud/pull/779). Updated the minimum required version to pull in the fix.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*