### PR TITLE
chore: Add support for Cinema 4D 2026 in the installer.

### DIFF
--- a/install_builder/deadline-cloud-for-cinema-4d.xml
+++ b/install_builder/deadline-cloud-for-cinema-4d.xml
@@ -143,8 +143,8 @@
                         # Replace installation path in plugin file
                         sed -i '' 's|C4D_Submitter_Installation_Dir_To_Replace|${cinema_4d_submitter_installdir}|g' '${installdir}/tmp/c4d_deps/DeadlineCloud.pyp'
 
-                        # Find and process Cinema 4D 2024 and 2025 directories
-                        for version in 2024 2025; do
+                        # Find and process Cinema 4D 2024 to 2026 directories
+                        for version in 2024 2025 2026; do
                             find \"\$HOME/Library/Preferences/Maxon\" -type d -name \"Maxon Cinema 4D \$version\_*\" -maxdepth 1 | while read -r dir; do
                                 if [ -n \"\$dir\" ]; then
                                     plugin_dir=\"\$dir/plugins\"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Cinema 4D 2026 has been released. But our current Mac installers only install the plugin in 2024-2025 Cinema 4D plugin libraries. 

### What was the solution? (How)

Start adding the plugin into Cinema 4D 2026 plugins library too. 

### What is the impact of this change?

Mac installers can install Deadline Cloud plugin for Cinema 4D 2026. 

### How was this change tested?

Currently, the support for Cinema 4D 2026 is work in progress. This is one of the tasks that we need to add to get 2026 working. 

### Was this change documented?

No, currently we are still working to support 2026 and we don't want to update the docs yet. 

### Is this a breaking change?


No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*