### PR TITLE
fix: Add the known asset root paths to suppress job submission warnings.

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -427,7 +427,7 @@ def create_job_bundle(
     attachments: AssetReferences,
     temp_dir: Optional[str] = None,
     host_requirements: Optional[dict] = None,
-):
+) -> dict[str, Any]:
     """
     Creates a job bundle and saves sticky settings for rendering.
 
@@ -513,6 +513,13 @@ def create_job_bundle(
     settings.input_directories = sorted(attachments.input_directories)
 
     settings.save_sticky_settings(Scene.name())
+
+    return {
+        "known_asset_paths": [
+            os.path.abspath(directory) for directory in settings.input_directories
+        ],
+        "job_parameters": parameter_values,
+    }
 
 
 def generate_take_parameter_names(submit_takes: list[TakeData]) -> None:
@@ -684,7 +691,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         Callback function for creating a job bundle when submitting the job.
         """
-        create_job_bundle(
+        return create_job_bundle(
             settings,
             takes,
             job_bundle_dir,
@@ -694,7 +701,6 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
             temp_dir,
             host_requirements,
         )
-        return {}
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/267

### What was the problem/requirement? (What/Why)

Right now, during job submissions we get a pop-up in the "Job attachments valid confirmation" asking users to confirm if they intend to submit a job that uses files from input and output directories.

We should be able to shrink the warnings by using the new feature in deadline-cloud 0.51 release as part of the efforts of this PR: https://github.com/aws-deadline/deadline-cloud/pull/673

### What was the solution? (How)

Implemented something similar to https://github.com/aws-deadline/deadline-cloud/blob/mainline/src/deadline/client/ui/job_bundle_submitter.py#L155-L158 by returning the "known_asset_paths" and "job_parameters"

### What is the impact of this change?

#### Before

<img width="609" height="713" alt="Screenshot 2025-08-09 at 6 22 53 PM" src="https://github.com/user-attachments/assets/236b4f5d-b996-40dc-81a2-83929d33631b" />


#### After

<img width="580" height="334" alt="Screenshot 2025-08-09 at 6 12 10 PM" src="https://github.com/user-attachments/assets/cd725a53-2e1b-4780-999c-454e2be07307" />


### How was this change tested?

I ran integration and unit tests and also submitted few jobs to my farm to confirm that there are no changes to the submission. 

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes

```
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 

=============================================================== slowest 5 durations =============================================================== 
501.09s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
117.05s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
91.88s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
89.71s call     test/integ/test_cinema4d.py::test_integ[redshift]
88.06s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
========================================================= 7 passed in 1012.40s (0:16:52) ==========================================================
```

- Have you made changes to the submitter?

Yes, now the create job callback returns "known_asset_paths" and "parameter_values". But this has no issues with the job submissions. 

### Was this change documented?

No doc changes were required. 

### Is this a breaking change?

It is more of an UI/UX change for easier job submissions and does not require an adaptor version update. Hence, I believe this is not a breaking change. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*