### PR TITLE
feat: Implement font handling for Cinema 4D submitter for Windows.

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -11,3 +11,4 @@ types-pyyaml == 6.*
 numpy == 2.*
 pillow == 11.*
 openjd-cli == 0.7.*
+fonttools >= 4.0.0

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -22,7 +22,20 @@ def has_gui_deps():
     return True
 
 
-def install_gui():
+def has_fonttools():
+    try:
+        import fontTools  # noqa
+    except ImportError:
+        return False
+    return True
+
+
+def _install_packages(packages, description):
+    """Helper function to install packages using Cinema 4D's python.
+
+    We are working on bundling these dependencies in the submitter.
+    But for now, its ok to install using pip install.
+    """
     c4d_app = sys.executable
 
     c4d_executable = "Cinema 4D.exe"
@@ -32,7 +45,7 @@ def install_gui():
         c4d_executable = "Cinema 4D.app/Contents/MacOS/Cinema 4D"
         python_location = "resource/modules/python/libs/python311.macos.framework/python"
 
-    # We want to install the GUI components using Cinema 4D's python.
+    # We want to install packages using Cinema 4D's python.
     c4d_python = c4d_app.replace(c4d_executable, python_location)
 
     # install pip if needed - C4D python doesn't come with it installed by default
@@ -43,27 +56,36 @@ def install_gui():
     ]
     subprocess.run(ensurepip_command, check=False)
 
-    import deadline.client
-
-    deadline_gui_install_command = [
+    install_command = [
         c4d_python,
         "-m",
         "pip",
         "install",
-        f"deadline[gui]=={deadline.client.version}",
-    ]
+    ] + packages
 
     # module_directory assumes relative install location of:
     #   * [installdir]/Submitters/Cinema4D/deadline/cinema4d_submitter/cinema4d_render_submitter.py
     module_directory = Path(__file__).parent.parent.parent
     if module_directory.exists():
-        _logger.info(f"Missing GUI libraries, installing deadline[gui] to {module_directory}")
-        deadline_gui_install_command.extend(["--target", str(module_directory)])
+        _logger.info(f"Missing {description}, installing to {module_directory}")
+        install_command.extend(["--target", str(module_directory)])
     else:
         _logger.info(
-            "Missing GUI libraries with non-standard set-up, installing deadline[gui] into Cinema 4D's python"
+            f"Missing {description} with non-standard set-up, installing into Cinema 4D's python"
         )
-    subprocess.run(deadline_gui_install_command, check=False)
+    subprocess.run(install_command, check=False)
+
+
+def install_gui():
+    import deadline.client
+
+    packages = [f"deadline[gui]=={deadline.client.version}"]
+    _install_packages(packages, "GUI libraries")
+
+
+def install_fonttools():
+    packages = ["fonttools"]
+    _install_packages(packages, "fonttools")
 
 
 if not has_gui_deps():
@@ -74,6 +96,16 @@ if not has_gui_deps():
     else:
         c4d.gui.MessageDialog(
             "Did not install GUI components, the AWS Deadline Cloud extension will fail with qtpy bindings errors."
+        )
+
+if not has_fonttools():
+    if c4d.gui.QuestionDialog(
+        "The AWS Deadline Cloud extension needs fonttools to work properly. Press Yes to install."
+    ):
+        install_fonttools()
+    else:
+        c4d.gui.MessageDialog(
+            "Did not install fonttools, some font-related functionality may not work properly."
         )
 
 from .cinema4d_render_submitter import show_submitter  # noqa: E402

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import c4d
 
 from .scene import Scene
+from .font_utils import is_asset_a_font, copy_font_to_scene_folder
 
 _FRAME_RE = re.compile("#+")
 
@@ -22,15 +23,36 @@ class AssetIntrospector:
         """
         # Grab tx files (if we need to)
         assets: set[Path] = set()
-        assets.add(Path(Scene.name()))
+
+        path_to_scene_file = Path(Scene.name())
+        path_to_scene_file_dir = path_to_scene_file.parent
+        assets.add(path_to_scene_file)
 
         doc = c4d.documents.GetActiveDocument()
         asset_list: list[dict] = []
-        c4d.documents.GetAllAssetsNew(doc, allowDialogs=False, lastPath="", assetList=asset_list)
+
+        c4d.documents.GetAllAssetsNew(
+            doc,
+            allowDialogs=False,
+            lastPath="",
+            assetList=asset_list,
+            flags=c4d.ASSETDATA_FLAG_WITHFONTS,
+        )
+
         for asset in asset_list:
+            if is_asset_a_font(asset):
+                copy_font_to_scene_folder(asset["assetname"], path_to_scene_file_dir)
+
             filename = asset.get("filename", None)
             exists = asset.get("exists", False)
             if exists is True and filename is not None:
                 assets.add(Path(filename))
+
+        # Add all font files from the tempFonts directory to assets
+        fonts_dir = path_to_scene_file_dir / "tempFonts"
+        if fonts_dir.exists():
+            for font_file in fonts_dir.iterdir():
+                if font_file.is_file():
+                    assets.add(font_file)
 
         return assets

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import c4d
 
 from .scene import Scene
-from .font_utils import is_asset_a_font, copy_font_to_scene_folder
+from .font_utils import is_asset_a_font, copy_font_to_scene_folder, TEMP_FONTS_DIR
 
 _FRAME_RE = re.compile("#+")
 
@@ -49,7 +49,7 @@ class AssetIntrospector:
                 assets.add(Path(filename))
 
         # Add all font files from the tempFonts directory to assets
-        fonts_dir = path_to_scene_file_dir / "tempFonts"
+        fonts_dir = path_to_scene_file_dir / TEMP_FONTS_DIR
         if fonts_dir.exists():
             for font_file in fonts_dir.iterdir():
                 if font_file.is_file():

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
+import shutil
+
 import c4d
 import yaml  # type: ignore[import]
 from qtpy import QtWidgets
@@ -26,6 +28,7 @@ from .assets import AssetIntrospector
 from .data_classes import (
     RenderSubmitterUISettings,
 )
+from .font_utils import scene_has_fonts, get_font_manager_environment
 from .scene import Animation, Scene
 from .style import C4D_STYLE
 from .takes import TakeSelection
@@ -278,6 +281,13 @@ def _get_job_template(
         if "jobEnvironments" not in job_template:
             job_template["jobEnvironments"] = []
         job_template["jobEnvironments"].append(override_environment["environment"])
+
+    # Conditionally add FontManager job environment if fonts are detected
+    if adaptor and scene_has_fonts(Path(Scene.name()).parent):
+        font_manager_environment = get_font_manager_environment()
+        if "jobEnvironments" not in job_template:
+            job_template["jobEnvironments"] = []
+        job_template["jobEnvironments"].append(font_manager_environment)
 
     add_timeouts_to_job_template(job_template, settings.timeouts)
 
@@ -625,7 +635,14 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
         temp_dir: Path to the temporary directory
         asset_references: Asset references to update
     """
+
     doc = c4d.documents.GetActiveDocument()
+
+    # Get the original scene file path BEFORE the temp export
+    # This is crucial because Scene.name() will change after SaveProject
+    original_scene_file_path = Path(Scene.name())
+    original_scene_dir = original_scene_file_path.parent
+    original_fonts_dir = original_scene_dir / "tempFonts"
 
     # Save the project to the temporary directory
     temp_file_path = os.path.join(temp_dir, doc.GetDocumentName())
@@ -642,9 +659,26 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
             "Exporting the scene failed. Please fix all the paths for your assets in your scene in Cinema 4D's Window menu bar > Project Asset Inspector."
         )
 
+    temp_fonts_dir = Path(Scene.name()).parent / "tempFonts"
+
+    # Copy fonts from the original scene's tempFonts directory to the temp directory
+
+    if original_fonts_dir.exists() and original_fonts_dir.is_dir():
+        # Create the tempFonts directory in the temp location
+        temp_fonts_dir.mkdir(exist_ok=True, parents=True)
+
+        # Copy all font files from the original tempFonts directory
+        copied_fonts = []
+        for font_file in original_fonts_dir.iterdir():
+            if font_file.is_file():
+                destination = temp_fonts_dir / font_file.name
+                shutil.copy2(font_file, destination)
+                copied_fonts.append(font_file.name)
+
     # If we get here, save was successful
     # Get all files within the temp directory
     temp_assets = set()
+
     for root, _, files in os.walk(temp_dir):
         for file in files:
             file_path = os.path.join(root, file)

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -668,12 +668,10 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
         temp_fonts_dir.mkdir(exist_ok=True, parents=True)
 
         # Copy all font files from the original tempFonts directory
-        copied_fonts = []
         for font_file in original_fonts_dir.iterdir():
             if font_file.is_file():
                 destination = temp_fonts_dir / font_file.name
                 shutil.copy2(font_file, destination)
-                copied_fonts.append(font_file.name)
 
     # If we get here, save was successful
     # Get all files within the temp directory

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -15,6 +15,8 @@ from typing import Set, Tuple
 _TEMP_FONTS_DIR = "tempFonts"
 
 if sys.platform == "win32":
+    from ctypes import wintypes
+
     try:
         import winreg
     except ImportError:
@@ -27,6 +29,7 @@ else:
     winreg = None  # type: ignore
     user32 = None  # type: ignore
     gdi32 = None  # type: ignore
+    wintypes = None  # type: ignore
 
 FONTS_REG_PATH = r"Software\Microsoft\Windows NT\CurrentVersion\Fonts"
 
@@ -106,12 +109,12 @@ def get_font_name(dst_path: str) -> str:
     fontname = os.path.splitext(filename)[0]
 
     # Try to get the font's real name
-    cb = ctypes.wintypes.DWORD()
+    cb = wintypes.DWORD()
     if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), None, GFRI_DESCRIPTION):
         buf = (ctypes.c_wchar * cb.value)()
         if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION):
             fontname = buf.value
-    is_truetype = ctypes.wintypes.BOOL()
+    is_truetype = wintypes.BOOL()
     cb.value = ctypes.sizeof(is_truetype)
     gdi32.GetFontResourceInfoW(
         filename, ctypes.byref(cb), ctypes.byref(is_truetype), GFRI_ISTRUETYPE

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -12,6 +12,8 @@ import sys
 import traceback
 from typing import Set, Tuple
 
+_TEMP_FONTS_DIR = "tempFonts"
+
 if sys.platform == "win32":
     try:
         import winreg
@@ -67,13 +69,13 @@ def find_fonts(session_dir: str) -> Set[str]:
         full_sub_dir = None
         for path, dirs, files in os.walk(asset_dir):
             for d in dirs:
-                if "tempFonts" in d:
+                if _TEMP_FONTS_DIR in d:
                     full_sub_dir = os.path.join(path, d)
                     logger.debug(f"tempFonts directory: {full_sub_dir}")
                     break
 
         if not full_sub_dir:
-            logger.debug(f"Couldn't recursively find tempFonts in subfolder: {subfolder}")
+            logger.debug(f"Couldn't recursively find {_TEMP_FONTS_DIR} in subfolder: {subfolder}")
             continue
 
         for file_name in os.listdir(full_sub_dir):
@@ -84,7 +86,7 @@ def find_fonts(session_dir: str) -> Set[str]:
                 fonts.add(full_assetpath)
             else:
                 logger.warning(
-                    f"A file that is not a supported font was found in the tempFonts folder: {full_assetpath}"
+                    f"A file that is not a supported font was found in the {_TEMP_FONTS_DIR} folder: {full_assetpath}"
                 )
     return fonts
 
@@ -100,26 +102,22 @@ def get_font_name(dst_path: str) -> str:
     if sys.platform != "win32":
         raise RuntimeError("Font installation is only supported on Windows")
 
-    try:
-        filename = os.path.basename(dst_path)
-        fontname = os.path.splitext(filename)[0]
+    filename = os.path.basename(dst_path)
+    fontname = os.path.splitext(filename)[0]
 
-        # Try to get the font's real name
-        cb = ctypes.wintypes.DWORD()
-        if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), None, GFRI_DESCRIPTION):
-            buf = (ctypes.c_wchar * cb.value)()
-            if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION):
-                fontname = buf.value
-        is_truetype = ctypes.wintypes.BOOL()
-        cb.value = ctypes.sizeof(is_truetype)
-        gdi32.GetFontResourceInfoW(
-            filename, ctypes.byref(cb), ctypes.byref(is_truetype), GFRI_ISTRUETYPE
-        )
-        if is_truetype:
-            fontname += " (TrueType)"
-
-    except Exception as e:
-        raise e
+    # Try to get the font's real name
+    cb = ctypes.wintypes.DWORD()
+    if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), None, GFRI_DESCRIPTION):
+        buf = (ctypes.c_wchar * cb.value)()
+        if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION):
+            fontname = buf.value
+    is_truetype = ctypes.wintypes.BOOL()
+    cb.value = ctypes.sizeof(is_truetype)
+    gdi32.GetFontResourceInfoW(
+        filename, ctypes.byref(cb), ctypes.byref(is_truetype), GFRI_ISTRUETYPE
+    )
+    if is_truetype:
+        fontname += " (TrueType)"
 
     return fontname
 
@@ -230,8 +228,7 @@ def _install_fonts(session_dir: str) -> None:
     fonts = find_fonts(session_dir)
 
     if not fonts:
-        logger.info("No custom fonts found, continuing task...")
-        return
+        raise RuntimeError("No custom fonts found")
     for font in fonts:
         logger.info("Installing font: " + font)
         installed, msg = install_font(font)

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -151,6 +151,11 @@ def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool, 
             registry_scope = winreg.HKEY_CURRENT_USER
         dst_path = os.path.join(dst_dir, os.path.basename(src_path))
 
+        # Check if font already exists at destination
+        if os.path.exists(dst_path):
+            logger.info(f"Font already exists at {dst_path}, skipping installation")
+            return True, ""
+
         # Copy the font to the Windows Fonts folder
         shutil.copy(src_path, dst_path)
 

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -13,8 +13,6 @@ import traceback
 from typing import Set, Tuple
 
 if sys.platform == "win32":
-    from ctypes import wintypes
-
     try:
         import winreg
     except ImportError:
@@ -27,7 +25,6 @@ else:
     winreg = None  # type: ignore
     user32 = None  # type: ignore
     gdi32 = None  # type: ignore
-    wintypes = None  # type: ignore
 
 FONTS_REG_PATH = r"Software\Microsoft\Windows NT\CurrentVersion\Fonts"
 
@@ -108,12 +105,12 @@ def get_font_name(dst_path: str) -> str:
         fontname = os.path.splitext(filename)[0]
 
         # Try to get the font's real name
-        cb = wintypes.DWORD()
+        cb = ctypes.wintypes.DWORD()
         if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), None, GFRI_DESCRIPTION):
             buf = (ctypes.c_wchar * cb.value)()
             if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION):
                 fontname = buf.value
-        is_truetype = wintypes.BOOL()
+        is_truetype = ctypes.wintypes.BOOL()
         cb.value = ctypes.sizeof(is_truetype)
         gdi32.GetFontResourceInfoW(
             filename, ctypes.byref(cb), ctypes.byref(is_truetype), GFRI_ISTRUETYPE

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -1,0 +1,286 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Utility functions for the handling of fonts
+"""
+
+import ctypes
+import logging
+import os
+import shutil
+import sys
+import traceback
+from typing import Set, Tuple
+
+if sys.platform == "win32":
+    from ctypes import wintypes
+
+    try:
+        import winreg
+    except ImportError:
+        import _winreg as winreg  # type: ignore
+
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    gdi32 = ctypes.WinDLL("gdi32", use_last_error=True)
+else:
+    # Stub for non-Windows platforms
+    winreg = None  # type: ignore
+    user32 = None  # type: ignore
+    gdi32 = None  # type: ignore
+    wintypes = None  # type: ignore
+
+FONTS_REG_PATH = r"Software\Microsoft\Windows NT\CurrentVersion\Fonts"
+
+HWND_BROADCAST = 0xFFFF
+SMTO_ABORTIFHUNG = 0x0002
+WM_FONTCHANGE = 0x001D
+GFRI_DESCRIPTION = 1
+GFRI_ISTRUETYPE = 3
+
+INSTALL_SCOPE_USER = "USER"
+INSTALL_SCOPE_SYSTEM = "SYSTEM"
+
+FONT_LOCATION_SYSTEM = os.path.join(os.environ.get("SystemRoot", "C:\\Windows"), "Fonts")
+FONT_LOCATION_USER = os.path.join(
+    os.environ.get("LocalAppData", ""), "Microsoft", "Windows", "Fonts"
+)
+
+# Font extensions supported in gdi32.AddFontResourceW
+# OpenType fonts without an extension can also be installed (e.g. Adobe Fonts)
+FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
+
+logger = logging.getLogger(__name__)
+
+
+def find_fonts(session_dir: str) -> Set[str]:
+    """
+    Looks for all font files that were sent along with the job
+
+    :param session_dir: the root folder in which to look for files
+
+    :returns: a set with all found fonts
+    """
+    fonts = set()
+    for subfolder in os.listdir(session_dir):
+        # Only look in assetroot folders
+        if not subfolder.startswith("assetroot-"):
+            continue
+        # Look for the tempFonts folder
+        asset_dir = os.path.join(session_dir, subfolder)
+        full_sub_dir = None
+        for path, dirs, files in os.walk(asset_dir):
+            for d in dirs:
+                if "tempFonts" in d:
+                    full_sub_dir = os.path.join(path, d)
+                    logger.debug(f"tempFonts directory: {full_sub_dir}")
+                    break
+
+        if not full_sub_dir:
+            logger.debug(f"Couldn't recursively find tempFonts in subfolder: {subfolder}")
+            continue
+
+        for file_name in os.listdir(full_sub_dir):
+            full_assetpath = os.path.join(full_sub_dir, file_name)
+            _, ext = os.path.splitext(full_assetpath)
+            if ext.lower() in FONT_EXTENSIONS:
+                logger.debug(f"Adding: {full_assetpath}")
+                fonts.add(full_assetpath)
+            else:
+                logger.warning(
+                    f"A file that is not a supported font was found in the tempFonts folder: {full_assetpath}"
+                )
+    return fonts
+
+
+def get_font_name(dst_path: str) -> str:
+    """
+    Get a font's Windows system name, which is the name stored in the registry.
+
+    :param dst_path: path of font that needs to be named
+
+    :returns: string with the font's name
+    """
+    if sys.platform != "win32":
+        raise RuntimeError("Font installation is only supported on Windows")
+
+    try:
+        filename = os.path.basename(dst_path)
+        fontname = os.path.splitext(filename)[0]
+
+        # Try to get the font's real name
+        cb = wintypes.DWORD()
+        if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), None, GFRI_DESCRIPTION):
+            buf = (ctypes.c_wchar * cb.value)()
+            if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION):
+                fontname = buf.value
+        is_truetype = wintypes.BOOL()
+        cb.value = ctypes.sizeof(is_truetype)
+        gdi32.GetFontResourceInfoW(
+            filename, ctypes.byref(cb), ctypes.byref(is_truetype), GFRI_ISTRUETYPE
+        )
+        if is_truetype:
+            fontname += " (TrueType)"
+
+    except Exception as e:
+        raise e
+
+    return fontname
+
+
+def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool, str]:
+    """
+    Install provided font to the worker machine
+
+    :param src_path: path of font that needs to be installed
+
+    :returns: boolean that represents if the font was installed and a string with any traceback that was created
+    """
+    if sys.platform != "win32":
+        return False, "Font installation is only supported on Windows"
+
+    try:
+        # Determine font destination
+        if scope == INSTALL_SCOPE_SYSTEM:
+            dst_dir = FONT_LOCATION_SYSTEM
+            registry_scope = winreg.HKEY_LOCAL_MACHINE
+        else:
+            # Check if the Fonts folder exists, create it if it doesn't
+            if not os.path.exists(FONT_LOCATION_USER):
+                logger.info(f"Creating User Fonts folder: {FONT_LOCATION_USER}")
+                os.makedirs(FONT_LOCATION_USER)
+
+            dst_dir = FONT_LOCATION_USER
+            registry_scope = winreg.HKEY_CURRENT_USER
+        dst_path = os.path.join(dst_dir, os.path.basename(src_path))
+
+        # Copy the font to the Windows Fonts folder
+        shutil.copy(src_path, dst_path)
+
+        # Load the font in the current session, remove font when loading fails
+        if not gdi32.AddFontResourceW(dst_path):
+            os.remove(dst_path)
+            raise OSError(f'AddFontResource failed to load "{src_path}"')
+
+        # Notify running programs
+        user32.SendMessageTimeoutW(
+            HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None
+        )
+
+        # Store the fontname/filename in the registry
+        filename = os.path.basename(dst_path)
+        fontname = get_font_name(dst_path)
+
+        # Creates registry if it doesn't exist, opens when it does exist
+        with winreg.CreateKeyEx(
+            registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE
+        ) as key:
+            winreg.SetValueEx(key, fontname, 0, winreg.REG_SZ, filename)
+    except Exception:
+        return False, traceback.format_exc()
+    return True, ""
+
+
+def uninstall_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool, str]:
+    """
+    Uninstall provided font from the worker machine
+
+    :param src_path: path of font that needs to be removed
+
+    :returns: boolean that represents if the font was uninstalled and a string with any traceback that was created
+    """
+    if sys.platform != "win32":
+        return False, "Font uninstallation is only supported on Windows"
+
+    try:
+        # Determine where the font was installed
+        if scope == INSTALL_SCOPE_SYSTEM:
+            dst_path = os.path.join(FONT_LOCATION_SYSTEM, os.path.basename(src_path))
+            registry_scope = winreg.HKEY_LOCAL_MACHINE
+        else:
+            dst_path = os.path.join(FONT_LOCATION_USER, os.path.basename(src_path))
+            registry_scope = winreg.HKEY_CURRENT_USER
+
+        # Remove the fontname/filename from the registry
+        fontname = get_font_name(dst_path)
+
+        with winreg.OpenKey(registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE) as key:
+            winreg.DeleteValue(key, fontname)
+
+        # Unload the font in the current session
+        if not gdi32.RemoveFontResourceW(dst_path):
+            os.remove(dst_path)
+            raise OSError(f'RemoveFontResourceW failed to load "{src_path}"')
+
+        if os.path.exists(dst_path):
+            os.remove(dst_path)
+
+        # Notify running programs
+        user32.SendMessageTimeoutW(
+            HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None
+        )
+    except Exception:
+        return False, traceback.format_exc()
+    return True, ""
+
+
+def _install_fonts(session_dir: str) -> None:
+    """
+    Calls all needed functions for installing fonts
+
+    :param session_dir: directory of the session
+    """
+    logger.info("Looking for fonts to install...")
+    fonts = find_fonts(session_dir)
+
+    if not fonts:
+        logger.info("No custom fonts found, continuing task...")
+        return
+    for font in fonts:
+        logger.info("Installing font: " + font)
+        installed, msg = install_font(font)
+        if not installed:
+            raise RuntimeError(f"Error installing font: {msg}")
+
+
+def _remove_fonts(session_dir: str) -> None:
+    """
+    Calls all needed functions for removing fonts
+
+    :param session_dir: directory of the session
+    """
+    logger.info("Looking for fonts to uninstall...")
+    fonts = find_fonts(session_dir)
+
+    if not fonts:
+        logger.info("No custom fonts found, finishing task...")
+        return
+
+    for font in fonts:
+        logger.info("Uninstalling font: " + font)
+        removed, msg = uninstall_font(font)
+        if not removed:
+            # Don't fail task if font didn't get uninstalled
+            logger.error(f"Error uninstalling font: {msg}")
+
+
+def setup_logger() -> None:
+    """
+    Does a basic setup for a logger
+    """
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(levelname)s:%(message)s")
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+
+if __name__ == "__main__":
+    setup_logger()
+    session_dir = sys.argv[2]
+
+    logger.debug(f"Running font script job: {sys.argv[1]}")
+
+    if sys.argv[1] == "install":
+        _install_fonts(session_dir)
+    if sys.argv[1] == "remove":
+        _remove_fonts(session_dir)

--- a/src/deadline/cinema4d_submitter/font_utils.py
+++ b/src/deadline/cinema4d_submitter/font_utils.py
@@ -1,0 +1,260 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import c4d
+import os
+import platform
+import shutil
+from pathlib import Path
+from typing import Optional, List, Any
+
+
+class FontNotFoundError(Exception):
+    """Exception raised when a font cannot be found in the system."""
+
+    pass
+
+
+def is_asset_a_font(asset: dict) -> bool:
+    """
+    Check if Cinema 4D considers the asset is a font.
+
+    """
+    pid: int = asset.get("paramId", c4d.NOTOK)
+    owner: Optional[c4d.BaseList2D] = asset.get("owner", None)
+    if pid == c4d.NOTOK or owner is None:
+        return False
+    # We check the type of the parameter value.
+    # If it is a FontData, we assume it is a font asset.
+    value = owner.GetParameter(pid, c4d.DESCFLAGS_GET_NONE)
+    return isinstance(value, c4d.FontData)
+
+
+def get_font_location(font_name: str) -> Optional[str]:
+    """
+    Scan font directories for Windows and Mac to find the location of a font.
+
+    Args:
+        font_name (str): Name of the font to find
+
+    Returns:
+        Optional[str]: Path to the font file if found, None otherwise
+    """
+    # Get system font directories based on the operating system
+    font_dirs = get_system_font_directories()
+
+    # Search for the font in all font directories
+    for font_dir in font_dirs:
+        try:
+            for root, _, files in os.walk(font_dir):
+                for file in files:
+                    # Check if the font name is in the file name (case-insensitive)
+                    if font_name.lower() in file.lower():
+                        file_path = os.path.join(root, file)
+                        # Check if it's a font file by extension and exists
+                        if is_font_file(file_path) and os.path.isfile(file_path):
+                            return file_path
+        except (PermissionError, OSError) as e:
+            print(f"[ERROR] Cannot access font directory {font_dir}: {e}")
+            continue
+
+    return None
+
+
+def get_system_font_directories() -> List[str]:
+    """
+    Get the font directories based on the operating system.
+    Includes Adobe font directories and user-installed fonts.
+
+    Returns:
+        List[str]: List of font directory paths
+    """
+    system = platform.system()
+    font_dirs = []
+
+    if system == "Windows":
+        # Windows font directories
+        windir = os.environ.get("WINDIR", r"C:\Windows")
+        localappdata = os.environ.get("LOCALAPPDATA")
+        appdata = os.environ.get("APPDATA")
+
+        # System fonts
+        font_dirs = [os.path.join(windir, "Fonts")]
+
+        # User-installed fonts
+        if localappdata:
+            user_fonts_dir = os.path.join(localappdata, "Microsoft", "Windows", "Fonts")
+            font_dirs.append(user_fonts_dir)
+
+        # Adobe fonts
+        if appdata:
+            adobe_livetype = os.path.join(appdata, "Adobe", "CoreSync", "plugins", "livetype")
+            adobe_user_fonts = os.path.join(appdata, "Adobe", "User Owned Fonts")
+            font_dirs.extend([adobe_livetype, adobe_user_fonts])
+
+    elif system == "Darwin":  # macOS
+        # macOS font directories
+        font_dirs = [
+            "/Library/Fonts",
+            "/System/Library/Fonts",
+            os.path.expanduser("~/Library/Fonts"),
+        ]
+
+        # Adobe fonts on macOS
+        adobe_livetype = os.path.expanduser(
+            "~/Library/Application Support/Adobe/CoreSync/plugins/livetype"
+        )
+        adobe_user_fonts = os.path.expanduser(
+            "~/Library/Application Support/Adobe/User Owned Fonts"
+        )
+        font_dirs.extend([adobe_livetype, adobe_user_fonts])
+
+    else:
+        print(f"[ERROR] Unknown operating system: {system}")
+
+    # Filter out directories that don't exist
+    return [d for d in font_dirs if d and os.path.isdir(d)]
+
+
+def is_font_file(file_path: str) -> bool:
+    """
+    Check if a file is a font file based on its extension.
+
+    Args:
+        file_path (str): Path to the file
+
+    Returns:
+        bool: True if the file is a font file, False otherwise
+    """
+    if not file_path:
+        return False
+
+    # Adobe fonts do not have an extension.
+    font_extensions = [".otf", ".ttf", ".fon", ""]
+    return any(file_path.lower().endswith(ext) for ext in font_extensions)
+
+
+def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
+    """
+    Copy a font to the fonts folder within the scene location.
+
+    Args:
+        font_name (str): Name of the font to copy
+        scene_location (Path): Path to the scene location
+
+    Raises:
+        FontNotFoundError: If the font cannot be found in system font directories
+        RuntimeError: If there's an error during the copy operation
+    """
+    if not font_name or not font_name.strip():
+        raise ValueError("Font name cannot be empty")
+
+    if not scene_location or not scene_location.exists():
+        raise ValueError(f"Scene location does not exist: {scene_location}")
+
+    # Get the font's location
+    font_location = get_font_location(font_name.strip())
+
+    if font_location is None:
+        raise FontNotFoundError(f"Font '{font_name}' not found in system font directories")
+
+    # Create the tempFonts directory within the scene location if it doesn't exist
+    fonts_dir = scene_location / "tempFonts"
+
+    try:
+        fonts_dir.mkdir(exist_ok=True, parents=True)
+    except OSError as e:
+        raise RuntimeError(f"Failed to create fonts directory '{fonts_dir}': {str(e)}")
+
+    # Copy the font file to the fonts directory
+    font_file_name = os.path.basename(font_location)
+    destination = fonts_dir / font_file_name
+
+    # Check if font already exists in destination
+    if destination.exists():
+        # Verify it's the same file by comparing sizes
+        try:
+            if destination.stat().st_size == os.path.getsize(font_location):
+                return
+        except OSError:
+            # If we can't check the file, proceed with copy to be safe
+            pass
+
+    try:
+        shutil.copy2(font_location, destination)
+    except (OSError, IOError, shutil.Error) as e:
+        print(f"[ERROR] Copy operation failed: {e}")
+        raise RuntimeError(
+            f"Error copying font '{font_name}' from '{font_location}' to '{destination}': {str(e)}"
+        )
+
+
+def scene_has_fonts(scene_location: Path) -> bool:
+    """
+    Check if a scene has fonts by looking for the tempFonts directory and its contents.
+
+    Args:
+        scene_location (Path): Path to the scene location
+
+    Returns:
+        bool: True if fonts are found, False otherwise
+    """
+    if not scene_location or not scene_location.exists():
+        return False
+
+    fonts_dir = scene_location / "tempFonts"
+
+    # Check if tempFonts directory exists and has font files
+    if fonts_dir.exists() and fonts_dir.is_dir():
+        for font_file in fonts_dir.iterdir():
+            if font_file.is_file() and is_font_file(str(font_file)):
+                return True
+
+    return False
+
+
+def get_font_manager_environment() -> dict[str, Any]:
+    """
+    Returns the FontManager job environment definition.
+
+    Returns:
+        dict[str, Any]: The FontManager job environment configuration
+    """
+    # Read the font installer script from file
+    font_installer_path = Path(__file__).parent / "font_installer.py"
+    with open(font_installer_path, "r", encoding="utf-8") as f:
+        font_installer_script = f.read()
+
+    return {
+        "name": "FontManager",
+        "description": "Manages font installation and cleanup for Cinema4D rendering.",
+        "script": {
+            "embeddedFiles": [
+                {
+                    "name": "fontInstaller",
+                    "filename": "font_installer.py",
+                    "type": "TEXT",
+                    "data": font_installer_script,
+                }
+            ],
+            "actions": {
+                "onEnter": {
+                    "command": "python",
+                    "args": [
+                        "{{Env.File.fontInstaller}}",
+                        "install",
+                        "{{Session.WorkingDirectory}}",
+                    ],
+                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                },
+                "onExit": {
+                    "command": "python",
+                    "args": [
+                        "{{Env.File.fontInstaller}}",
+                        "remove",
+                        "{{Session.WorkingDirectory}}",
+                    ],
+                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                },
+            },
+        },
+    }

--- a/src/deadline/cinema4d_submitter/font_utils.py
+++ b/src/deadline/cinema4d_submitter/font_utils.py
@@ -7,6 +7,8 @@ import shutil
 from pathlib import Path
 from typing import Optional, List, Any
 
+TEMP_FONTS_DIR = "tempFonts"
+
 
 class FontNotFoundError(Exception):
     """Exception raised when a font cannot be found in the system."""
@@ -51,7 +53,7 @@ def get_font_location(font_name: str) -> Optional[str]:
                     if font_name.lower() in file.lower():
                         file_path = os.path.join(root, file)
                         # Check if it's a font file by extension and exists
-                        if is_font_file(file_path) and os.path.isfile(file_path):
+                        if is_font_file(file_path):
                             return file_path
         except (PermissionError, OSError) as e:
             print(f"[ERROR] Cannot access font directory {font_dir}: {e}")
@@ -128,6 +130,9 @@ def is_font_file(file_path: str) -> bool:
     if not file_path:
         return False
 
+    if not os.path.isfile(file_path):
+        return False
+
     # Adobe fonts do not have an extension.
     font_extensions = [".otf", ".ttf", ".fon", ""]
     return any(file_path.lower().endswith(ext) for ext in font_extensions)
@@ -158,7 +163,7 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
         raise FontNotFoundError(f"Font '{font_name}' not found in system font directories")
 
     # Create the tempFonts directory within the scene location if it doesn't exist
-    fonts_dir = scene_location / "tempFonts"
+    fonts_dir = scene_location / TEMP_FONTS_DIR
 
     try:
         fonts_dir.mkdir(exist_ok=True, parents=True)
@@ -201,12 +206,12 @@ def scene_has_fonts(scene_location: Path) -> bool:
     if not scene_location or not scene_location.exists():
         return False
 
-    fonts_dir = scene_location / "tempFonts"
+    fonts_dir = scene_location / TEMP_FONTS_DIR
 
     # Check if tempFonts directory exists and has font files
     if fonts_dir.exists() and fonts_dir.is_dir():
         for font_file in fonts_dir.iterdir():
-            if font_file.is_file() and is_font_file(str(font_file)):
+            if is_font_file(str(font_file)):
                 return True
 
     return False
@@ -226,7 +231,7 @@ def get_font_manager_environment() -> dict[str, Any]:
 
     return {
         "name": "FontManager",
-        "description": "Manages font installation and cleanup for Cinema4D rendering.",
+        "description": "Manages font installation and cleanup for Cinema4D rendering as submitter detected some fonts in the scene.",
         "script": {
             "embeddedFiles": [
                 {

--- a/src/deadline/cinema4d_submitter/font_utils.py
+++ b/src/deadline/cinema4d_submitter/font_utils.py
@@ -1,25 +1,98 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import c4d
+import logging
 import os
 import platform
 import shutil
 from pathlib import Path
-from typing import Optional, List, Any
+from typing import Optional, List, Any, Dict
+
+# Import fontTools for robust font metadata extraction
+# for detecting Adobe fonts.
+from fontTools import ttLib
 
 TEMP_FONTS_DIR = "tempFonts"
 
+# Font table indices from TrueType specification
+TTF_FAMILY_NAME = 1
+TTF_STYLE = 2
+TTF_FULL_NAME = 4
+TTF_POSTSCRIPT_NAME = 6
 
-class FontNotFoundError(Exception):
-    """Exception raised when a font cannot be found in the system."""
+# Set up logging
+logger = logging.getLogger(__name__)
 
-    pass
+
+def get_font_metadata(font_path: str) -> Optional[Dict[str, Any]]:
+    """
+    Extract font metadata from a font file using fontTools.
+
+    Args:
+        font_path (str): Path to the font file
+
+    Returns:
+        Optional[Dict[str, Any]]: Font metadata dictionary or None if extraction fails
+    """
+
+    if not font_path or not os.path.isfile(font_path):
+        return None
+
+    try:
+        font = ttLib.TTFont(font_path)
+        names_table = font["name"].names
+
+        # Extract key font information
+        metadata: dict[str, Any] = {
+            "file_path": font_path,
+            "family_name": None,
+            "style": None,
+            "full_name": None,
+            "postscript_name": None,
+            "raw_names": {},
+        }
+
+        # Build raw names table for debugging
+        try:
+            metadata["raw_names"] = {i: str(names_table[i]) for i in range(len(names_table))}
+        except Exception as e:
+            logger.debug(f"Could not build raw names table for {font_path}: {e}")
+
+        # Extract standard font names
+        try:
+            if len(names_table) > TTF_FAMILY_NAME:
+                metadata["family_name"] = str(names_table[TTF_FAMILY_NAME])
+        except (IndexError, Exception) as e:
+            logger.debug(f"Could not extract family name from {font_path}: {e}")
+
+        try:
+            if len(names_table) > TTF_STYLE:
+                metadata["style"] = str(names_table[TTF_STYLE])
+        except (IndexError, Exception) as e:
+            logger.debug(f"Could not extract style from {font_path}: {e}")
+
+        try:
+            if len(names_table) > TTF_FULL_NAME:
+                metadata["full_name"] = str(names_table[TTF_FULL_NAME])
+        except (IndexError, Exception) as e:
+            logger.debug(f"Could not extract full name from {font_path}: {e}")
+
+        try:
+            if len(names_table) > TTF_POSTSCRIPT_NAME:
+                metadata["postscript_name"] = str(names_table[TTF_POSTSCRIPT_NAME])
+        except (IndexError, Exception) as e:
+            logger.debug(f"Could not extract PostScript name from {font_path}: {e}")
+
+        return metadata
+
+    except Exception as e:
+        logger.debug(f"Failed to extract metadata from {font_path}: {e}")
+        return None
 
 
 def is_asset_a_font(asset: dict) -> bool:
     """
     Check if Cinema 4D considers the asset is a font.
-
     """
     pid: int = asset.get("paramId", c4d.NOTOK)
     owner: Optional[c4d.BaseList2D] = asset.get("owner", None)
@@ -41,25 +114,83 @@ def get_font_location(font_name: str) -> Optional[str]:
     Returns:
         Optional[str]: Path to the font file if found, None otherwise
     """
-    # Get system font directories based on the operating system
+    if not font_name or not font_name.strip():
+        return None
+
+    font_name = font_name.strip()
     font_dirs = get_system_font_directories()
 
-    # Search for the font in all font directories
     for font_dir in font_dirs:
         try:
             for root, _, files in os.walk(font_dir):
                 for file in files:
-                    # Check if the font name is in the file name (case-insensitive)
-                    if font_name.lower() in file.lower():
-                        file_path = os.path.join(root, file)
-                        # Check if it's a font file by extension and exists
-                        if is_font_file(file_path):
-                            return file_path
+                    file_path = os.path.join(root, file)
+
+                    # Check if it's a font file by extension and exists
+                    if not is_font_file(file_path):
+                        continue
+
+                    # Check if this font matches
+                    if _is_font_match(font_name, file, file_path):
+                        logger.debug(f"Font match found: {file_path}")
+                        return file_path
+
         except (PermissionError, OSError) as e:
-            print(f"[ERROR] Cannot access font directory {font_dir}: {e}")
+            logger.debug(f"Cannot access font directory {font_dir}: {e}")
             continue
 
+    logger.debug(f"No suitable font match found for: {font_name}")
     return None
+
+
+def _is_font_match(font_name: str, filename: str, file_path: str) -> bool:
+    """
+    Check if a font name matches a font file.
+
+    Args:
+        font_name (str): The font name to match
+        filename (str): The font filename
+        file_path (str): Full path to the font file
+
+    Returns:
+        bool: True if the font matches, False otherwise
+    """
+    font_name_lower = font_name.lower()
+    filename_lower = filename.lower()
+
+    # Try metadata-based matching first (most reliable)
+    metadata = get_font_metadata(file_path)
+    if metadata:
+        # Check PostScript name match (exact match - highest priority)
+        postscript_name = metadata.get("postscript_name", "")
+        if postscript_name and font_name == postscript_name:
+            return True
+
+        # Check family name match
+        family_name = metadata.get("family_name", "").lower()
+        if family_name and (font_name_lower == family_name or font_name_lower in family_name):
+            return True
+
+        # Check full name match
+        full_name = metadata.get("full_name", "").lower()
+        if full_name and (font_name_lower == full_name or font_name_lower in full_name):
+            return True
+
+    # Fall back to filename-based matching
+    # Exact filename match (without extension)
+    name_without_ext = os.path.splitext(filename_lower)[0]
+    if font_name_lower == name_without_ext:
+        return True
+
+    # Check if font name is contained in filename
+    if font_name_lower in filename_lower:
+        return True
+
+    # Check if filename is contained in font name
+    if name_without_ext in font_name_lower:
+        return True
+
+    return False
 
 
 def get_system_font_directories() -> List[str]:
@@ -80,46 +211,58 @@ def get_system_font_directories() -> List[str]:
         appdata = os.environ.get("APPDATA")
 
         # System fonts
-        font_dirs = [os.path.join(windir, "Fonts")]
+        system_fonts = os.path.join(windir, "Fonts")
+        if os.path.isdir(system_fonts):
+            font_dirs.append(system_fonts)
 
         # User-installed fonts
         if localappdata:
             user_fonts_dir = os.path.join(localappdata, "Microsoft", "Windows", "Fonts")
-            font_dirs.append(user_fonts_dir)
+            if os.path.isdir(user_fonts_dir):
+                font_dirs.append(user_fonts_dir)
 
         # Adobe fonts
         if appdata:
-            adobe_livetype = os.path.join(appdata, "Adobe", "CoreSync", "plugins", "livetype")
-            adobe_user_fonts = os.path.join(appdata, "Adobe", "User Owned Fonts")
-            font_dirs.extend([adobe_livetype, adobe_user_fonts])
+            adobe_locations = [
+                os.path.join(appdata, "Adobe", "CoreSync", "plugins", "livetype", "r"),
+                os.path.join(appdata, "Adobe", "User Owned Fonts"),
+            ]
+            for location in adobe_locations:
+                if os.path.isdir(location):
+                    font_dirs.append(location)
 
     elif system == "Darwin":  # macOS
         # macOS font directories
-        font_dirs = [
+        mac_locations = [
             "/Library/Fonts",
             "/System/Library/Fonts",
             os.path.expanduser("~/Library/Fonts"),
         ]
 
+        for location in mac_locations:
+            if os.path.isdir(location):
+                font_dirs.append(location)
+
         # Adobe fonts on macOS
-        adobe_livetype = os.path.expanduser(
-            "~/Library/Application Support/Adobe/CoreSync/plugins/livetype"
-        )
-        adobe_user_fonts = os.path.expanduser(
-            "~/Library/Application Support/Adobe/User Owned Fonts"
-        )
-        font_dirs.extend([adobe_livetype, adobe_user_fonts])
+        adobe_locations = [
+            os.path.expanduser("~/Library/Application Support/Adobe/CoreSync/plugins/livetype/r"),
+            os.path.expanduser("~/Library/Application Support/Adobe/User Owned Fonts"),
+        ]
+
+        for location in adobe_locations:
+            if os.path.isdir(location):
+                font_dirs.append(location)
 
     else:
-        print(f"[ERROR] Unknown operating system: {system}")
+        logger.warning(f"Unknown operating system: {system}")
 
-    # Filter out directories that don't exist
-    return [d for d in font_dirs if d and os.path.isdir(d)]
+    logger.debug(f"Found {len(font_dirs)} font directories: {font_dirs}")
+    return font_dirs
 
 
 def is_font_file(file_path: str) -> bool:
     """
-    Check if a file is a font file based on its extension.
+    Check if a file is a font file based on its extension and validate it can be parsed.
 
     Args:
         file_path (str): Path to the file
@@ -133,9 +276,23 @@ def is_font_file(file_path: str) -> bool:
     if not os.path.isfile(file_path):
         return False
 
-    # Adobe fonts do not have an extension.
-    font_extensions = [".otf", ".ttf", ".fon", ""]
-    return any(file_path.lower().endswith(ext) for ext in font_extensions)
+    # Check file extension first (quick check)
+    font_extensions = [".otf", ".ttf", ".fon", ""]  # Adobe fonts may have no extension
+    has_font_extension = any(file_path.lower().endswith(ext) for ext in font_extensions)
+
+    if not has_font_extension:
+        return False
+
+    # Try to validate the font file using fontTools
+    try:
+        # Try to open the font file to validate it
+        font = ttLib.TTFont(file_path)
+        # If we can access the name table, it's likely a valid font
+        _ = font["name"]
+        return True
+    except Exception as e:
+        logger.debug(f"Font validation failed for {file_path}: {e}")
+        return False
 
 
 def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
@@ -147,8 +304,8 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
         scene_location (Path): Path to the scene location
 
     Raises:
-        FontNotFoundError: If the font cannot be found in system font directories
         RuntimeError: If there's an error during the copy operation
+        ValueError: If input parameters are not valid
     """
     if not font_name or not font_name.strip():
         raise ValueError("Font name cannot be empty")
@@ -156,11 +313,20 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
     if not scene_location or not scene_location.exists():
         raise ValueError(f"Scene location does not exist: {scene_location}")
 
+    font_name = font_name.strip()
+
     # Get the font's location
-    font_location = get_font_location(font_name.strip())
+    font_location = get_font_location(font_name)
 
     if font_location is None:
-        raise FontNotFoundError(f"Font '{font_name}' not found in system font directories")
+        # We were unable to find the font, we silently fail here.
+        logger.error(f"Font '{font_name}' not found in system font directories")
+        return
+
+    # Validate the font file before copying
+    if not is_font_file(font_location):
+        logger.error(f"Font file validation failed: {font_location}")
+        return
 
     # Create the tempFonts directory within the scene location if it doesn't exist
     fonts_dir = scene_location / TEMP_FONTS_DIR
@@ -176,21 +342,36 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
 
     # Check if font already exists in destination
     if destination.exists():
-        # Verify it's the same file by comparing sizes
+        # Verify it's the same file by comparing sizes and modification times
         try:
-            if destination.stat().st_size == os.path.getsize(font_location):
+            src_stat = os.stat(font_location)
+            dst_stat = destination.stat()
+            if (
+                dst_stat.st_size == src_stat.st_size
+                and abs(dst_stat.st_mtime - src_stat.st_mtime) < 1
+            ):
+                logger.debug(f"Font already exists and is identical: {destination}")
                 return
         except OSError:
             # If we can't check the file, proceed with copy to be safe
-            pass
+            logger.debug(
+                f"Could not verify existing font file, proceeding with copy: {destination}"
+            )
 
     try:
         shutil.copy2(font_location, destination)
+        logger.debug(f"Successfully copied font from {font_location} to {destination}")
+
+        # Verify the copied file
+        if not is_font_file(str(destination)):
+            raise RuntimeError(f"Copied font file failed validation: {destination}")
+
     except (OSError, IOError, shutil.Error) as e:
-        print(f"[ERROR] Copy operation failed: {e}")
-        raise RuntimeError(
+        error_msg = (
             f"Error copying font '{font_name}' from '{font_location}' to '{destination}': {str(e)}"
         )
+        logger.error(error_msg)
+        raise RuntimeError(error_msg)
 
 
 def scene_has_fonts(scene_location: Path) -> bool:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

One of our customers pointed out that in Cinema 4D we can add different fonts for "Text" but for the fonts to be rendered properly, it needs to be installed on the workers. 

### What was the solution? (How)

Added logic to install fonts during the job environment phase before the Cinema 4D application is opened. 

There is an issue with fonts in Mac and we will be working on it separately to fix it but it looks as though the issue is on the Cinema 4D side. 

### What is the impact of this change?

Custom fonts would be rendered in Cinema 4D. 

### How was this change tested?

I tested it by submitting a bunch of scenes with different fonts and confirmed that it worked. 

- Have you run the unit tests?
Yes

I also plan to add unit tests separately. 

- Have you run the integration tests? (Add your integration test report below)
Yes. Running them now. 

I also plan to add an integration test separately for this issue. 

- Have you made changes to the submitter?
Yes. 

### Was this change documented?

No change to documentation is necessary. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*