### PR TITLE
chore: set allow_zero_version = true for semantic release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ show_missing = true
 fail_under = 23
 
 [tool.semantic_release]
+allow_zero_version = true
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Per @karthikbekalp's comment on https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/224
> We need to to add allow_zero_version = true to all the pyproject.toml files under tool.semantic_release before we merge this PR.

https://github.com/python-semantic-release/python-semantic-release/commit/c6b6eabbfe100d2c741620eb3fa12a382531fa94

### What was the solution? (How)
Added it!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*