### PR TITLE
chore: Add fonttools dependency license.

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,0 +1,25 @@
+** fonttools; version 4.59.2 -- https://github.com/fonttools/fonttools
+
+MIT License
+
+Copyright (c) 2017 Just van Rossum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ destinations = [
 include = [
     "src/*",
     "hatch_custom_hook.py",
+    "THIRD_PARTY_LICENSES",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to bundle `fonttools` in our submitters. 

### What was the solution? (How)
To get permissions to distribute this package in our submitter, we need to add the license for this dependency. 

This license is from `fonttools`'s license file. https://github.com/fonttools/fonttools/blob/main/LICENSE 

This is only to include the license file, we will be adding a separate PR to add 

### What is the impact of this change?

Customers get `fonttools` bundled with the submitter. 

### How was this change tested?

No change as this only adds the license file. 

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*