### PR TITLE
feat: Include fonttools in submitter installer. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ classifiers = [
 dependencies = [
     "deadline >= 0.51.1,< 0.53",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
+    # fonttools is Windows-only due to Cinema 4D technical limitations
+    "fonttools >=4.59.2, <4.60; sys_platform == 'win32'",
 ]
 
 [project.urls]

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import c4d
 
-from .platform_utils import is_windows, is_macos
+from .platform_utils import is_macos
 
 _logger = _logging.getLogger(__name__)
 
@@ -21,14 +21,6 @@ def has_gui_deps():
             raise
         return False
 
-    return True
-
-
-def has_fonttools():
-    try:
-        import fontTools  # noqa
-    except ImportError:
-        return False
     return True
 
 
@@ -85,11 +77,6 @@ def install_gui():
     _install_packages(packages, "GUI libraries")
 
 
-def install_fonttools():
-    packages = ["fonttools"]
-    _install_packages(packages, "fonttools")
-
-
 if not has_gui_deps():
     if c4d.gui.QuestionDialog(
         "The AWS Deadline Cloud extension needs a few GUI components to work. Press Yes to install."
@@ -98,17 +85,6 @@ if not has_gui_deps():
     else:
         c4d.gui.MessageDialog(
             "Did not install GUI components, the AWS Deadline Cloud extension will fail with qtpy bindings errors."
-        )
-
-# Only install fonttools on Windows. Mac font functionality is not supported
-if is_windows() and not has_fonttools():
-    if c4d.gui.QuestionDialog(
-        "The AWS Deadline Cloud extension needs fonttools to work properly. Press Yes to install."
-    ):
-        install_fonttools()
-    else:
-        c4d.gui.MessageDialog(
-            "Did not install fonttools, some font-related functionality may not work properly."
         )
 
 from .cinema4d_render_submitter import show_submitter  # noqa: E402

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -95,11 +95,15 @@ def _validate_files(installation_path: Path) -> None:
 
     if platform.system() == "Windows":
         assert "cinema_4d_plugins" in top_level_dir
+        # fontTools is Windows-only due to Cinema 4D technical limitations
+        assert "fontTools" in top_level_dir
 
         # Check the Cinema_4d plugin file is inside the plugin folder
         plugin_file = [f.name for f in (installation_path / "cinema_4d_plugins").iterdir()]
         assert len(plugin_file) == 1
         assert "DeadlineCloud.pyp" in plugin_file
+    else:
+        assert "fontTools" not in top_level_dir
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Currently, customers would have to install `fonttools` dependency separately using `pip install` but this can be cumbersome for customers that prefer offline installations. 

### What was the solution? (How)

We have received [approvals](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/2bad5605d6fa719a539a7e6c56ff53022376fbc0) to bundle `fonttools` as part of our submitter installer. 

### What is the impact of this change?

Customers don't have to install `fonttools` separately, it will be included with the submitter installer. 

### How was this change tested?

I built a local installer and confirmed that it worked as expected. 

- Have you run the unit tests?
Yes. 

   Also added a unit test to check if `fonttools` is added as part of the installation. 

- Have you run the integration tests? (Add your integration test report below)
Yes. 

```
scheduling tests via LoadScheduling

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical] 
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured] 
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift] 
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes] 
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured] 
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] 
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes] 

=============================================================== slowest 5 durations =============================================================== 
591.00s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
127.90s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
103.60s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
97.04s call     test/integ/test_cinema4d.py::test_integ[redshift]
95.61s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
========================================================= 7 passed in 1153.81s (0:19:13) ==========================================================
```

- Have you made changes to the submitter?

Yes, but this does not require any updates. 

### Was this change documented?

Documentation is not required. 

### Is this a breaking change?

No. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*