### PR TITLE
test: improve sys.exit mock in adaptor test

### DIFF
--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -240,12 +240,6 @@ def test_activate_error_checking(init_data: dict, activate_error_checking: int) 
 
 @pytest.fixture()
 def run_data() -> dict:
-    """
-    Pytest Fixture to return a run_data dictionary that passes validation
-
-    Returns:
-        dict: A run_data dictionary
-    """
     return {"frame": 42}
 
 

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_client.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_client.py
@@ -13,17 +13,17 @@ class TestCinema4DClient:
     def test_cinema4dclient(self, mock_httpclient: Mock) -> None:
         """Tests that the cinema4d client can initialize, set a take and close"""
         client = Cinema4DClient(server_path=str(9999))
-        with pytest.raises(SystemExit) as e:
+        with patch("sys.exit") as mock_exit:
             client.close()
-        assert e.value.code == 0
+        mock_exit.assert_called_once_with(0)
 
     @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client.ClientInterface")
     def test_graceful_shutdown(self, mock_httpclient: Mock) -> None:
         """Tests that the cinema4d client can initialize, set a take and close"""
         client = Cinema4DClient(server_path=str(9999))
-        with pytest.raises(SystemExit) as e:
+        with patch("sys.exit") as mock_exit:
             client.graceful_shutdown(0, None)
-        assert e.value.code == 0
+        mock_exit.assert_called_once_with(0)
 
     @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_client.os.path.exists")
     @patch.dict(os.environ, {"CINEMA4D_ADAPTOR_SERVER_PATH": "server_path"})


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Improve unit test mock to avoid catching SystemExit exception

### What was the solution? (How)

patch sys.ext

### What is the impact of this change?

modify unit test

### How was this change tested?

hatch run test

- Have you run the unit tests?
yes
- Have you run the integration tests? (Add your integration test report below)
no

- Have you made changes to the submitter?
no
### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*