### PR TITLE
fix: Use scene file location to map path for fonts folder.

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -28,7 +28,7 @@ from .assets import AssetIntrospector
 from .data_classes import (
     RenderSubmitterUISettings,
 )
-from .font_utils import scene_has_fonts, get_font_manager_environment
+from .font_utils import scene_has_fonts, get_font_manager_environment, TEMP_FONTS_DIR
 from .scene import Animation, Scene
 from .style import C4D_STYLE
 from .takes import TakeSelection
@@ -284,7 +284,7 @@ def _get_job_template(
 
     # Conditionally add FontManager job environment if fonts are detected
     if adaptor and scene_has_fonts(Path(Scene.name()).parent):
-        font_manager_environment = get_font_manager_environment()
+        font_manager_environment = get_font_manager_environment(Scene.name())
         if "jobEnvironments" not in job_template:
             job_template["jobEnvironments"] = []
         job_template["jobEnvironments"].append(font_manager_environment)
@@ -642,7 +642,7 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
     # This is crucial because Scene.name() will change after SaveProject
     original_scene_file_path = Path(Scene.name())
     original_scene_dir = original_scene_file_path.parent
-    original_fonts_dir = original_scene_dir / "tempFonts"
+    original_fonts_dir = original_scene_dir / TEMP_FONTS_DIR
 
     # Save the project to the temporary directory
     temp_file_path = os.path.join(temp_dir, doc.GetDocumentName())
@@ -659,7 +659,7 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
             "Exporting the scene failed. Please fix all the paths for your assets in your scene in Cinema 4D's Window menu bar > Project Asset Inspector."
         )
 
-    temp_fonts_dir = Path(Scene.name()).parent / "tempFonts"
+    temp_fonts_dir = Path(Scene.name()).parent / TEMP_FONTS_DIR
 
     # Copy fonts from the original scene's tempFonts directory to the temp directory
 

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import sys
 import traceback
+from pathlib import Path
 from typing import Set, Tuple
 
 _TEMP_FONTS_DIR = "tempFonts"
@@ -54,15 +55,22 @@ FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
 logger = logging.getLogger(__name__)
 
 
-def find_fonts(session_dir: str) -> Set[str]:
+def find_fonts(session_dir: str, scene_file_path: str) -> Set[str]:
     """
     Looks for all font files that were sent along with the job
 
     :param session_dir: the root folder in which to look for files
+    :param scene_file_path: path to the scene file to use for finding fonts
 
     :returns: a set with all found fonts
     """
+    logger.debug(f"Starting font search in session_dir: {session_dir}")
+    logger.debug(f"Scene file path provided: {scene_file_path}")
+
     fonts = set()
+
+    # First, try the asset root approach
+    logger.debug("Using asset root font search approach")
     for subfolder in os.listdir(session_dir):
         # Only look in assetroot folders
         if not subfolder.startswith("assetroot-"):
@@ -74,7 +82,7 @@ def find_fonts(session_dir: str) -> Set[str]:
             for d in dirs:
                 if _TEMP_FONTS_DIR in d:
                     full_sub_dir = os.path.join(path, d)
-                    logger.debug(f"tempFonts directory: {full_sub_dir}")
+                    logger.debug(f"{_TEMP_FONTS_DIR} directory: {full_sub_dir}")
                     break
 
         if not full_sub_dir:
@@ -91,6 +99,43 @@ def find_fonts(session_dir: str) -> Set[str]:
                 logger.warning(
                     f"A file that is not a supported font was found in the {_TEMP_FONTS_DIR} folder: {full_assetpath}"
                 )
+
+    # If fonts were found in asset root, return them
+    if fonts:
+        logger.debug(f"Found {len(fonts)} fonts in asset root directories")
+        return fonts
+
+    # Fall back to scene file path approach if no fonts found in asset root
+    logger.debug(
+        "No fonts found in asset root, trying scene-based relative path font search approach"
+    )
+    try:
+        scene_parent_dir = Path(scene_file_path).parent
+        temp_fonts_dir = scene_parent_dir / _TEMP_FONTS_DIR
+        logger.debug(f"Looking for fonts in scene-based directory: {temp_fonts_dir}")
+
+        if temp_fonts_dir.exists() and temp_fonts_dir.is_dir():
+            logger.debug(f"Scene-based {_TEMP_FONTS_DIR} directory found: {temp_fonts_dir}")
+            font_count = 0
+            for font_file in temp_fonts_dir.iterdir():
+                if font_file.is_file():
+                    _, ext = os.path.splitext(str(font_file))
+                    if ext.lower() in FONT_EXTENSIONS:
+                        logger.debug(f"Adding font from scene {_TEMP_FONTS_DIR}: {font_file}")
+                        fonts.add(str(font_file))
+                        font_count += 1
+                    else:
+                        logger.warning(
+                            f"Non-font file found in {_TEMP_FONTS_DIR} folder: {font_file}"
+                        )
+            logger.debug(f"Found {font_count} fonts in scene-based {_TEMP_FONTS_DIR} directory")
+        else:
+            logger.debug(
+                f"Scene-based {_TEMP_FONTS_DIR} directory not found or not a directory: {temp_fonts_dir}"
+            )
+    except Exception as e:
+        logger.warning(f"Error accessing scene file path for font location: {e}")
+
     return fonts
 
 
@@ -226,14 +271,15 @@ def uninstall_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool
     return True, ""
 
 
-def _install_fonts(session_dir: str) -> None:
+def _install_fonts(session_dir: str, scene_file_path: str) -> None:
     """
     Calls all needed functions for installing fonts
 
     :param session_dir: directory of the session
+    :param scene_file_path: path to the scene file to use for finding fonts
     """
     logger.info("Looking for fonts to install...")
-    fonts = find_fonts(session_dir)
+    fonts = find_fonts(session_dir, scene_file_path)
 
     if not fonts:
         raise RuntimeError("No custom fonts found")
@@ -244,14 +290,15 @@ def _install_fonts(session_dir: str) -> None:
             raise RuntimeError(f"Error installing font: {msg}")
 
 
-def _remove_fonts(session_dir: str) -> None:
+def _remove_fonts(session_dir: str, scene_file_path: str) -> None:
     """
     Calls all needed functions for removing fonts
 
     :param session_dir: directory of the session
+    :param scene_file_path: path to the scene file to use for finding fonts
     """
     logger.info("Looking for fonts to uninstall...")
-    fonts = find_fonts(session_dir)
+    fonts = find_fonts(session_dir, scene_file_path)
 
     if not fonts:
         logger.info("No custom fonts found, finishing task...")
@@ -279,10 +326,12 @@ def setup_logger() -> None:
 if __name__ == "__main__":
     setup_logger()
     session_dir = sys.argv[2]
+    scene_file_path = sys.argv[3]
 
     logger.debug(f"Running font script job: {sys.argv[1]}")
+    logger.debug(f"Using scene file path: {scene_file_path}")
 
     if sys.argv[1] == "install":
-        _install_fonts(session_dir)
+        _install_fonts(session_dir, scene_file_path)
     if sys.argv[1] == "remove":
-        _remove_fonts(session_dir)
+        _remove_fonts(session_dir, scene_file_path)

--- a/src/deadline/cinema4d_submitter/font_utils.py
+++ b/src/deadline/cinema4d_submitter/font_utils.py
@@ -398,15 +398,20 @@ def scene_has_fonts(scene_location: Path) -> bool:
     return False
 
 
-def get_font_manager_environment() -> dict[str, Any]:
+def get_font_manager_environment(scene_file_path: str) -> dict[str, Any]:
     """
     Returns the FontManager job environment definition.
+
+    Args:
+        scene_file_path (str): Path to the scene file to use for finding fonts
 
     Returns:
         dict[str, Any]: The FontManager job environment configuration
     """
+
     # Read the font installer script from file
     font_installer_path = Path(__file__).parent / "font_installer.py"
+
     with open(font_installer_path, "r", encoding="utf-8") as f:
         font_installer_script = f.read()
 
@@ -429,6 +434,7 @@ def get_font_manager_environment() -> dict[str, Any]:
                         "{{Env.File.fontInstaller}}",
                         "install",
                         "{{Session.WorkingDirectory}}",
+                        scene_file_path,
                     ],
                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
                 },
@@ -438,6 +444,7 @@ def get_font_manager_environment() -> dict[str, Any]:
                         "{{Env.File.fontInstaller}}",
                         "remove",
                         "{{Session.WorkingDirectory}}",
+                        scene_file_path,
                     ],
                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
                 },


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Farms that use a storage profile need a different way to get the fonts as the fonts don't get uploaded in JA. 

### What was the solution? (How)

Provide a relative path based fonts detection so that if workers are using storage profiles then it find the font directories relative to the scene file. 

### What is the impact of this change?

Font installation works for workers using storage profiles. 

### How was this change tested?

I manually tested it on a farm that uses storage profiles and confirmed that the changes worked. 

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)


```

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 

======================================================================== slowest 5 durations ======================================================================== 
478.12s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
108.43s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
87.14s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
84.36s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
83.93s call     test/integ/test_cinema4d.py::test_integ[redshift]
=================================================================== 7 passed in 971.34s (0:16:11) ===================================================================
```

- Have you made changes to the submitter?

Yes, but it does not require any changes to the tests. 

### Was this change documented?

Does not need documentation as this was a bug for workers using storage profiles. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*