### PR TITLE
chore: Fix integ test checker to be ignore conda package versions.

### DIFF
--- a/test/integ/utils.py
+++ b/test/integ/utils.py
@@ -164,6 +164,11 @@ def assert_expected_job_bundle_and_generated_job_bundle_are_equal(
             content1 = replace_backslashes(content1)
             content2 = replace_backslashes(content2)
 
+            # Special handling for parameter_values.yaml to normalize version differences
+            if file == "parameter_values.yaml":
+                content1 = _normalize_conda_packages_version(content1)
+                content2 = _normalize_conda_packages_version(content2)
+
             if content1 == content2:
                 results["identical_files"].append(file)
             else:
@@ -178,6 +183,21 @@ def assert_expected_job_bundle_and_generated_job_bundle_are_equal(
     assert "template.yaml" in results["identical_files"]
     assert "parameter_values.yaml" in results["identical_files"]
     assert "asset_references.yaml" in results["identical_files"]
+
+
+def _normalize_conda_packages_version(content: str) -> str:
+    """
+    Normalize the CondaPackages parameter to match the expected test format.
+    This allows tests to pass regardless of the actual version numbers by
+    normalizing the generated content to match the expected format.
+    """
+
+    content = re.sub(
+        r"cinema4d=202[4-9].\* cinema4d-openjd=0.\d.\*",
+        "cinema4d=2025.* cinema4d-openjd=0.7.*",
+        content,
+    )
+    return content
 
 
 def assert_all_images_close(expected_image_directory: Path, actual_image_directory: Path):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The integration tests was checking if the conda package versions are equivalent to what was added into the test packages. It does not need to be so strict as the conda package versions could change. 

### What was the solution? (How)

Added code identical to keyshot [over here](https://github.com/aws-deadline/deadline-cloud-for-keyshot/blob/mainline/test/integ/helpers/test_runners.py#L181-L184). 

### What is the impact of this change?

We don't need to update the version numbers for the conda packages again in tests. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes

- Have you made changes to the submitter?
No

### Was this change documented?
Only changes to the test. 

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*