### PR TITLE
fix: Only bundle fonts on Windows as its not supported on Mac.

### DIFF
--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -56,6 +56,12 @@ A: Yes! Redshift GPU rendering is supported.
 
 A: Cloud rendering can be much faster than local rendering because you can use multiple powerful instances simultaneously.
 
+**Q: Why don't fonts work while submitting with macOS?**
+
+A: Font functionality is currently only supported on Windows due to technical limitations. This is a known behavior in mixed macOS/Windows environments, as confirmed by Maxon's official documentation. 
+
+For more information, see [Maxon's official FAQ on resolving missing fonts in Team Render](https://support.maxon.net/hc/en-us/articles/1500006439721-How-to-resolve-missing-fonts-in-Team-Render-for-Cinema-4D-install-fonts-or-make-Text-editable).
+
 ## Troubleshooting
 
 **Q: My submitter button doesn't appear in Cinema 4D.**

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -98,7 +98,8 @@ if not has_gui_deps():
             "Did not install GUI components, the AWS Deadline Cloud extension will fail with qtpy bindings errors."
         )
 
-if not has_fonttools():
+# Only install fonttools on Windows. Mac font functionality is not supported
+if sys.platform == "win32" and not has_fonttools():
     if c4d.gui.QuestionDialog(
         "The AWS Deadline Cloud extension needs fonttools to work properly. Press Yes to install."
     ):

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import c4d
 
+from .platform_utils import is_windows, is_macos
+
 _logger = _logging.getLogger(__name__)
 
 
@@ -41,7 +43,7 @@ def _install_packages(packages, description):
     c4d_executable = "Cinema 4D.exe"
     python_location = "resource\\modules\\python\\libs\\win64\\python.exe"
     # If its MacOS, install it in MacOS python location.
-    if sys.platform == "darwin":
+    if is_macos():
         c4d_executable = "Cinema 4D.app/Contents/MacOS/Cinema 4D"
         python_location = "resource/modules/python/libs/python311.macos.framework/python"
 
@@ -99,7 +101,7 @@ if not has_gui_deps():
         )
 
 # Only install fonttools on Windows. Mac font functionality is not supported
-if sys.platform == "win32" and not has_fonttools():
+if is_windows() and not has_fonttools():
     if c4d.gui.QuestionDialog(
         "The AWS Deadline Cloud extension needs fonttools to work properly. Press Yes to install."
     ):

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import re
-import sys
 from pathlib import Path
 
 import c4d
 
+from .platform_utils import is_windows
 from .scene import Scene
 from .font_utils import is_asset_a_font, copy_font_to_scene_folder, FONTS_DIR
 
@@ -42,7 +42,7 @@ class AssetIntrospector:
 
         for asset in asset_list:
             # Only process fonts on Windows. Mac font functionality is not supported
-            if sys.platform == "win32" and is_asset_a_font(asset):
+            if is_windows() and is_asset_a_font(asset):
                 copy_font_to_scene_folder(asset["assetname"], path_to_scene_file_dir)
 
             filename = asset.get("filename", None)
@@ -51,7 +51,7 @@ class AssetIntrospector:
                 assets.add(Path(filename))
 
         # Add all font files from the fonts directory to assets (Windows only)
-        if sys.platform == "win32":
+        if is_windows():
             fonts_dir = path_to_scene_file_dir / FONTS_DIR
             if fonts_dir.exists():
                 for font_file in fonts_dir.iterdir():

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
 import c4d
 
 from .scene import Scene
-from .font_utils import is_asset_a_font, copy_font_to_scene_folder, TEMP_FONTS_DIR
+from .font_utils import is_asset_a_font, copy_font_to_scene_folder, FONTS_DIR
 
 _FRAME_RE = re.compile("#+")
 
@@ -40,7 +41,8 @@ class AssetIntrospector:
         )
 
         for asset in asset_list:
-            if is_asset_a_font(asset):
+            # Only process fonts on Windows. Mac font functionality is not supported
+            if sys.platform == "win32" and is_asset_a_font(asset):
                 copy_font_to_scene_folder(asset["assetname"], path_to_scene_file_dir)
 
             filename = asset.get("filename", None)
@@ -48,11 +50,12 @@ class AssetIntrospector:
             if exists is True and filename is not None:
                 assets.add(Path(filename))
 
-        # Add all font files from the tempFonts directory to assets
-        fonts_dir = path_to_scene_file_dir / TEMP_FONTS_DIR
-        if fonts_dir.exists():
-            for font_file in fonts_dir.iterdir():
-                if font_file.is_file():
-                    assets.add(font_file)
+        # Add all font files from the fonts directory to assets (Windows only)
+        if sys.platform == "win32":
+            fonts_dir = path_to_scene_file_dir / FONTS_DIR
+            if fonts_dir.exists():
+                for font_file in fonts_dir.iterdir():
+                    if font_file.is_file():
+                        assets.add(font_file)
 
         return assets

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 import re
+import sys
 import tempfile
 from copy import deepcopy
 from dataclasses import dataclass
@@ -28,7 +29,7 @@ from .assets import AssetIntrospector
 from .data_classes import (
     RenderSubmitterUISettings,
 )
-from .font_utils import scene_has_fonts, get_font_manager_environment, TEMP_FONTS_DIR
+from .font_utils import scene_has_fonts, get_font_manager_environment, FONTS_DIR
 from .scene import Animation, Scene
 from .style import C4D_STYLE
 from .takes import TakeSelection
@@ -282,8 +283,8 @@ def _get_job_template(
             job_template["jobEnvironments"] = []
         job_template["jobEnvironments"].append(override_environment["environment"])
 
-    # Conditionally add FontManager job environment if fonts are detected
-    if adaptor and scene_has_fonts(Path(Scene.name()).parent):
+    # Conditionally add FontManager job environment if fonts are detected (Windows only)
+    if adaptor and sys.platform == "win32" and scene_has_fonts(Path(Scene.name()).parent):
         font_manager_environment = get_font_manager_environment(Scene.name())
         if "jobEnvironments" not in job_template:
             job_template["jobEnvironments"] = []
@@ -642,7 +643,7 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
     # This is crucial because Scene.name() will change after SaveProject
     original_scene_file_path = Path(Scene.name())
     original_scene_dir = original_scene_file_path.parent
-    original_fonts_dir = original_scene_dir / TEMP_FONTS_DIR
+    original_fonts_dir = original_scene_dir / FONTS_DIR
 
     # Save the project to the temporary directory
     temp_file_path = os.path.join(temp_dir, doc.GetDocumentName())
@@ -659,18 +660,17 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
             "Exporting the scene failed. Please fix all the paths for your assets in your scene in Cinema 4D's Window menu bar > Project Asset Inspector."
         )
 
-    temp_fonts_dir = Path(Scene.name()).parent / TEMP_FONTS_DIR
+    fonts_dir = Path(Scene.name()).parent / FONTS_DIR
 
-    # Copy fonts from the original scene's tempFonts directory to the temp directory
+    # Copy fonts from the original scene's fonts directory to the temp directory (Windows only)
+    if sys.platform == "win32" and original_fonts_dir.exists() and original_fonts_dir.is_dir():
+        # Create the fonts directory in the temp location
+        fonts_dir.mkdir(exist_ok=True, parents=True)
 
-    if original_fonts_dir.exists() and original_fonts_dir.is_dir():
-        # Create the tempFonts directory in the temp location
-        temp_fonts_dir.mkdir(exist_ok=True, parents=True)
-
-        # Copy all font files from the original tempFonts directory
+        # Copy all font files from the original fonts directory
         for font_file in original_fonts_dir.iterdir():
             if font_file.is_file():
-                destination = temp_fonts_dir / font_file.name
+                destination = fonts_dir / font_file.name
                 shutil.copy2(font_file, destination)
 
     # If we get here, save was successful

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 import re
-import sys
 import tempfile
 from copy import deepcopy
 from dataclasses import dataclass
@@ -30,6 +29,7 @@ from .data_classes import (
     RenderSubmitterUISettings,
 )
 from .font_utils import scene_has_fonts, get_font_manager_environment, FONTS_DIR
+from .platform_utils import is_windows
 from .scene import Animation, Scene
 from .style import C4D_STYLE
 from .takes import TakeSelection
@@ -284,7 +284,7 @@ def _get_job_template(
         job_template["jobEnvironments"].append(override_environment["environment"])
 
     # Conditionally add FontManager job environment if fonts are detected (Windows only)
-    if adaptor and sys.platform == "win32" and scene_has_fonts(Path(Scene.name()).parent):
+    if adaptor and is_windows() and scene_has_fonts(Path(Scene.name()).parent):
         font_manager_environment = get_font_manager_environment(Scene.name())
         if "jobEnvironments" not in job_template:
             job_template["jobEnvironments"] = []
@@ -663,7 +663,7 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
     fonts_dir = Path(Scene.name()).parent / FONTS_DIR
 
     # Copy fonts from the original scene's fonts directory to the temp directory (Windows only)
-    if sys.platform == "win32" and original_fonts_dir.exists() and original_fonts_dir.is_dir():
+    if is_windows() and original_fonts_dir.exists() and original_fonts_dir.is_dir():
         # Create the fonts directory in the temp location
         fonts_dir.mkdir(exist_ok=True, parents=True)
 

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -14,23 +14,6 @@ from typing import Set
 
 FONTS_DIR = "fonts"
 
-if sys.platform == "win32":
-    from ctypes import wintypes
-
-    try:
-        import winreg
-    except ImportError:
-        import _winreg as winreg  # type: ignore
-
-    user32 = ctypes.WinDLL("user32", use_last_error=True)
-    gdi32 = ctypes.WinDLL("gdi32", use_last_error=True)
-else:
-    # Stub for non-Windows platforms
-    winreg = None  # type: ignore
-    user32 = None  # type: ignore
-    gdi32 = None  # type: ignore
-    wintypes = None  # type: ignore
-
 FONTS_REG_PATH = r"Software\Microsoft\Windows NT\CurrentVersion\Fonts"
 
 HWND_BROADCAST = 0xFFFF
@@ -52,6 +35,16 @@ FONT_LOCATION_USER = os.path.join(
 FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
 
 logger = logging.getLogger(__name__)
+
+
+def is_windows() -> bool:
+    """
+    Check if the current platform is Windows.
+
+    Returns:
+        bool: True if running on Windows, False otherwise
+    """
+    return sys.platform == "win32"
 
 
 def _collect_fonts_from_directory(fonts_dir: str) -> Set[str]:
@@ -186,8 +179,13 @@ def get_font_name(dst_path: str) -> str:
 
     :returns: string with the font's name
     """
-    if sys.platform != "win32":
+    if not is_windows():
         raise RuntimeError("Font installation is only supported on Windows")
+
+    # Import Windows-specific modules only when needed
+    from ctypes import wintypes
+
+    gdi32 = ctypes.WinDLL("gdi32", use_last_error=True)  # type: ignore[attr-defined]
 
     filename = os.path.basename(dst_path)
     fontname = os.path.splitext(filename)[0]
@@ -218,15 +216,23 @@ def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> None:
 
     :raises RuntimeError: if font installation fails
     """
-    if sys.platform != "win32":
+    if not is_windows():
         logger.error("Font installation is only supported on Windows")
         return
+
+    # Import Windows-specific modules only when needed
+    try:
+        import winreg
+    except ImportError:
+        import _winreg as winreg  # type: ignore
+
+    gdi32 = ctypes.WinDLL("gdi32", use_last_error=True)  # type: ignore[attr-defined]
 
     try:
         # Determine font destination
         if scope == INSTALL_SCOPE_SYSTEM:
             dst_dir = FONT_LOCATION_SYSTEM
-            registry_scope = winreg.HKEY_LOCAL_MACHINE
+            registry_scope = winreg.HKEY_LOCAL_MACHINE  # type: ignore[attr-defined]
         else:
             # Check if the Fonts folder exists, create it if it doesn't
             if not os.path.exists(FONT_LOCATION_USER):
@@ -234,7 +240,7 @@ def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> None:
                 os.makedirs(FONT_LOCATION_USER)
 
             dst_dir = FONT_LOCATION_USER
-            registry_scope = winreg.HKEY_CURRENT_USER
+            registry_scope = winreg.HKEY_CURRENT_USER  # type: ignore[attr-defined]
         dst_path = os.path.join(dst_dir, os.path.basename(src_path))
 
         # Check if font already exists at destination
@@ -255,10 +261,10 @@ def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> None:
         fontname = get_font_name(dst_path)
 
         # Creates registry if it doesn't exist, opens when it does exist
-        with winreg.CreateKeyEx(
-            registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE
+        with winreg.CreateKeyEx(  # type: ignore[attr-defined]
+            registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE  # type: ignore[attr-defined]
         ) as key:
-            winreg.SetValueEx(key, fontname, 0, winreg.REG_SZ, filename)
+            winreg.SetValueEx(key, fontname, 0, winreg.REG_SZ, filename)  # type: ignore[attr-defined]
     except Exception as e:
         raise RuntimeError(f"Failed to install font '{src_path}': {str(e)}") from e
 
@@ -272,24 +278,32 @@ def uninstall_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> None:
 
     :raises RuntimeError: if font uninstallation fails
     """
-    if sys.platform != "win32":
+    if not is_windows():
         logger.error("Font uninstallation is only supported on Windows")
         return
+
+    # Import Windows-specific modules only when needed
+    try:
+        import winreg
+    except ImportError:
+        import _winreg as winreg  # type: ignore
+
+    gdi32 = ctypes.WinDLL("gdi32", use_last_error=True)  # type: ignore[attr-defined]
 
     try:
         # Determine where the font was installed
         if scope == INSTALL_SCOPE_SYSTEM:
             dst_path = os.path.join(FONT_LOCATION_SYSTEM, os.path.basename(src_path))
-            registry_scope = winreg.HKEY_LOCAL_MACHINE
+            registry_scope = winreg.HKEY_LOCAL_MACHINE  # type: ignore[attr-defined]
         else:
             dst_path = os.path.join(FONT_LOCATION_USER, os.path.basename(src_path))
-            registry_scope = winreg.HKEY_CURRENT_USER
+            registry_scope = winreg.HKEY_CURRENT_USER  # type: ignore[attr-defined]
 
         # Remove the fontname/filename from the registry
         fontname = get_font_name(dst_path)
 
-        with winreg.OpenKey(registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE) as key:
-            winreg.DeleteValue(key, fontname)
+        with winreg.OpenKey(registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE) as key:  # type: ignore[attr-defined]
+            winreg.DeleteValue(key, fontname)  # type: ignore[attr-defined]
 
         # Unload the font in the current session
         if not gdi32.RemoveFontResourceW(dst_path):
@@ -307,8 +321,11 @@ def _notify_font_change() -> None:
     Send a notification to all running programs that fonts have changed.
     This should be called once after all font operations are complete.
     """
-    if sys.platform != "win32":
+    if not is_windows():
         return
+
+    # Import Windows-specific modules only when needed
+    user32 = ctypes.WinDLL("user32", use_last_error=True)  # type: ignore[attr-defined]
 
     logger.debug("Notifying running programs of font changes")
     user32.SendMessageTimeoutW(HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None)
@@ -321,7 +338,7 @@ def _install_fonts(session_dir: str, scene_file_path: str) -> None:
     :param session_dir: directory of the session
     :param scene_file_path: path to the scene file to use for finding fonts
     """
-    if sys.platform != "win32":
+    if not is_windows():
         logger.info("Font installation is only supported on Windows, skipping...")
         return
 
@@ -348,7 +365,7 @@ def _remove_fonts(session_dir: str, scene_file_path: str) -> None:
     :param session_dir: directory of the session
     :param scene_file_path: path to the scene file to use for finding fonts
     """
-    if sys.platform != "win32":
+    if not is_windows():
         logger.info("Font uninstallation is only supported on Windows, skipping...")
         return
 

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -9,11 +9,10 @@ import logging
 import os
 import shutil
 import sys
-import traceback
 from pathlib import Path
-from typing import Set, Tuple
+from typing import Set
 
-_TEMP_FONTS_DIR = "tempFonts"
+FONTS_DIR = "fonts"
 
 if sys.platform == "win32":
     from ctypes import wintypes
@@ -69,69 +68,61 @@ def find_fonts(session_dir: str, scene_file_path: str) -> Set[str]:
 
     fonts = set()
 
-    # First, try the asset root approach
-    logger.debug("Using asset root font search approach")
-    for subfolder in os.listdir(session_dir):
-        # Only look in assetroot folders
-        if not subfolder.startswith("assetroot-"):
-            continue
-        # Look for the tempFonts folder
-        asset_dir = os.path.join(session_dir, subfolder)
-        full_sub_dir = None
-        for path, dirs, files in os.walk(asset_dir):
-            for d in dirs:
-                if _TEMP_FONTS_DIR in d:
-                    full_sub_dir = os.path.join(path, d)
-                    logger.debug(f"{_TEMP_FONTS_DIR} directory: {full_sub_dir}")
-                    break
+    # Approach 1: Recursive search for fonts directories in session_dir
+    logger.debug("Using recursive font search approach")
+    try:
+        for root, dirs, files in os.walk(session_dir):
+            for dir_name in dirs:
+                if dir_name == FONTS_DIR:
+                    fonts_dir = os.path.join(root, dir_name)
+                    logger.debug(f"Found {FONTS_DIR} directory: {fonts_dir}")
 
-        if not full_sub_dir:
-            logger.debug(f"Couldn't recursively find {_TEMP_FONTS_DIR} in subfolder: {subfolder}")
-            continue
+                    try:
+                        for file_name in os.listdir(fonts_dir):
+                            full_path = os.path.join(fonts_dir, file_name)
+                            if os.path.isfile(full_path):
+                                _, ext = os.path.splitext(full_path)
+                                if ext.lower() in FONT_EXTENSIONS:
+                                    logger.debug(f"Adding font: {full_path}")
+                                    fonts.add(full_path)
+                                else:
+                                    logger.warning(
+                                        f"Non-font file found in {FONTS_DIR} folder: {full_path}"
+                                    )
+                    except (OSError, PermissionError) as e:
+                        logger.warning(f"Could not access fonts directory {fonts_dir}: {e}")
+                        continue
+    except (OSError, PermissionError) as e:
+        logger.warning(f"Could not perform recursive search in session directory: {e}")
 
-        for file_name in os.listdir(full_sub_dir):
-            full_assetpath = os.path.join(full_sub_dir, file_name)
-            _, ext = os.path.splitext(full_assetpath)
-            if ext.lower() in FONT_EXTENSIONS:
-                logger.debug(f"Adding: {full_assetpath}")
-                fonts.add(full_assetpath)
-            else:
-                logger.warning(
-                    f"A file that is not a supported font was found in the {_TEMP_FONTS_DIR} folder: {full_assetpath}"
-                )
-
-    # If fonts were found in asset root, return them
+    # If fonts were found via recursive search, return them
     if fonts:
-        logger.debug(f"Found {len(fonts)} fonts in asset root directories")
+        logger.debug(f"Found {len(fonts)} fonts via recursive search")
         return fonts
 
-    # Fall back to scene file path approach if no fonts found in asset root
-    logger.debug(
-        "No fonts found in asset root, trying scene-based relative path font search approach"
-    )
+    # Approach 2: Scene file path approach as fallback
+    logger.debug("No fonts found via recursive search, trying scene-based approach")
     try:
         scene_parent_dir = Path(scene_file_path).parent
-        temp_fonts_dir = scene_parent_dir / _TEMP_FONTS_DIR
-        logger.debug(f"Looking for fonts in scene-based directory: {temp_fonts_dir}")
+        fonts_dir_path = scene_parent_dir / FONTS_DIR
+        logger.debug(f"Looking for fonts in scene-based directory: {fonts_dir_path}")
 
-        if temp_fonts_dir.exists() and temp_fonts_dir.is_dir():
-            logger.debug(f"Scene-based {_TEMP_FONTS_DIR} directory found: {temp_fonts_dir}")
+        if fonts_dir_path.exists() and fonts_dir_path.is_dir():
+            logger.debug(f"Scene-based {FONTS_DIR} directory found: {fonts_dir_path}")
             font_count = 0
-            for font_file in temp_fonts_dir.iterdir():
+            for font_file in fonts_dir_path.iterdir():
                 if font_file.is_file():
                     _, ext = os.path.splitext(str(font_file))
                     if ext.lower() in FONT_EXTENSIONS:
-                        logger.debug(f"Adding font from scene {_TEMP_FONTS_DIR}: {font_file}")
+                        logger.debug(f"Adding font from scene {FONTS_DIR}: {font_file}")
                         fonts.add(str(font_file))
                         font_count += 1
                     else:
-                        logger.warning(
-                            f"Non-font file found in {_TEMP_FONTS_DIR} folder: {font_file}"
-                        )
-            logger.debug(f"Found {font_count} fonts in scene-based {_TEMP_FONTS_DIR} directory")
+                        logger.warning(f"Non-font file found in {FONTS_DIR} folder: {font_file}")
+            logger.debug(f"Found {font_count} fonts in scene-based {FONTS_DIR} directory")
         else:
             logger.debug(
-                f"Scene-based {_TEMP_FONTS_DIR} directory not found or not a directory: {temp_fonts_dir}"
+                f"Scene-based {FONTS_DIR} directory not found or not a directory: {fonts_dir_path}"
             )
     except Exception as e:
         logger.warning(f"Error accessing scene file path for font location: {e}")
@@ -170,16 +161,18 @@ def get_font_name(dst_path: str) -> str:
     return fontname
 
 
-def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool, str]:
+def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> None:
     """
     Install provided font to the worker machine
 
     :param src_path: path of font that needs to be installed
+    :param scope: installation scope (USER or SYSTEM)
 
-    :returns: boolean that represents if the font was installed and a string with any traceback that was created
+    :raises RuntimeError: if font installation fails
     """
     if sys.platform != "win32":
-        return False, "Font installation is only supported on Windows"
+        logger.error("Font installation is only supported on Windows")
+        return
 
     try:
         # Determine font destination
@@ -199,7 +192,7 @@ def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool, 
         # Check if font already exists at destination
         if os.path.exists(dst_path):
             logger.info(f"Font already exists at {dst_path}, skipping installation")
-            return True, ""
+            return
 
         # Copy the font to the Windows Fonts folder
         shutil.copy(src_path, dst_path)
@@ -208,11 +201,6 @@ def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool, 
         if not gdi32.AddFontResourceW(dst_path):
             os.remove(dst_path)
             raise OSError(f'AddFontResource failed to load "{src_path}"')
-
-        # Notify running programs
-        user32.SendMessageTimeoutW(
-            HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None
-        )
 
         # Store the fontname/filename in the registry
         filename = os.path.basename(dst_path)
@@ -223,21 +211,22 @@ def install_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool, 
             registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE
         ) as key:
             winreg.SetValueEx(key, fontname, 0, winreg.REG_SZ, filename)
-    except Exception:
-        return False, traceback.format_exc()
-    return True, ""
+    except Exception as e:
+        raise RuntimeError(f"Failed to install font '{src_path}': {str(e)}") from e
 
 
-def uninstall_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool, str]:
+def uninstall_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> None:
     """
     Uninstall provided font from the worker machine
 
     :param src_path: path of font that needs to be removed
+    :param scope: installation scope (USER or SYSTEM)
 
-    :returns: boolean that represents if the font was uninstalled and a string with any traceback that was created
+    :raises RuntimeError: if font uninstallation fails
     """
     if sys.platform != "win32":
-        return False, "Font uninstallation is only supported on Windows"
+        logger.error("Font uninstallation is only supported on Windows")
+        return
 
     try:
         # Determine where the font was installed
@@ -261,14 +250,20 @@ def uninstall_font(src_path: str, scope: str = INSTALL_SCOPE_USER) -> Tuple[bool
 
         if os.path.exists(dst_path):
             os.remove(dst_path)
+    except Exception as e:
+        raise RuntimeError(f"Failed to uninstall font '{src_path}': {str(e)}") from e
 
-        # Notify running programs
-        user32.SendMessageTimeoutW(
-            HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None
-        )
-    except Exception:
-        return False, traceback.format_exc()
-    return True, ""
+
+def _notify_font_change() -> None:
+    """
+    Send a notification to all running programs that fonts have changed.
+    This should be called once after all font operations are complete.
+    """
+    if sys.platform != "win32":
+        return
+
+    logger.debug("Notifying running programs of font changes")
+    user32.SendMessageTimeoutW(HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None)
 
 
 def _install_fonts(session_dir: str, scene_file_path: str) -> None:
@@ -278,16 +273,24 @@ def _install_fonts(session_dir: str, scene_file_path: str) -> None:
     :param session_dir: directory of the session
     :param scene_file_path: path to the scene file to use for finding fonts
     """
+    if sys.platform != "win32":
+        logger.info("Font installation is only supported on Windows, skipping...")
+        return
+
     logger.info("Looking for fonts to install...")
     fonts = find_fonts(session_dir, scene_file_path)
 
     if not fonts:
         raise RuntimeError("No custom fonts found")
+
+    # Install all fonts first
     for font in fonts:
         logger.info("Installing font: " + font)
-        installed, msg = install_font(font)
-        if not installed:
-            raise RuntimeError(f"Error installing font: {msg}")
+        install_font(font)  # Now raises RuntimeError directly on failure
+
+    # Send a single notification after all fonts are installed
+    _notify_font_change()
+    logger.info(f"Successfully installed {len(fonts)} fonts and notified running programs")
 
 
 def _remove_fonts(session_dir: str, scene_file_path: str) -> None:
@@ -297,6 +300,10 @@ def _remove_fonts(session_dir: str, scene_file_path: str) -> None:
     :param session_dir: directory of the session
     :param scene_file_path: path to the scene file to use for finding fonts
     """
+    if sys.platform != "win32":
+        logger.info("Font uninstallation is only supported on Windows, skipping...")
+        return
+
     logger.info("Looking for fonts to uninstall...")
     fonts = find_fonts(session_dir, scene_file_path)
 
@@ -304,12 +311,27 @@ def _remove_fonts(session_dir: str, scene_file_path: str) -> None:
         logger.info("No custom fonts found, finishing task...")
         return
 
+    # Track successful uninstalls for notification
+    fonts_uninstalled = 0
+
+    # Uninstall all fonts first
     for font in fonts:
         logger.info("Uninstalling font: " + font)
-        removed, msg = uninstall_font(font)
-        if not removed:
+        try:
+            uninstall_font(font)  # Now raises RuntimeError directly on failure
+            fonts_uninstalled += 1
+        except RuntimeError as e:
             # Don't fail task if font didn't get uninstalled
-            logger.error(f"Error uninstalling font: {msg}")
+            logger.error(f"Error uninstalling font: {e}")
+
+    # Send a single notification after all font operations are complete
+    if fonts_uninstalled > 0:
+        _notify_font_change()
+        logger.info(
+            f"Successfully uninstalled {fonts_uninstalled} fonts and notified running programs"
+        )
+    else:
+        logger.warning("No fonts were uninstalled")
 
 
 def setup_logger() -> None:

--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -54,6 +54,108 @@ FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
 logger = logging.getLogger(__name__)
 
 
+def _collect_fonts_from_directory(fonts_dir: str) -> Set[str]:
+    """
+    Collect all valid font files from a given directory.
+
+    :param fonts_dir: path to the fonts directory
+    :returns: set of font file paths found in the directory
+    """
+    fonts = set()
+
+    try:
+        for file_name in os.listdir(fonts_dir):
+            full_path = os.path.join(fonts_dir, file_name)
+
+            # Skip non-files (directories, symlinks, etc.)
+            if not os.path.isfile(full_path):
+                continue
+
+            _, ext = os.path.splitext(full_path)
+            if ext.lower() in FONT_EXTENSIONS:
+                logger.debug(f"Adding font: {full_path}")
+                fonts.add(full_path)
+            else:
+                logger.warning(f"Non-font file found in {FONTS_DIR} folder: {full_path}")
+
+    except (OSError, PermissionError) as e:
+        logger.warning(f"Could not access fonts directory {fonts_dir}: {e}")
+
+    return fonts
+
+
+def _find_fonts_recursive(session_dir: str) -> Set[str]:
+    """
+    Recursively search for fonts directory in session_dir.
+
+    :param session_dir: the root folder in which to look for files
+    :returns: set of font file paths found via recursive search
+    """
+    logger.info("Using recursive font search approach")
+    fonts = set()
+
+    try:
+        for root, dirs, files in os.walk(session_dir):
+            for dir_name in dirs:
+                # Skip directories that are not fonts directories
+                if dir_name != FONTS_DIR:
+                    continue
+
+                fonts_dir = os.path.join(root, dir_name)
+                logger.info(f"Found {FONTS_DIR} directory: {fonts_dir}")
+
+                # Skip system fonts directories (those under .env directories)
+                if os.sep + ".env" + os.sep in fonts_dir:
+                    logger.info(f"Skipping system fonts directory under .env: {fonts_dir}")
+                    continue
+
+                # Collect fonts from this directory and add to the overall set
+                logger.info(f"Processing fonts directory: {fonts_dir}")
+                directory_fonts = _collect_fonts_from_directory(fonts_dir)
+                logger.info(f"Found {len(directory_fonts)} fonts in directory: {fonts_dir}")
+                fonts.update(directory_fonts)
+
+    except (OSError, PermissionError) as e:
+        logger.warning(f"Could not perform recursive search in session directory: {e}")
+
+    logger.info(f"Recursive search completed. Total fonts found: {len(fonts)}")
+    return fonts
+
+
+def _find_fonts_scene_based(scene_file_path: str) -> Set[str]:
+    """
+    Search for fonts directory relative to the scene file path.
+
+    :param scene_file_path: path to the scene file to use for finding fonts
+    :returns: set of font file paths found via scene-based search
+    """
+    logger.debug("Using scene-based approach")
+
+    try:
+        scene_parent_dir = Path(scene_file_path).parent
+        fonts_dir_path = scene_parent_dir / FONTS_DIR
+        logger.debug(f"Looking for fonts in scene-based directory: {fonts_dir_path}")
+
+        # Early return if fonts directory doesn't exist
+        if not fonts_dir_path.exists():
+            logger.debug(f"Scene-based {FONTS_DIR} directory not found: {fonts_dir_path}")
+            return set()
+
+        # Early return if path exists but isn't a directory
+        if not fonts_dir_path.is_dir():
+            logger.debug(f"Scene-based {FONTS_DIR} path is not a directory: {fonts_dir_path}")
+            return set()
+
+        logger.debug(f"Scene-based {FONTS_DIR} directory found: {fonts_dir_path}")
+        fonts = _collect_fonts_from_directory(str(fonts_dir_path))
+        logger.debug(f"Found {len(fonts)} fonts in scene-based {FONTS_DIR} directory")
+        return fonts
+
+    except Exception as e:
+        logger.warning(f"Error accessing scene file path for font location: {e}")
+        return set()
+
+
 def find_fonts(session_dir: str, scene_file_path: str) -> Set[str]:
     """
     Looks for all font files that were sent along with the job
@@ -66,68 +168,14 @@ def find_fonts(session_dir: str, scene_file_path: str) -> Set[str]:
     logger.debug(f"Starting font search in session_dir: {session_dir}")
     logger.debug(f"Scene file path provided: {scene_file_path}")
 
-    fonts = set()
-
     # Approach 1: Recursive search for fonts directories in session_dir
-    logger.debug("Using recursive font search approach")
-    try:
-        for root, dirs, files in os.walk(session_dir):
-            for dir_name in dirs:
-                if dir_name == FONTS_DIR:
-                    fonts_dir = os.path.join(root, dir_name)
-                    logger.debug(f"Found {FONTS_DIR} directory: {fonts_dir}")
-
-                    try:
-                        for file_name in os.listdir(fonts_dir):
-                            full_path = os.path.join(fonts_dir, file_name)
-                            if os.path.isfile(full_path):
-                                _, ext = os.path.splitext(full_path)
-                                if ext.lower() in FONT_EXTENSIONS:
-                                    logger.debug(f"Adding font: {full_path}")
-                                    fonts.add(full_path)
-                                else:
-                                    logger.warning(
-                                        f"Non-font file found in {FONTS_DIR} folder: {full_path}"
-                                    )
-                    except (OSError, PermissionError) as e:
-                        logger.warning(f"Could not access fonts directory {fonts_dir}: {e}")
-                        continue
-    except (OSError, PermissionError) as e:
-        logger.warning(f"Could not perform recursive search in session directory: {e}")
-
-    # If fonts were found via recursive search, return them
+    fonts = _find_fonts_recursive(session_dir)
     if fonts:
-        logger.debug(f"Found {len(fonts)} fonts via recursive search")
         return fonts
 
     # Approach 2: Scene file path approach as fallback
     logger.debug("No fonts found via recursive search, trying scene-based approach")
-    try:
-        scene_parent_dir = Path(scene_file_path).parent
-        fonts_dir_path = scene_parent_dir / FONTS_DIR
-        logger.debug(f"Looking for fonts in scene-based directory: {fonts_dir_path}")
-
-        if fonts_dir_path.exists() and fonts_dir_path.is_dir():
-            logger.debug(f"Scene-based {FONTS_DIR} directory found: {fonts_dir_path}")
-            font_count = 0
-            for font_file in fonts_dir_path.iterdir():
-                if font_file.is_file():
-                    _, ext = os.path.splitext(str(font_file))
-                    if ext.lower() in FONT_EXTENSIONS:
-                        logger.debug(f"Adding font from scene {FONTS_DIR}: {font_file}")
-                        fonts.add(str(font_file))
-                        font_count += 1
-                    else:
-                        logger.warning(f"Non-font file found in {FONTS_DIR} folder: {font_file}")
-            logger.debug(f"Found {font_count} fonts in scene-based {FONTS_DIR} directory")
-        else:
-            logger.debug(
-                f"Scene-based {FONTS_DIR} directory not found or not a directory: {fonts_dir_path}"
-            )
-    except Exception as e:
-        logger.warning(f"Error accessing scene file path for font location: {e}")
-
-    return fonts
+    return _find_fonts_scene_based(scene_file_path)
 
 
 def get_font_name(dst_path: str) -> str:

--- a/src/deadline/cinema4d_submitter/font_utils.py
+++ b/src/deadline/cinema4d_submitter/font_utils.py
@@ -5,14 +5,21 @@ import logging
 import os
 import platform
 import shutil
+import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, List, Any, Dict
 
 # Import fontTools for robust font metadata extraction
 # for detecting Adobe fonts.
-from fontTools import ttLib
+# Only available on Windows. Mac font functionality is not supported
+if sys.platform == "win32":
+    from fontTools import ttLib
+else:
+    # Stub for non-Windows platforms where font functionality is deactivated
+    ttLib = None  # type: ignore
 
-TEMP_FONTS_DIR = "tempFonts"
+FONTS_DIR = "fonts"
 
 # Font table indices from TrueType specification
 TTF_FAMILY_NAME = 1
@@ -24,7 +31,26 @@ TTF_POSTSCRIPT_NAME = 6
 logger = logging.getLogger(__name__)
 
 
-def get_font_metadata(font_path: str) -> Optional[Dict[str, Any]]:
+@dataclass
+class FontMetadata:
+    """
+    Dataclass representing font metadata extracted from a font file.
+    """
+
+    file_path: str
+    family_name: Optional[str] = None
+    style: Optional[str] = None
+    full_name: Optional[str] = None
+    postscript_name: Optional[str] = None
+    raw_names: Optional[Dict[int, str]] = None
+
+    def __post_init__(self):
+        """Initialize raw_names as empty dict if None."""
+        if self.raw_names is None:
+            self.raw_names = {}
+
+
+def get_font_metadata(font_path: str) -> Optional[FontMetadata]:
     """
     Extract font metadata from a font file using fontTools.
 
@@ -32,54 +58,50 @@ def get_font_metadata(font_path: str) -> Optional[Dict[str, Any]]:
         font_path (str): Path to the font file
 
     Returns:
-        Optional[Dict[str, Any]]: Font metadata dictionary or None if extraction fails
+        Optional[FontMetadata]: Font metadata dataclass or None if extraction fails
     """
 
     if not font_path or not os.path.isfile(font_path):
+        return None
+
+    if ttLib is None:
         return None
 
     try:
         font = ttLib.TTFont(font_path)
         names_table = font["name"].names
 
-        # Extract key font information
-        metadata: dict[str, Any] = {
-            "file_path": font_path,
-            "family_name": None,
-            "style": None,
-            "full_name": None,
-            "postscript_name": None,
-            "raw_names": {},
-        }
+        # Create FontMetadata instance
+        metadata = FontMetadata(file_path=font_path)
 
         # Build raw names table for debugging
         try:
-            metadata["raw_names"] = {i: str(names_table[i]) for i in range(len(names_table))}
+            metadata.raw_names = {i: str(names_table[i]) for i in range(len(names_table))}
         except Exception as e:
             logger.debug(f"Could not build raw names table for {font_path}: {e}")
 
         # Extract standard font names
         try:
             if len(names_table) > TTF_FAMILY_NAME:
-                metadata["family_name"] = str(names_table[TTF_FAMILY_NAME])
+                metadata.family_name = str(names_table[TTF_FAMILY_NAME])
         except (IndexError, Exception) as e:
             logger.debug(f"Could not extract family name from {font_path}: {e}")
 
         try:
             if len(names_table) > TTF_STYLE:
-                metadata["style"] = str(names_table[TTF_STYLE])
+                metadata.style = str(names_table[TTF_STYLE])
         except (IndexError, Exception) as e:
             logger.debug(f"Could not extract style from {font_path}: {e}")
 
         try:
             if len(names_table) > TTF_FULL_NAME:
-                metadata["full_name"] = str(names_table[TTF_FULL_NAME])
+                metadata.full_name = str(names_table[TTF_FULL_NAME])
         except (IndexError, Exception) as e:
             logger.debug(f"Could not extract full name from {font_path}: {e}")
 
         try:
             if len(names_table) > TTF_POSTSCRIPT_NAME:
-                metadata["postscript_name"] = str(names_table[TTF_POSTSCRIPT_NAME])
+                metadata.postscript_name = str(names_table[TTF_POSTSCRIPT_NAME])
         except (IndexError, Exception) as e:
             logger.debug(f"Could not extract PostScript name from {font_path}: {e}")
 
@@ -162,19 +184,20 @@ def _is_font_match(font_name: str, filename: str, file_path: str) -> bool:
     metadata = get_font_metadata(file_path)
     if metadata:
         # Check PostScript name match (exact match - highest priority)
-        postscript_name = metadata.get("postscript_name", "")
-        if postscript_name and font_name == postscript_name:
+        if metadata.postscript_name and font_name == metadata.postscript_name:
             return True
 
         # Check family name match
-        family_name = metadata.get("family_name", "").lower()
-        if family_name and (font_name_lower == family_name or font_name_lower in family_name):
-            return True
+        if metadata.family_name:
+            family_name_lower = metadata.family_name.lower()
+            if font_name_lower == family_name_lower or font_name_lower in family_name_lower:
+                return True
 
         # Check full name match
-        full_name = metadata.get("full_name", "").lower()
-        if full_name and (font_name_lower == full_name or font_name_lower in full_name):
-            return True
+        if metadata.full_name:
+            full_name_lower = metadata.full_name.lower()
+            if font_name_lower == full_name_lower or font_name_lower in full_name_lower:
+                return True
 
     # Fall back to filename-based matching
     # Exact filename match (without extension)
@@ -231,28 +254,6 @@ def get_system_font_directories() -> List[str]:
                 if os.path.isdir(location):
                     font_dirs.append(location)
 
-    elif system == "Darwin":  # macOS
-        # macOS font directories
-        mac_locations = [
-            "/Library/Fonts",
-            "/System/Library/Fonts",
-            os.path.expanduser("~/Library/Fonts"),
-        ]
-
-        for location in mac_locations:
-            if os.path.isdir(location):
-                font_dirs.append(location)
-
-        # Adobe fonts on macOS
-        adobe_locations = [
-            os.path.expanduser("~/Library/Application Support/Adobe/CoreSync/plugins/livetype/r"),
-            os.path.expanduser("~/Library/Application Support/Adobe/User Owned Fonts"),
-        ]
-
-        for location in adobe_locations:
-            if os.path.isdir(location):
-                font_dirs.append(location)
-
     else:
         logger.warning(f"Unknown operating system: {system}")
 
@@ -276,11 +277,7 @@ def is_font_file(file_path: str) -> bool:
     if not os.path.isfile(file_path):
         return False
 
-    # Check file extension first (quick check)
-    font_extensions = [".otf", ".ttf", ".fon", ""]  # Adobe fonts may have no extension
-    has_font_extension = any(file_path.lower().endswith(ext) for ext in font_extensions)
-
-    if not has_font_extension:
+    if ttLib is None:
         return False
 
     # Try to validate the font file using fontTools
@@ -328,8 +325,8 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
         logger.error(f"Font file validation failed: {font_location}")
         return
 
-    # Create the tempFonts directory within the scene location if it doesn't exist
-    fonts_dir = scene_location / TEMP_FONTS_DIR
+    # Create the fonts directory within the scene location if it doesn't exist
+    fonts_dir = scene_location / FONTS_DIR
 
     try:
         fonts_dir.mkdir(exist_ok=True, parents=True)
@@ -376,7 +373,7 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
 
 def scene_has_fonts(scene_location: Path) -> bool:
     """
-    Check if a scene has fonts by looking for the tempFonts directory and its contents.
+    Check if a scene has fonts by looking for the fonts directory and its contents.
 
     Args:
         scene_location (Path): Path to the scene location
@@ -387,9 +384,9 @@ def scene_has_fonts(scene_location: Path) -> bool:
     if not scene_location or not scene_location.exists():
         return False
 
-    fonts_dir = scene_location / TEMP_FONTS_DIR
+    fonts_dir = scene_location / FONTS_DIR
 
-    # Check if tempFonts directory exists and has font files
+    # Check if fonts directory exists and has font files
     if fonts_dir.exists() and fonts_dir.is_dir():
         for font_file in fonts_dir.iterdir():
             if is_font_file(str(font_file)):

--- a/src/deadline/cinema4d_submitter/font_utils.py
+++ b/src/deadline/cinema4d_submitter/font_utils.py
@@ -3,21 +3,12 @@
 import c4d
 import logging
 import os
-import platform
 import shutil
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, List, Any, Dict
 
-# Import fontTools for robust font metadata extraction
-# for detecting Adobe fonts.
-# Only available on Windows. Mac font functionality is not supported
-if sys.platform == "win32":
-    from fontTools import ttLib
-else:
-    # Stub for non-Windows platforms where font functionality is deactivated
-    ttLib = None  # type: ignore
+from .platform_utils import is_windows
 
 FONTS_DIR = "fonts"
 
@@ -64,7 +55,13 @@ def get_font_metadata(font_path: str) -> Optional[FontMetadata]:
     if not font_path or not os.path.isfile(font_path):
         return None
 
-    if ttLib is None:
+    if not is_windows():
+        return None
+
+    # Import fontTools only when needed and on Windows
+    try:
+        from fontTools import ttLib
+    except ImportError:
         return None
 
     try:
@@ -224,10 +221,9 @@ def get_system_font_directories() -> List[str]:
     Returns:
         List[str]: List of font directory paths
     """
-    system = platform.system()
     font_dirs = []
 
-    if system == "Windows":
+    if is_windows():
         # Windows font directories
         windir = os.environ.get("WINDIR", r"C:\Windows")
         localappdata = os.environ.get("LOCALAPPDATA")
@@ -255,7 +251,7 @@ def get_system_font_directories() -> List[str]:
                     font_dirs.append(location)
 
     else:
-        logger.warning(f"Unknown operating system: {system}")
+        logger.warning("Font functionality is only supported on Windows")
 
     logger.debug(f"Found {len(font_dirs)} font directories: {font_dirs}")
     return font_dirs
@@ -277,7 +273,13 @@ def is_font_file(file_path: str) -> bool:
     if not os.path.isfile(file_path):
         return False
 
-    if ttLib is None:
+    if not is_windows():
+        return False
+
+    # Import fontTools only when needed and on Windows
+    try:
+        from fontTools import ttLib
+    except ImportError:
         return False
 
     # Try to validate the font file using fontTools

--- a/src/deadline/cinema4d_submitter/platform_utils.py
+++ b/src/deadline/cinema4d_submitter/platform_utils.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Platform utility functions for cross-platform compatibility.
+"""
+
+import sys
+
+
+def is_windows() -> bool:
+    """
+    Check if the current platform is Windows.
+
+    Returns:
+        bool: True if running on Windows, False otherwise
+    """
+    return sys.platform == "win32"
+
+
+def is_macos() -> bool:
+    """
+    Check if the current platform is macOS.
+
+    Returns:
+        bool: True if running on macOS, False otherwise
+    """
+    return sys.platform == "darwin"


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/292

### What was the problem/requirement? (What/Why)

Fonts does not work when submitted from MacOS.

### What was the solution? (How)

I contacted Maxon support and they suggested that we should just use instruct customers to make their text objects editable and submit as that's their recommended option for us. 
So I updated the code to do just that. 

I also added the code that I was working on [font's PR](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/283) followup into this PR. 

I'm also working on unit tests for this feature. But I guess its best to add that into a follow up PR and not make this PR even bigger than it already is. 

### What is the impact of this change?

Better visibility and only runs the font bundling logic in Windows. Also, updated our docs with this info. 

### How was this change tested?

Ran few manual tests to confirm that no font bundling happens. 

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes ( I had to modify the versions in parameter_values.yaml to make it work, I'll have a PR for that shortly. )

```

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 

======================================================================== slowest 5 durations ======================================================================== 
475.01s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
109.75s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
87.64s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
85.93s call     test/integ/test_cinema4d.py::test_integ[redshift]
80.12s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
=================================================================== 7 passed in 962.10s (0:16:02) ===================================================================
```

- Have you made changes to the submitter?
Yes and it does not require any changes to the test setup. 

### Was this change documented?

Yes

### Is this a breaking change?

No. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*