### PR TITLE
feat: improved render progress reporting

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -34,19 +34,19 @@ def progress_callback(progress_percent, progress_type_int):
         progress_type (c4d.RENDERPROGRESSTYPE): The Main part of the current rendering step
     """
     progress_type_map = {
-        c4d.RENDERPROGRESSTYPE_BEFORERENDERING: "Before Rendering",
-        c4d.RENDERPROGRESSTYPE_DURINGRENDERING: "During Rendering",
-        c4d.RENDERPROGRESSTYPE_AFTERRENDERING: "After Rendering",
-        c4d.RENDERPROGRESSTYPE_GLOBALILLUMINATION: "Global Illumination",
-        c4d.RENDERPROGRESSTYPE_QUICK_PREVIEW: "Quick Preview",
-        c4d.RENDERPROGRESSTYPE_AMBIENTOCCLUSION: "Ambient Occlusion",
+        c4d.RENDERPROGRESSTYPE_BEFORERENDERING: "before rendering",
+        c4d.RENDERPROGRESSTYPE_DURINGRENDERING: "during rendering",
+        c4d.RENDERPROGRESSTYPE_AFTERRENDERING: "after rendering",
+        c4d.RENDERPROGRESSTYPE_GLOBALILLUMINATION: "global illumination",
+        c4d.RENDERPROGRESSTYPE_QUICK_PREVIEW: "quick preview",
+        c4d.RENDERPROGRESSTYPE_AMBIENTOCCLUSION: "ambient occlusion",
     }
     if progress_type_int in progress_type_map:
         progress_type_text = progress_type_map[progress_type_int]
     else:
         progress_type_text = f"Unknown progress type ({progress_type_int})"
 
-    print(f"Progress Update: ({progress_type_text}): {progress_percent * 100.0}%")
+    print(f"Progress update ({progress_type_text}): {progress_percent * 100.0}%")
 
     if progress_type_int == c4d.RENDERPROGRESSTYPE_DURINGRENDERING:
         print("ALF_PROGRESS %g" % (progress_percent * 100))

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -26,9 +26,30 @@ _RENDERRESULT = {
 }
 
 
-def progress_callback(progress, progress_type):
-    if progress_type == c4d.RENDERPROGRESSTYPE_DURINGRENDERING:
-        print("ALF_PROGRESS %g" % (progress * 100))
+def progress_callback(progress_percent, progress_type_int):
+    """Function passed in RenderDocument. It will be called automatically by Cinema 4D with the current render progress.
+
+    Args:
+        progress (float): The percent of the progress for the current step
+        progress_type (c4d.RENDERPROGRESSTYPE): The Main part of the current rendering step
+    """
+    progress_type_map = {
+        c4d.RENDERPROGRESSTYPE_BEFORERENDERING: "Before Rendering",
+        c4d.RENDERPROGRESSTYPE_DURINGRENDERING: "During Rendering",
+        c4d.RENDERPROGRESSTYPE_AFTERRENDERING: "After Rendering",
+        c4d.RENDERPROGRESSTYPE_GLOBALILLUMINATION: "Global Illumination",
+        c4d.RENDERPROGRESSTYPE_QUICK_PREVIEW: "Quick Preview",
+        c4d.RENDERPROGRESSTYPE_AMBIENTOCCLUSION: "Ambient Occlusion",
+    }
+    if progress_type_int in progress_type_map:
+        progress_type_text = progress_type_map[progress_type_int]
+    else:
+        progress_type_text = f"Unknown progress type ({progress_type_int})"
+
+    print(f"Progress Update: ({progress_type_text}): {progress_percent * 100.0}%")
+
+    if progress_type_int == c4d.RENDERPROGRESSTYPE_DURINGRENDERING:
+        print("ALF_PROGRESS %g" % (progress_percent * 100))
 
 
 class Cinema4DHandler:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Previously, progress reporting was only done during rendering. However, there are several additional steps in the Cinema4D RenderDocument flow, including `c4d.RENDERPROGRESSTYPE_BEFORERENDERING`, `c4d.RENDERPROGRESSTYPE_AFTERRENDERING`, and `c4d.RENDERPROGRESSTYPE_GLOBALILLUMINATION`. Added these into progress reporting for better progress tracking.

See https://developers.maxon.net/docs/py/2025_1_0/modules/c4d.documents/index.html#c4d.documents.RenderDocument

### How was this change tested?

Built a Conda package for `deadline-cloud-for-cinema-4d` and ran it on a worker. Confirmed that the progress reporting had become more informative:
```
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:35-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 50.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 66.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 83.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 100.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 115.99999999999999%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 133.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 50.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 25.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 50.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 75.0%
2025/08/12 10:24:36-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 90.0%
2025/08/12 10:24:37-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 100.0%
2025/08/12 10:24:37-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:37-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:37-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 100.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 6.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 13.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 20.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (before rendering): 26.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 33.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 40.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 46.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 53.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 60.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 66.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 73.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 80.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 86.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 93.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 100.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 100.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (global illumination): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 0.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 0
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 3.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 3
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 5.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 5
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 6.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 6
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 8.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 8
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 10.0%
2025/08/12 10:24:40-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 10
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 11.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 11
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 13.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 13
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 15.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 15
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 16.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 16
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 18.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 18
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 20.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 20
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 21.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 21
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 23.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 23
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 25.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 25
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 26.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 26
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 28.000000000000004%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 28
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 30.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 30
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 31.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 31
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 33.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 33
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 35.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 35
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 36.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 36
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 38.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 38
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 40.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 40
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 41.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 41
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 43.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 43
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 45.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 45
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 46.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 46
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 48.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 48
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 50.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 50
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 51.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 51
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 53.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 53
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 55.00000000000001%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 55
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 56.00000000000001%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 56
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 57.99999999999999%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 58
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 60.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 60
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 61.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 61
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 63.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 63
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 65.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 65
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 66.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 66
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 68.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 68
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 70.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 70
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 71.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 71
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 73.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 73
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 75.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 75
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 76.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 76
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 78.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 78
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 80.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 80
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 81.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 81
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 83.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 83
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 85.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 85
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 86.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 86
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 88.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 88
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 90.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 90
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 91.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 91
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 93.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 93
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 95.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 95
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 96.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 96
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 98.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 98
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 100.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 100.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (during rendering): 100.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (after rendering): 0.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Progress update (after rendering): 100.0%
2025/08/12 10:24:41-05:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
2025/08/11 17:48:50-05:00 INFO: Done Cinema4DAdaptor main
```

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*