### PR TITLE
chore: Do not bundle fonttools in Mac

### DIFF
--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import subprocess
 import sys
-
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Optional
-
 
 ADAPTOR_ONLY_DEPENDENCIES = {"openjd-adaptor-runtime"}
 
@@ -61,7 +59,8 @@ def get_dependencies(pyproject_dict: dict[str, Any], exclude_adaptor_only=True) 
     return [
         Dependency(dep_str)
         for dep_str in pyproject_dict["project"]["dependencies"]
-        if exclude_adaptor_only or dep_str not in ADAPTOR_ONLY_DEPENDENCIES
+        if (exclude_adaptor_only or dep_str not in ADAPTOR_ONLY_DEPENDENCIES)
+        and not (dep_str.startswith("fonttools") and sys.platform == "darwin")
     ]
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was an issue where the `fontTools` was getting packaged in Mac installers as well even though they cannot be used in Mac. 
The issue was that our packaging [code actually removed the markers](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/scripts/_project.py#L44-L46) and hence it would still package it. 

### What was the solution? (How)

Ideally, we should check whether the conditions satisfy and only then bundle the dependency. Unfortunately, this is not simple. For now, I propose to add a simple check so that the dependency does not get bundled. If we start adding multiple dependencies with specific conditions, we can make this better. 

### What is the impact of this change?

Mac OS submitters wouldn't have `fontTools` in them. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
No, there is no backend code change here. 

But ran the installer specific tests and confirmed that it works both on Mac and Windows:

```
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw8] [  7%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw4] [ 15%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw3] [ 23%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw1] [ 30%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [ 38%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw10] [ 46%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw5] [ 53%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw11] [ 61%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw12] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw0] [ 76%] PASSED test/installer/test_installer.py::test_default_location 
[gw6] [ 84%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 92%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

===================================== warnings summary =====================================

...

========================= 4 passed, 9 skipped, 1 warning in 12.23s =========================
```

- Have you made changes to the submitter?
No

### Was this change documented?
Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*