### PR TITLE
ci: add changelog section for performance improvements

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -22,4 +22,11 @@
         {% endfor %}
     {% endif %}
 
+    {% if "performance improvements" in release["elements"] %}
+### Performance Improvements
+        {% for commit in release["elements"]["performance improvements"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
 {% endfor %}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,7 @@ We ask that you use these commit types in your commit titles:
 * `refactor` - When the pull request is implementing only a refactor of existing code;
 * `ci` - When the pull request is implementing a change to the CI infrastructure of the packge;
 * `chore` - When the pull request is a generic maintenance task.
+* `perf` - When the pull request is a performance improvement.
 
 We also require that the type in your conventional commit title end in an exclaimation point (e.g. `feat!` or `fix!`)
 if the pull request should be considered to be a breaking change in some way. Please also include a "BREAKING CHANGE" footer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ patch_tags = [
   "feat",
   "fix",
   "refactor",
+  "perf",
 ]
 
 [tool.semantic_release.publish]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There is no development/release workflow for communicating performance improvements.

### What was the solution? (How)

[Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standardizes the `perf: ...` commit type for this purpose.

This followed a previous work in aws-deadline/deadline-cloud#870:

1.  adds a section to the changelog template for performance improvements
2. adds `perf` commits to the `patch_tags` setting of `python-semantic-release` so that they are considered as part of bumping a version for release
3. adds developer-facing documentation for using the `perf:` commit type for performance improvements

### What is the impact of this change?

Developers can use `perf: ...` [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to communicate performance improvements when changelogs are automatically generated as part of the release

### How was this change tested?

1.  Set my local `mainline` branch to this commit
2. Added example commits using the `perf: ...` commit summary message
3. Ran:
    ```
    hatch run release:deps
    hatch run release:bump
    ```
4.  confirmed that rendered `CHANGELOG.md` contained the expected "Performance Improvements" section correctly

>   ## 0.8.3 (2025-10-20)
>   
>   
>   ### Features
>   * Include fonttools in submitter installer. (#306) ([`2422e7f`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/2422e7f8000d8840933b821a58667837863cc7f1))
>   
>   ### Bug Fixes
>   * Only bundle fonts on Windows as its not supported on Mac. (#294) ([`6ecebce`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/6ecebce5fc2dbf98e048adfd193511488d835dca))
>   
>   ### Performance Improvements
>   * a performance improvement message ([`c5ab1a4`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/commit/c5ab1a43da8d593fcf07c38ed94496ef4aca3b96))

### Was this change documented?

I've updated `CONTRIBUTING.md` to document the `perf: ...` commit type

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*