### PR TITLE
refactor: Improving font handling and added some tests

### DIFF
--- a/src/deadline/cinema4d_submitter/font_installer.py
+++ b/src/deadline/cinema4d_submitter/font_installer.py
@@ -5,6 +5,7 @@ Utility functions for the handling of fonts
 """
 
 import ctypes
+import glob
 import logging
 import os
 import shutil
@@ -66,7 +67,7 @@ def _collect_fonts_from_directory(fonts_dir: str) -> Set[str]:
 
             _, ext = os.path.splitext(full_path)
             if ext.lower() in FONT_EXTENSIONS:
-                logger.debug(f"Adding font: {full_path}")
+                logger.info(f"Adding font: {full_path}")
                 fonts.add(full_path)
             else:
                 logger.warning(f"Non-font file found in {FONTS_DIR} folder: {full_path}")
@@ -88,25 +89,26 @@ def _find_fonts_recursive(session_dir: str) -> Set[str]:
     fonts = set()
 
     try:
-        for root, dirs, files in os.walk(session_dir):
-            for dir_name in dirs:
-                # Skip directories that are not fonts directories
-                if dir_name != FONTS_DIR:
-                    continue
+        # Use glob to find all fonts directories recursively
+        fonts_dir_pattern = os.path.join(session_dir, "**", FONTS_DIR)
+        fonts_directories = glob.glob(fonts_dir_pattern, recursive=True)
 
-                fonts_dir = os.path.join(root, dir_name)
-                logger.info(f"Found {FONTS_DIR} directory: {fonts_dir}")
+        for fonts_dir in fonts_directories:
+            if not os.path.isdir(fonts_dir):
+                continue
 
-                # Skip system fonts directories (those under .env directories)
-                if os.sep + ".env" + os.sep in fonts_dir:
-                    logger.info(f"Skipping system fonts directory under .env: {fonts_dir}")
-                    continue
+            logger.info(f"Found {FONTS_DIR} directory: {fonts_dir}")
 
-                # Collect fonts from this directory and add to the overall set
-                logger.info(f"Processing fonts directory: {fonts_dir}")
-                directory_fonts = _collect_fonts_from_directory(fonts_dir)
-                logger.info(f"Found {len(directory_fonts)} fonts in directory: {fonts_dir}")
-                fonts.update(directory_fonts)
+            # Skip system fonts directories (those under .env directories)
+            if os.sep + ".env" + os.sep in fonts_dir:
+                logger.info(f"Skipping system fonts directory under .env: {fonts_dir}")
+                continue
+
+            # Collect fonts from this directory and add to the overall set
+            logger.info(f"Processing fonts directory: {fonts_dir}")
+            directory_fonts = _collect_fonts_from_directory(fonts_dir)
+            logger.info(f"Found {len(directory_fonts)} fonts in directory: {fonts_dir}")
+            fonts.update(directory_fonts)
 
     except (OSError, PermissionError) as e:
         logger.warning(f"Could not perform recursive search in session directory: {e}")
@@ -122,26 +124,26 @@ def _find_fonts_scene_based(scene_file_path: str) -> Set[str]:
     :param scene_file_path: path to the scene file to use for finding fonts
     :returns: set of font file paths found via scene-based search
     """
-    logger.debug("Using scene-based approach")
+    logger.info("Using scene-based approach")
 
     try:
         scene_parent_dir = Path(scene_file_path).parent
         fonts_dir_path = scene_parent_dir / FONTS_DIR
-        logger.debug(f"Looking for fonts in scene-based directory: {fonts_dir_path}")
+        logger.info(f"Looking for fonts in scene-based directory: {fonts_dir_path}")
 
         # Early return if fonts directory doesn't exist
         if not fonts_dir_path.exists():
-            logger.debug(f"Scene-based {FONTS_DIR} directory not found: {fonts_dir_path}")
+            logger.info(f"Scene-based {FONTS_DIR} directory not found: {fonts_dir_path}")
             return set()
 
         # Early return if path exists but isn't a directory
         if not fonts_dir_path.is_dir():
-            logger.debug(f"Scene-based {FONTS_DIR} path is not a directory: {fonts_dir_path}")
+            logger.info(f"Scene-based {FONTS_DIR} path is not a directory: {fonts_dir_path}")
             return set()
 
-        logger.debug(f"Scene-based {FONTS_DIR} directory found: {fonts_dir_path}")
+        logger.info(f"Scene-based {FONTS_DIR} directory found: {fonts_dir_path}")
         fonts = _collect_fonts_from_directory(str(fonts_dir_path))
-        logger.debug(f"Found {len(fonts)} fonts in scene-based {FONTS_DIR} directory")
+        logger.info(f"Found {len(fonts)} fonts in scene-based {FONTS_DIR} directory")
         return fonts
 
     except Exception as e:
@@ -158,17 +160,21 @@ def find_fonts(session_dir: str, scene_file_path: str) -> Set[str]:
 
     :returns: a set with all found fonts
     """
-    logger.debug(f"Starting font search in session_dir: {session_dir}")
-    logger.debug(f"Scene file path provided: {scene_file_path}")
+    logger.info(f"Starting font search in session_dir: {session_dir}")
+    logger.info(f"Scene file path provided: {scene_file_path}")
 
-    # Approach 1: Recursive search for fonts directories in session_dir
-    fonts = _find_fonts_recursive(session_dir)
-    if fonts:
-        return fonts
+    # Combine both approaches for comprehensive font discovery
+    recursive_fonts = _find_fonts_recursive(session_dir)
+    scene_fonts = _find_fonts_scene_based(scene_file_path)
 
-    # Approach 2: Scene file path approach as fallback
-    logger.debug("No fonts found via recursive search, trying scene-based approach")
-    return _find_fonts_scene_based(scene_file_path)
+    # Combine results from both approaches
+    all_fonts = recursive_fonts.union(scene_fonts)
+
+    logger.info(f"Recursive search found: {len(recursive_fonts)} fonts")
+    logger.info(f"Scene-based search found: {len(scene_fonts)} fonts")
+    logger.info(f"Total unique fonts found: {len(all_fonts)}")
+
+    return all_fonts
 
 
 def get_font_name(dst_path: str) -> str:
@@ -327,7 +333,7 @@ def _notify_font_change() -> None:
     # Import Windows-specific modules only when needed
     user32 = ctypes.WinDLL("user32", use_last_error=True)  # type: ignore[attr-defined]
 
-    logger.debug("Notifying running programs of font changes")
+    logger.info("Notifying running programs of font changes")
     user32.SendMessageTimeoutW(HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None)
 
 
@@ -415,8 +421,8 @@ if __name__ == "__main__":
     session_dir = sys.argv[2]
     scene_file_path = sys.argv[3]
 
-    logger.debug(f"Running font script job: {sys.argv[1]}")
-    logger.debug(f"Using scene file path: {scene_file_path}")
+    logger.info(f"Running font script job: {sys.argv[1]}")
+    logger.info(f"Using scene file path: {scene_file_path}")
 
     if sys.argv[1] == "install":
         _install_fonts(session_dir, scene_file_path)

--- a/src/deadline/cinema4d_submitter/font_utils.py
+++ b/src/deadline/cinema4d_submitter/font_utils.py
@@ -6,7 +6,7 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, List, Any, Dict
+from typing import Optional, List, Any
 
 from .platform_utils import is_windows
 
@@ -33,12 +33,6 @@ class FontMetadata:
     style: Optional[str] = None
     full_name: Optional[str] = None
     postscript_name: Optional[str] = None
-    raw_names: Optional[Dict[int, str]] = None
-
-    def __post_init__(self):
-        """Initialize raw_names as empty dict if None."""
-        if self.raw_names is None:
-            self.raw_names = {}
 
 
 def get_font_metadata(font_path: str) -> Optional[FontMetadata]:
@@ -70,12 +64,6 @@ def get_font_metadata(font_path: str) -> Optional[FontMetadata]:
 
         # Create FontMetadata instance
         metadata = FontMetadata(file_path=font_path)
-
-        # Build raw names table for debugging
-        try:
-            metadata.raw_names = {i: str(names_table[i]) for i in range(len(names_table))}
-        except Exception as e:
-            logger.debug(f"Could not build raw names table for {font_path}: {e}")
 
         # Extract standard font names
         try:
@@ -187,13 +175,13 @@ def _is_font_match(font_name: str, filename: str, file_path: str) -> bool:
         # Check family name match
         if metadata.family_name:
             family_name_lower = metadata.family_name.lower()
-            if font_name_lower == family_name_lower or font_name_lower in family_name_lower:
+            if font_name_lower in family_name_lower:
                 return True
 
         # Check full name match
         if metadata.full_name:
             full_name_lower = metadata.full_name.lower()
-            if font_name_lower == full_name_lower or font_name_lower in full_name_lower:
+            if font_name_lower in full_name_lower:
                 return True
 
     # Fall back to filename-based matching

--- a/src/deadline/cinema4d_submitter/platform_utils.py
+++ b/src/deadline/cinema4d_submitter/platform_utils.py
@@ -8,20 +8,10 @@ import sys
 
 
 def is_windows() -> bool:
-    """
-    Check if the current platform is Windows.
-
-    Returns:
-        bool: True if running on Windows, False otherwise
-    """
+    """Check if running on Windows."""
     return sys.platform == "win32"
 
 
 def is_macos() -> bool:
-    """
-    Check if the current platform is macOS.
-
-    Returns:
-        bool: True if running on macOS, False otherwise
-    """
+    """Check if running on macOS."""
     return sys.platform == "darwin"

--- a/test/unit/deadline_submitter_for_cinema4d/test_assets.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_assets.py
@@ -94,3 +94,124 @@ def test_parse_scene_assets(input_assets: list[dict], expected_output: set[Path]
     mock_documents.GetActiveDocument.assert_called_once()
     mock_documents.GetAllAssetsNew.assert_called_once()
     assert output_assets == expected_output
+
+
+# Font-related tests for AssetIntrospector
+class TestAssetIntrospectorFonts:
+    """Test font functionality in AssetIntrospector.parse_scene_assets()"""
+
+    def _create_font_asset(self, name="Arial", param_id=12345, exists=True):
+        """Helper to create font asset dict"""
+        return {"assetname": name, "paramId": param_id, "owner": mock.MagicMock(), "exists": exists}
+
+    def _setup_scene(self, tmp_path, create_fonts_dir=True, font_name="Arial"):
+        """Helper to set up scene directory structure"""
+        scene_dir = tmp_path / "scene"
+        scene_dir.mkdir()
+        scene_file = scene_dir / "test.c4d"
+        fonts_dir = scene_dir / "fonts"
+
+        if create_fonts_dir:
+            fonts_dir.mkdir()
+            font_file = fonts_dir / f"{font_name}.ttf"
+            font_file.write_text("fake font data")
+            return scene_dir, scene_file, fonts_dir, font_file
+
+        return scene_dir, scene_file, fonts_dir, None
+
+    @pytest.mark.parametrize(
+        "is_windows,should_copy,font_in_assets",
+        [
+            (True, True, True),  # Windows: copy fonts and include in assets
+            (False, False, False),  # Non-Windows: skip fonts
+        ],
+    )
+    def test_font_handling_by_platform(self, tmp_path, is_windows, should_copy, font_in_assets):
+        """Test font handling differs by platform"""
+        scene_dir, scene_file, fonts_dir, font_file = self._setup_scene(tmp_path)
+        font_asset = self._create_font_asset()
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch("deadline.cinema4d_submitter.assets.is_windows", return_value=is_windows),
+            mock.patch("deadline.cinema4d_submitter.assets.is_asset_a_font", return_value=True),
+            mock.patch("deadline.cinema4d_submitter.assets.copy_font_to_scene_folder") as mock_copy,
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [font_asset], kwargs["assetList"]
+            )
+
+            assets = AssetIntrospector().parse_scene_assets()
+
+            if should_copy:
+                mock_copy.assert_called_once_with("Arial", scene_dir)
+            else:
+                mock_copy.assert_not_called()
+
+            assert (font_file in assets) == font_in_assets
+            assert scene_file in assets
+
+    def test_font_copying_behavior(self, tmp_path):
+        """Test that detected fonts trigger copy operation"""
+        scene_dir, scene_file, _, _ = self._setup_scene(tmp_path, create_fonts_dir=False)
+        font_asset = self._create_font_asset("CustomFont")
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch("deadline.cinema4d_submitter.assets.is_windows", return_value=True),
+            mock.patch("deadline.cinema4d_submitter.assets.is_asset_a_font", return_value=True),
+            mock.patch("deadline.cinema4d_submitter.assets.copy_font_to_scene_folder") as mock_copy,
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [font_asset], kwargs["assetList"]
+            )
+            AssetIntrospector().parse_scene_assets()
+            mock_copy.assert_called_once_with("CustomFont", scene_dir)
+
+    def test_no_fonts_directory(self, tmp_path):
+        """Test behavior when no fonts directory exists"""
+        scene_dir, scene_file, _, _ = self._setup_scene(tmp_path, create_fonts_dir=False)
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch("deadline.cinema4d_submitter.assets.is_windows", return_value=True),
+            mock.patch("deadline.cinema4d_submitter.assets.is_asset_a_font", return_value=False),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [], kwargs["assetList"]
+            )
+            assets = AssetIntrospector().parse_scene_assets()
+            assert assets == {scene_file}
+
+    def test_mixed_font_and_regular_assets(self, tmp_path):
+        """Test parsing scene with both font and regular assets"""
+        scene_dir, scene_file, fonts_dir, font_file = self._setup_scene(
+            tmp_path, font_name="TestFont"
+        )
+
+        font_asset = self._create_font_asset("TestFont")
+        regular_asset = {"filename": "C:\\Users\\test-user\\texture.png", "exists": True}
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch("deadline.cinema4d_submitter.assets.is_windows", return_value=True),
+            mock.patch(
+                "deadline.cinema4d_submitter.assets.is_asset_a_font",
+                side_effect=lambda asset: asset.get("assetname") == "TestFont",
+            ),
+            mock.patch("deadline.cinema4d_submitter.assets.copy_font_to_scene_folder") as mock_copy,
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [font_asset, regular_asset], kwargs["assetList"]
+            )
+
+            assets = AssetIntrospector().parse_scene_assets()
+
+            mock_copy.assert_called_once_with("TestFont", scene_dir)
+            assert {scene_file, Path("C:\\Users\\test-user\\texture.png"), font_file}.issubset(
+                assets
+            )

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -1,0 +1,124 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest import mock
+
+
+from deadline.cinema4d_submitter.cinema4d_render_submitter import (
+    _get_job_template,
+    TakeData,
+)
+from deadline.cinema4d_submitter.data_classes import (
+    RenderSubmitterUISettings,
+    default_timeout_entries,
+)
+
+
+class TestCinema4dRenderSubmitterFonts:
+    """Test cases for font-related functionality in cinema4d_render_submitter.py."""
+
+    def test_get_job_template_adds_font_manager_when_fonts_detected(self, tmp_path):
+        """Test FontManager environment is added when fonts are detected on Windows."""
+        # Create mock settings
+        settings = RenderSubmitterUISettings()
+        settings.name = "Test Job"
+        settings.include_adaptor_wheels = False
+        settings.timeouts = default_timeout_entries()
+
+        # Create minimal take (required parameter but not used for font logic)
+        takes = [TakeData("Main", "Main", "standard", "", None, "1-10", set(), False)]
+
+        # Create a scene file
+        scene_file = tmp_path / "test_scene.c4d"
+        scene_file.write_text("dummy scene content")
+
+        # Test: Windows + fonts detected = FontManager added
+        with mock.patch(
+            "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows", return_value=True
+        ):
+            with mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
+                return_value=str(scene_file),
+            ):
+                with mock.patch(
+                    "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
+                    return_value=True,
+                ):
+                    # Test the function
+                    result = _get_job_template(settings, set(), takes)
+
+                    # Verify FontManager environment was added
+                    assert "jobEnvironments" in result
+                    assert len(result["jobEnvironments"]) == 1
+                    assert result["jobEnvironments"][0]["name"] == "FontManager"
+
+    def test_get_job_template_skips_font_manager_non_windows(self, tmp_path):
+        """Test FontManager environment is NOT added on non-Windows platforms."""
+        # Create mock settings
+        settings = RenderSubmitterUISettings()
+        settings.name = "Test Job"
+        settings.include_adaptor_wheels = False
+        settings.timeouts = default_timeout_entries()
+
+        # Create minimal take (required parameter but not used for font logic)
+        takes = [TakeData("Main", "Main", "standard", "", None, "1-10", set(), False)]
+
+        # Create a scene file
+        scene_file = tmp_path / "test_scene.c4d"
+        scene_file.write_text("dummy scene content")
+
+        # Test: Non-Windows = FontManager NOT added (even if fonts exist)
+        with mock.patch(
+            "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows", return_value=False
+        ):
+            with mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
+                return_value=str(scene_file),
+            ):
+                with mock.patch(
+                    "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
+                    return_value=True,
+                ):
+                    # Test the function
+                    result = _get_job_template(settings, set(), takes)
+
+                    # Verify FontManager environment was NOT added
+                    assert (
+                        "jobEnvironments" not in result
+                        or len(result.get("jobEnvironments", [])) == 0
+                    )
+
+    def test_get_job_template_skips_font_manager_no_fonts(self, tmp_path):
+        """Test FontManager environment is NOT added when no fonts are detected."""
+        # Create mock settings
+        settings = RenderSubmitterUISettings()
+        settings.name = "Test Job"
+        settings.include_adaptor_wheels = False
+        settings.timeouts = default_timeout_entries()
+
+        # Create minimal take (required parameter but not used for font logic)
+        takes = [TakeData("Main", "Main", "standard", "", None, "1-10", set(), False)]
+
+        # Create a scene file
+        scene_file = tmp_path / "test_scene.c4d"
+        scene_file.write_text("dummy scene content")
+
+        # Test: Windows + no fonts = FontManager NOT added
+        with mock.patch(
+            "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows", return_value=True
+        ):
+            with mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
+                return_value=str(scene_file),
+            ):
+                with mock.patch(
+                    "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
+                    return_value=False,
+                ):
+                    # Test the function
+                    result = _get_job_template(settings, set(), takes)
+
+                    # Verify FontManager environment was NOT added
+                    assert (
+                        "jobEnvironments" not in result
+                        or len(result.get("jobEnvironments", [])) == 0
+                    )

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -32,24 +32,27 @@ class TestCinema4dRenderSubmitterFonts:
         scene_file.write_text("dummy scene content")
 
         # Test: Windows + fonts detected = FontManager added
-        with mock.patch(
-            "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows", return_value=True
-        ):
-            with mock.patch(
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows",
+                return_value=True,
+            ),
+            mock.patch(
                 "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
                 return_value=str(scene_file),
-            ):
-                with mock.patch(
-                    "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
-                    return_value=True,
-                ):
-                    # Test the function
-                    result = _get_job_template(settings, set(), takes)
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
+                return_value=True,
+            ),
+        ):
+            # Test the function
+            result = _get_job_template(settings, set(), takes)
 
-                    # Verify FontManager environment was added
-                    assert "jobEnvironments" in result
-                    assert len(result["jobEnvironments"]) == 1
-                    assert result["jobEnvironments"][0]["name"] == "FontManager"
+            # Verify FontManager environment was added
+            assert "jobEnvironments" in result
+            assert len(result["jobEnvironments"]) == 1
+            assert result["jobEnvironments"][0]["name"] == "FontManager"
 
     def test_get_job_template_skips_font_manager_non_windows(self, tmp_path):
         """Test FontManager environment is NOT added on non-Windows platforms."""
@@ -67,25 +70,25 @@ class TestCinema4dRenderSubmitterFonts:
         scene_file.write_text("dummy scene content")
 
         # Test: Non-Windows = FontManager NOT added (even if fonts exist)
-        with mock.patch(
-            "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows", return_value=False
-        ):
-            with mock.patch(
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows",
+                return_value=False,
+            ),
+            mock.patch(
                 "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
                 return_value=str(scene_file),
-            ):
-                with mock.patch(
-                    "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
-                    return_value=True,
-                ):
-                    # Test the function
-                    result = _get_job_template(settings, set(), takes)
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
+                return_value=True,
+            ),
+        ):
+            # Test the function
+            result = _get_job_template(settings, set(), takes)
 
-                    # Verify FontManager environment was NOT added
-                    assert (
-                        "jobEnvironments" not in result
-                        or len(result.get("jobEnvironments", [])) == 0
-                    )
+            # Verify FontManager environment was NOT added
+            assert "jobEnvironments" not in result or len(result.get("jobEnvironments", [])) == 0
 
     def test_get_job_template_skips_font_manager_no_fonts(self, tmp_path):
         """Test FontManager environment is NOT added when no fonts are detected."""
@@ -103,22 +106,22 @@ class TestCinema4dRenderSubmitterFonts:
         scene_file.write_text("dummy scene content")
 
         # Test: Windows + no fonts = FontManager NOT added
-        with mock.patch(
-            "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows", return_value=True
-        ):
-            with mock.patch(
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows",
+                return_value=True,
+            ),
+            mock.patch(
                 "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
                 return_value=str(scene_file),
-            ):
-                with mock.patch(
-                    "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
-                    return_value=False,
-                ):
-                    # Test the function
-                    result = _get_job_template(settings, set(), takes)
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
+                return_value=False,
+            ),
+        ):
+            # Test the function
+            result = _get_job_template(settings, set(), takes)
 
-                    # Verify FontManager environment was NOT added
-                    assert (
-                        "jobEnvironments" not in result
-                        or len(result.get("jobEnvironments", [])) == 0
-                    )
+            # Verify FontManager environment was NOT added
+            assert "jobEnvironments" not in result or len(result.get("jobEnvironments", [])) == 0

--- a/test/unit/deadline_submitter_for_cinema4d/test_font_installer.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_font_installer.py
@@ -216,17 +216,17 @@ class TestFontInstaller:
         scene_file.write_text("dummy scene")
 
         # Mock is_windows to return False
-        with mock.patch(
-            "deadline.cinema4d_submitter.font_installer.is_windows", return_value=False
+        with (
+            mock.patch("deadline.cinema4d_submitter.font_installer.is_windows", return_value=False),
+            mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger,
         ):
-            with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
-                # Should not raise any exceptions
-                _install_fonts(str(session_dir), str(scene_file))
+            # Should not raise any exceptions
+            _install_fonts(str(session_dir), str(scene_file))
 
-                # Should log that it's skipping
-                mock_logger.info.assert_called_with(
-                    "Font installation is only supported on Windows, skipping..."
-                )
+            # Should log that it's skipping
+            mock_logger.info.assert_called_with(
+                "Font installation is only supported on Windows, skipping..."
+            )
 
     def test_remove_fonts_non_windows_skips(self, tmp_path):
         """Test skipping on non-Windows."""
@@ -237,17 +237,17 @@ class TestFontInstaller:
         scene_file.write_text("dummy scene")
 
         # Mock is_windows to return False
-        with mock.patch(
-            "deadline.cinema4d_submitter.font_installer.is_windows", return_value=False
+        with (
+            mock.patch("deadline.cinema4d_submitter.font_installer.is_windows", return_value=False),
+            mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger,
         ):
-            with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
-                # Should not raise any exceptions
-                _remove_fonts(str(session_dir), str(scene_file))
+            # Should not raise any exceptions
+            _remove_fonts(str(session_dir), str(scene_file))
 
-                # Should log that it's skipping
-                mock_logger.info.assert_called_with(
-                    "Font uninstallation is only supported on Windows, skipping..."
-                )
+            # Should log that it's skipping
+            mock_logger.info.assert_called_with(
+                "Font uninstallation is only supported on Windows, skipping..."
+            )
 
     def test_install_font_non_windows_logs_error(self, tmp_path):
         """Test behavior on non-Windows platforms."""
@@ -256,17 +256,15 @@ class TestFontInstaller:
         font_file.write_text("dummy font content")
 
         # Mock is_windows to return False
-        with mock.patch(
-            "deadline.cinema4d_submitter.font_installer.is_windows", return_value=False
+        with (
+            mock.patch("deadline.cinema4d_submitter.font_installer.is_windows", return_value=False),
+            mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger,
         ):
-            with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
-                # Should not raise any exceptions but should log error
-                install_font(str(font_file))
+            # Should not raise any exceptions but should log error
+            install_font(str(font_file))
 
-                # Should log that it's not supported
-                mock_logger.error.assert_called_with(
-                    "Font installation is only supported on Windows"
-                )
+            # Should log that it's not supported
+            mock_logger.error.assert_called_with("Font installation is only supported on Windows")
 
     def test_uninstall_font_non_windows_logs_error(self, tmp_path):
         """Test behavior on non-Windows platforms."""
@@ -275,14 +273,12 @@ class TestFontInstaller:
         font_file.write_text("dummy font content")
 
         # Mock is_windows to return False
-        with mock.patch(
-            "deadline.cinema4d_submitter.font_installer.is_windows", return_value=False
+        with (
+            mock.patch("deadline.cinema4d_submitter.font_installer.is_windows", return_value=False),
+            mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger,
         ):
-            with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
-                # Should not raise any exceptions but should log error
-                uninstall_font(str(font_file))
+            # Should not raise any exceptions but should log error
+            uninstall_font(str(font_file))
 
-                # Should log that it's not supported
-                mock_logger.error.assert_called_with(
-                    "Font uninstallation is only supported on Windows"
-                )
+            # Should log that it's not supported
+            mock_logger.error.assert_called_with("Font uninstallation is only supported on Windows")

--- a/test/unit/deadline_submitter_for_cinema4d/test_font_installer.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_font_installer.py
@@ -1,0 +1,288 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest import mock
+
+
+from deadline.cinema4d_submitter.font_installer import (
+    _collect_fonts_from_directory,
+    _find_fonts_recursive,
+    _find_fonts_scene_based,
+    find_fonts,
+    install_font,
+    uninstall_font,
+    _install_fonts,
+    _remove_fonts,
+    FONTS_DIR,
+)
+
+
+class TestFontInstaller:
+    """Test cases for font_installer.py functionality."""
+
+    def test_collect_fonts_from_directory_mixed_files(self, tmp_path):
+        """Test directory with fonts and non-font files."""
+        # Create fonts directory
+        fonts_dir = tmp_path / FONTS_DIR
+        fonts_dir.mkdir()
+
+        # Create mixed files - fonts and non-fonts
+        files = [
+            "arial.ttf",  # Valid font
+            "helvetica.otf",  # Valid font
+            "readme.txt",  # Non-font file
+            "image.png",  # Non-font file
+            "config.json",  # Non-font file
+            "system.fon",  # Valid font
+            "adobe_font",  # No extension (Adobe fonts)
+        ]
+
+        for file_name in files:
+            file_path = fonts_dir / file_name
+            file_path.write_text("dummy content")
+
+        # Mock logger to capture warnings
+        with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
+            result = _collect_fonts_from_directory(str(fonts_dir))
+
+        # Verify only font files are collected
+        assert len(result) == 4
+
+        expected_font_paths = {
+            str(fonts_dir / "arial.ttf"),
+            str(fonts_dir / "helvetica.otf"),
+            str(fonts_dir / "system.fon"),
+            str(fonts_dir / "adobe_font"),
+        }
+        assert result == expected_font_paths
+
+        # Verify warnings were logged for non-font files
+        assert mock_logger.warning.call_count == 3  # 3 non-font files
+
+    def test_collect_fonts_from_directory_empty(self, tmp_path):
+        """Test empty directory."""
+        # Create empty fonts directory
+        fonts_dir = tmp_path / FONTS_DIR
+        fonts_dir.mkdir()
+
+        # Test the function
+        result = _collect_fonts_from_directory(str(fonts_dir))
+
+        # Verify no fonts are collected
+        assert len(result) == 0
+        assert result == set()
+
+    def test_find_fonts_combines_recursive_and_scene(self, tmp_path):
+        """Test that both search methods are combined."""
+        # Create session directory
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        # Create scene file
+        scene_file = session_dir / "my_scene.c4d"
+        scene_file.write_text("dummy scene content")
+
+        # Create fonts via recursive search (in subdirectory)
+        recursive_fonts_dir = session_dir / "assets" / FONTS_DIR
+        recursive_fonts_dir.mkdir(parents=True)
+        (recursive_fonts_dir / "recursive_font.ttf").write_text("dummy content")
+
+        # Create fonts via scene-based search (next to scene file)
+        scene_fonts_dir = session_dir / FONTS_DIR
+        scene_fonts_dir.mkdir()
+        (scene_fonts_dir / "scene_font.otf").write_text("dummy content")
+
+        # Test the combined function
+        result = find_fonts(str(session_dir), str(scene_file))
+
+        # Verify fonts from both methods are found
+        assert len(result) == 2
+        expected_paths = {
+            str(recursive_fonts_dir / "recursive_font.ttf"),
+            str(scene_fonts_dir / "scene_font.otf"),
+        }
+        assert result == expected_paths
+
+    def test_find_fonts_scene_based_no_fonts_dir(self, tmp_path):
+        """Test when no fonts directory exists."""
+        # Create scene file
+        scene_file = tmp_path / "my_scene.c4d"
+        scene_file.write_text("dummy scene content")
+
+        # Create some other directories but no fonts directory
+        (tmp_path / "textures").mkdir()
+        (tmp_path / "models").mkdir()
+
+        # Test the function
+        result = _find_fonts_scene_based(str(scene_file))
+
+        # Verify no fonts are found
+        assert len(result) == 0
+        assert result == set()
+
+    def test_find_fonts_recursive_nested_structure(self, tmp_path):
+        """Test deeply nested directory structure."""
+        # Create deeply nested structure
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        # Create nested fonts directory
+        nested_fonts_dir = session_dir / "level1" / "level2" / "level3" / FONTS_DIR
+        nested_fonts_dir.mkdir(parents=True)
+        (nested_fonts_dir / "nested_font.ttf").write_text("dummy content")
+
+        # Test the function
+        result = _find_fonts_recursive(str(session_dir))
+
+        # Verify nested font is found
+        assert len(result) == 1
+        expected_path = str(nested_fonts_dir / "nested_font.ttf")
+        assert expected_path in result
+
+    def test_find_fonts_recursive_skips_env_directories(self, tmp_path):
+        """Test skipping .env directories."""
+        # Create session directory
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        # Create regular fonts directory
+        regular_fonts_dir = session_dir / FONTS_DIR
+        regular_fonts_dir.mkdir()
+        (regular_fonts_dir / "regular_font.ttf").write_text("dummy content")
+
+        # Create fonts directory under .env (should be skipped)
+        env_fonts_dir = session_dir / ".env" / FONTS_DIR
+        env_fonts_dir.mkdir(parents=True)
+        (env_fonts_dir / "system_font.ttf").write_text("dummy content")
+
+        # Test the function
+        result = _find_fonts_recursive(str(session_dir))
+
+        # Verify only regular font is found, .env font is skipped
+        assert len(result) == 1
+        expected_path = str(regular_fonts_dir / "regular_font.ttf")
+        assert expected_path in result
+
+        # Verify .env font is not included
+        env_font_path = str(env_fonts_dir / "system_font.ttf")
+        assert env_font_path not in result
+
+    def test_find_fonts_recursive_no_fonts_found(self, tmp_path):
+        """Test when no fonts directories exist."""
+        # Create session directory with no fonts directories
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        # Create some other directories but no fonts
+        (session_dir / "assets").mkdir()
+        (session_dir / "textures").mkdir()
+
+        # Test the function
+        result = _find_fonts_recursive(str(session_dir))
+
+        # Verify no fonts are found
+        assert len(result) == 0
+        assert result == set()
+
+    def test_find_fonts_scene_based_fonts_dir_exists(self, tmp_path):
+        """Test when fonts directory exists next to scene."""
+        # Create scene file
+        scene_file = tmp_path / "my_scene.c4d"
+        scene_file.write_text("dummy scene content")
+
+        # Create fonts directory next to scene file
+        fonts_dir = tmp_path / FONTS_DIR
+        fonts_dir.mkdir()
+
+        # Create test font files
+        font_files = ["scene_font.ttf", "another_font.otf"]
+        for font_file in font_files:
+            font_path = fonts_dir / font_file
+            font_path.write_text("dummy font content")
+
+        # Test the function
+        result = _find_fonts_scene_based(str(scene_file))
+
+        # Verify fonts are found
+        assert len(result) == 2
+        expected_paths = {str(fonts_dir / font) for font in font_files}
+        assert result == expected_paths
+
+    def test_install_fonts_non_windows_skips(self, tmp_path):
+        """Test skipping on non-Windows."""
+        # Create session directory and scene file
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        scene_file = session_dir / "scene.c4d"
+        scene_file.write_text("dummy scene")
+
+        # Mock is_windows to return False
+        with mock.patch(
+            "deadline.cinema4d_submitter.font_installer.is_windows", return_value=False
+        ):
+            with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
+                # Should not raise any exceptions
+                _install_fonts(str(session_dir), str(scene_file))
+
+                # Should log that it's skipping
+                mock_logger.info.assert_called_with(
+                    "Font installation is only supported on Windows, skipping..."
+                )
+
+    def test_remove_fonts_non_windows_skips(self, tmp_path):
+        """Test skipping on non-Windows."""
+        # Create session directory and scene file
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        scene_file = session_dir / "scene.c4d"
+        scene_file.write_text("dummy scene")
+
+        # Mock is_windows to return False
+        with mock.patch(
+            "deadline.cinema4d_submitter.font_installer.is_windows", return_value=False
+        ):
+            with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
+                # Should not raise any exceptions
+                _remove_fonts(str(session_dir), str(scene_file))
+
+                # Should log that it's skipping
+                mock_logger.info.assert_called_with(
+                    "Font uninstallation is only supported on Windows, skipping..."
+                )
+
+    def test_install_font_non_windows_logs_error(self, tmp_path):
+        """Test behavior on non-Windows platforms."""
+        # Create a dummy font file
+        font_file = tmp_path / "test_font.ttf"
+        font_file.write_text("dummy font content")
+
+        # Mock is_windows to return False
+        with mock.patch(
+            "deadline.cinema4d_submitter.font_installer.is_windows", return_value=False
+        ):
+            with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
+                # Should not raise any exceptions but should log error
+                install_font(str(font_file))
+
+                # Should log that it's not supported
+                mock_logger.error.assert_called_with(
+                    "Font installation is only supported on Windows"
+                )
+
+    def test_uninstall_font_non_windows_logs_error(self, tmp_path):
+        """Test behavior on non-Windows platforms."""
+        # Create a dummy font file
+        font_file = tmp_path / "test_font.ttf"
+        font_file.write_text("dummy font content")
+
+        # Mock is_windows to return False
+        with mock.patch(
+            "deadline.cinema4d_submitter.font_installer.is_windows", return_value=False
+        ):
+            with mock.patch("deadline.cinema4d_submitter.font_installer.logger") as mock_logger:
+                # Should not raise any exceptions but should log error
+                uninstall_font(str(font_file))
+
+                # Should log that it's not supported
+                mock_logger.error.assert_called_with(
+                    "Font uninstallation is only supported on Windows"
+                )

--- a/test/unit/deadline_submitter_for_cinema4d/test_font_utils.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_font_utils.py
@@ -18,59 +18,63 @@ class TestFontUtils:
     # System Font Directory Tests
     def test_get_system_font_directories_windows(self):
         """Test Windows font directory detection."""
-        with mock.patch("deadline.cinema4d_submitter.font_utils.is_windows", return_value=True):
-            with mock.patch.dict(
+        with (
+            mock.patch("deadline.cinema4d_submitter.font_utils.is_windows", return_value=True),
+            mock.patch.dict(
                 os.environ,
                 {
                     "WINDIR": r"C:\Windows",
                     "LOCALAPPDATA": r"C:\Users\Test\AppData\Local",
                     "APPDATA": r"C:\Users\Test\AppData\Roaming",
                 },
-            ):
-                with mock.patch("os.path.isdir", return_value=True):
-                    result = get_system_font_directories()
+            ),
+            mock.patch("os.path.isdir", return_value=True),
+        ):
+            result = get_system_font_directories()
 
-                    # Verify expected directories are included
-                    assert len(result) >= 4  # At least system, user, and 2 Adobe directories
+            # Verify expected directories are included
+            assert len(result) >= 4  # At least system, user, and 2 Adobe directories
 
-                    # Check for system fonts directory (use os.path.join for cross-platform compatibility)
-                    expected_system_fonts = os.path.join(r"C:\Windows", "Fonts")
-                    assert expected_system_fonts in result
+            # Check for system fonts directory (use os.path.join for cross-platform compatibility)
+            expected_system_fonts = os.path.join(r"C:\Windows", "Fonts")
+            assert expected_system_fonts in result
 
-                    # Check for user fonts directory
-                    expected_user_fonts = os.path.join(
-                        r"C:\Users\Test\AppData\Local", "Microsoft", "Windows", "Fonts"
-                    )
-                    assert expected_user_fonts in result
+            # Check for user fonts directory
+            expected_user_fonts = os.path.join(
+                r"C:\Users\Test\AppData\Local", "Microsoft", "Windows", "Fonts"
+            )
+            assert expected_user_fonts in result
 
-                    # Check for Adobe font directories
-                    expected_adobe_dirs = [
-                        os.path.join(
-                            r"C:\Users\Test\AppData\Roaming",
-                            "Adobe",
-                            "CoreSync",
-                            "plugins",
-                            "livetype",
-                            "r",
-                        ),
-                        os.path.join(r"C:\Users\Test\AppData\Roaming", "Adobe", "User Owned Fonts"),
-                    ]
-                    for adobe_dir in expected_adobe_dirs:
-                        assert adobe_dir in result
+            # Check for Adobe font directories
+            expected_adobe_dirs = [
+                os.path.join(
+                    r"C:\Users\Test\AppData\Roaming",
+                    "Adobe",
+                    "CoreSync",
+                    "plugins",
+                    "livetype",
+                    "r",
+                ),
+                os.path.join(r"C:\Users\Test\AppData\Roaming", "Adobe", "User Owned Fonts"),
+            ]
+            for adobe_dir in expected_adobe_dirs:
+                assert adobe_dir in result
 
     def test_get_system_font_directories_non_windows(self):
         """Test non-Windows behavior."""
-        with mock.patch("deadline.cinema4d_submitter.font_utils.is_windows", return_value=False):
-            with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
-                result = get_system_font_directories()
+        with (
+            mock.patch("deadline.cinema4d_submitter.font_utils.is_windows", return_value=False),
+            mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger,
+        ):
+            result = get_system_font_directories()
 
-                # Should return empty list on non-Windows
-                assert result == []
+            # Should return empty list on non-Windows
+            assert result == []
 
-                # Should log warning
-                mock_logger.warning.assert_called_with(
-                    "Font functionality is only supported on Windows"
-                )
+            # Should log warning
+            mock_logger.warning.assert_called_with(
+                "Font functionality is only supported on Windows"
+            )
 
     # Font Copying Tests
     def test_copy_font_to_scene_folder_creates_fonts_dir(self, tmp_path):
@@ -79,40 +83,42 @@ class TestFontUtils:
         scene_location.mkdir()
 
         # Mock font location and validation
-        with mock.patch(
-            "deadline.cinema4d_submitter.font_utils.get_font_location",
-            return_value="/system/fonts/test.ttf",
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.font_utils.get_font_location",
+                return_value="/system/fonts/test.ttf",
+            ),
+            mock.patch("deadline.cinema4d_submitter.font_utils.is_font_file", return_value=True),
+            mock.patch("os.path.basename", return_value="test.ttf"),
+            mock.patch("shutil.copy2") as mock_copy,
         ):
-            with mock.patch(
-                "deadline.cinema4d_submitter.font_utils.is_font_file", return_value=True
-            ):
-                with mock.patch("os.path.basename", return_value="test.ttf"):
-                    with mock.patch("shutil.copy2") as mock_copy:
-                        copy_font_to_scene_folder("TestFont", scene_location)
+            copy_font_to_scene_folder("TestFont", scene_location)
 
-                        # Should create fonts directory
-                        fonts_dir = scene_location / FONTS_DIR
-                        assert fonts_dir.exists()
-                        assert fonts_dir.is_dir()
+            # Should create fonts directory
+            fonts_dir = scene_location / FONTS_DIR
+            assert fonts_dir.exists()
+            assert fonts_dir.is_dir()
 
-                        # Should copy the font
-                        mock_copy.assert_called_once()
+            # Should copy the font
+            mock_copy.assert_called_once()
 
     def test_copy_font_to_scene_folder_font_not_found(self, tmp_path):
         """Test when font not found in system."""
         scene_location = tmp_path / "scene"
         scene_location.mkdir()
 
-        with mock.patch(
-            "deadline.cinema4d_submitter.font_utils.get_font_location", return_value=None
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.font_utils.get_font_location", return_value=None
+            ),
+            mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger,
         ):
-            with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
-                # Should not raise exception, just log error
-                copy_font_to_scene_folder("NonExistentFont", scene_location)
+            # Should not raise exception, just log error
+            copy_font_to_scene_folder("NonExistentFont", scene_location)
 
-                mock_logger.error.assert_called_with(
-                    "Font 'NonExistentFont' not found in system font directories"
-                )
+            mock_logger.error.assert_called_with(
+                "Font 'NonExistentFont' not found in system font directories"
+            )
 
     def test_get_font_manager_environment_actions(self):
         """Test onEnter/onExit actions."""

--- a/test/unit/deadline_submitter_for_cinema4d/test_font_utils.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_font_utils.py
@@ -1,0 +1,157 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+from unittest import mock
+
+
+from deadline.cinema4d_submitter.font_utils import (
+    get_system_font_directories,
+    copy_font_to_scene_folder,
+    get_font_manager_environment,
+    FONTS_DIR,
+)
+
+
+class TestFontUtils:
+    """Test cases for font_utils.py functionality."""
+
+    # System Font Directory Tests
+    def test_get_system_font_directories_windows(self):
+        """Test Windows font directory detection."""
+        with mock.patch("deadline.cinema4d_submitter.font_utils.is_windows", return_value=True):
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "WINDIR": r"C:\Windows",
+                    "LOCALAPPDATA": r"C:\Users\Test\AppData\Local",
+                    "APPDATA": r"C:\Users\Test\AppData\Roaming",
+                },
+            ):
+                with mock.patch("os.path.isdir", return_value=True):
+                    result = get_system_font_directories()
+
+                    # Verify expected directories are included
+                    assert len(result) >= 4  # At least system, user, and 2 Adobe directories
+
+                    # Check for system fonts directory (use os.path.join for cross-platform compatibility)
+                    expected_system_fonts = os.path.join(r"C:\Windows", "Fonts")
+                    assert expected_system_fonts in result
+
+                    # Check for user fonts directory
+                    expected_user_fonts = os.path.join(
+                        r"C:\Users\Test\AppData\Local", "Microsoft", "Windows", "Fonts"
+                    )
+                    assert expected_user_fonts in result
+
+                    # Check for Adobe font directories
+                    expected_adobe_dirs = [
+                        os.path.join(
+                            r"C:\Users\Test\AppData\Roaming",
+                            "Adobe",
+                            "CoreSync",
+                            "plugins",
+                            "livetype",
+                            "r",
+                        ),
+                        os.path.join(r"C:\Users\Test\AppData\Roaming", "Adobe", "User Owned Fonts"),
+                    ]
+                    for adobe_dir in expected_adobe_dirs:
+                        assert adobe_dir in result
+
+    def test_get_system_font_directories_non_windows(self):
+        """Test non-Windows behavior."""
+        with mock.patch("deadline.cinema4d_submitter.font_utils.is_windows", return_value=False):
+            with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
+                result = get_system_font_directories()
+
+                # Should return empty list on non-Windows
+                assert result == []
+
+                # Should log warning
+                mock_logger.warning.assert_called_with(
+                    "Font functionality is only supported on Windows"
+                )
+
+    # Font Copying Tests
+    def test_copy_font_to_scene_folder_creates_fonts_dir(self, tmp_path):
+        """Test fonts directory creation."""
+        scene_location = tmp_path / "scene"
+        scene_location.mkdir()
+
+        # Mock font location and validation
+        with mock.patch(
+            "deadline.cinema4d_submitter.font_utils.get_font_location",
+            return_value="/system/fonts/test.ttf",
+        ):
+            with mock.patch(
+                "deadline.cinema4d_submitter.font_utils.is_font_file", return_value=True
+            ):
+                with mock.patch("os.path.basename", return_value="test.ttf"):
+                    with mock.patch("shutil.copy2") as mock_copy:
+                        copy_font_to_scene_folder("TestFont", scene_location)
+
+                        # Should create fonts directory
+                        fonts_dir = scene_location / FONTS_DIR
+                        assert fonts_dir.exists()
+                        assert fonts_dir.is_dir()
+
+                        # Should copy the font
+                        mock_copy.assert_called_once()
+
+    def test_copy_font_to_scene_folder_font_not_found(self, tmp_path):
+        """Test when font not found in system."""
+        scene_location = tmp_path / "scene"
+        scene_location.mkdir()
+
+        with mock.patch(
+            "deadline.cinema4d_submitter.font_utils.get_font_location", return_value=None
+        ):
+            with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
+                # Should not raise exception, just log error
+                copy_font_to_scene_folder("NonExistentFont", scene_location)
+
+                mock_logger.error.assert_called_with(
+                    "Font 'NonExistentFont' not found in system font directories"
+                )
+
+    def test_get_font_manager_environment_actions(self):
+        """Test onEnter/onExit actions."""
+        scene_file_path = "/path/to/scene.c4d"
+
+        with mock.patch("builtins.open", mock.mock_open(read_data="mock content")):
+            result = get_font_manager_environment(scene_file_path)
+
+            actions = result["script"]["actions"]
+
+            # Check onEnter action
+            assert "onEnter" in actions
+            on_enter = actions["onEnter"]
+            assert on_enter["command"] == "python"
+            assert len(on_enter["args"]) == 4
+            assert on_enter["args"][0] == "{{Env.File.fontInstaller}}"
+            assert on_enter["args"][1] == "install"
+            assert on_enter["args"][2] == "{{Session.WorkingDirectory}}"
+            assert on_enter["args"][3] == scene_file_path
+
+            # Check onExit action
+            assert "onExit" in actions
+            on_exit = actions["onExit"]
+            assert on_exit["command"] == "python"
+            assert len(on_exit["args"]) == 4
+            assert on_exit["args"][0] == "{{Env.File.fontInstaller}}"
+            assert on_exit["args"][1] == "remove"
+            assert on_exit["args"][2] == "{{Session.WorkingDirectory}}"
+            assert on_exit["args"][3] == scene_file_path
+
+    def test_get_font_manager_environment_scene_file_path(self):
+        """Test scene file path parameter."""
+        scene_file_path = "/custom/path/to/my_scene.c4d"
+
+        with mock.patch("builtins.open", mock.mock_open(read_data="mock content")):
+            result = get_font_manager_environment(scene_file_path)
+
+            actions = result["script"]["actions"]
+
+            # Check that scene file path is correctly passed to both actions
+            assert actions["onEnter"]["args"][3] == scene_file_path
+            assert actions["onExit"]["args"][3] == scene_file_path


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

This adds unit tests and also adds some refactor based on feedback from https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/294/files 

### What is the impact of this change?

More tests so more confidence in our code. No customer impact. 

### How was this change tested?

Ran the tests manually if the fonts are included. 

- Have you run the unit tests?
Yes. 

- Have you run the integration tests? (Add your integration test report below)
```
test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 

======================================================================== slowest 5 durations ======================================================================== 
476.08s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
108.51s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
99.43s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
85.26s call     test/integ/test_cinema4d.py::test_integ[redshift]
84.49s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
=================================================================== 7 passed in 974.76s (0:16:14) ===================================================================
```

- Have you made changes to the submitter?
No this is more on the tests side. 

### Was this change documented?

Just tests and refactor, no doc changes needed. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*