### PR TITLE
fix: Allow other users to access dependencies installed by system installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,33 @@ if not defined g_additionalModulePath (setx g_additionalModulePath %SUBMITTER_LO
 
 ```
 
+##### System-Wide Installation for All Users
+
+For shared workstations or enterprise environments where multiple users need access to the Cinema 4D submitter, you can perform a system-wide installation.
+
+**Prerequisites:**
+- Administrator account access
+- Cinema 4D installed on the system
+
+**Installation Steps:**
+
+1. **Install the submitter as Administrator:**
+   - Run the [Deadline Cloud submitter installer][deadline-cloud-submitter] as Administrator
+   - Select "system installation" option during installation
+   - This installs the submitter to a shared location (e.g., `C:\Program Files\DeadlineCloudSubmitter\`)
+
+2. **Initial dependency setup:**
+   - Open Cinema 4D as Administrator (right-click → "Run as administrator")
+   - The first time you access the submitter (`Extensions` > `AWS Deadline Cloud Submitter`), it will prompt to install GUI dependencies
+   - Click "Yes" to install the dependencies
+   - This step configures permissions so all users can access the installed packages
+
+3. **Regular usage:**
+   - After the initial setup, any user can open Cinema 4D normally (without Administrator privileges)
+   - The AWS Deadline Cloud Submitter will be available to all users
+
+If you encounter permission errors, ensure that step 2 (initial dependency setup) was completed as Administrator.
+
 #### Mac
 
 In a Mac terminal:

--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -84,6 +84,32 @@ A: Yes, you can set job priority levels in the submitter to control render queue
 
 A: The submitter includes built-in error detection to catch common issues like missing assets before submission. This can be deactivated in the submitter.
 
+**Q: I'm getting permission errors with a system-wide installation on Windows. How do I fix this?**
+
+A: If users encounter permission errors when accessing the submitter after a system-wide installation:
+
+1. **Verify initial setup was completed:**
+   - Ensure Cinema 4D was opened as Administrator at least once
+   - Ensure the dependency installation prompt was accepted
+   - Check that the installation completed without errors
+
+2. **Check file permissions:**
+   - Navigate to the installation directory (e.g., `C:\Program Files\DeadlineCloudSubmitter\`)
+   - Right-click → Properties → Security tab
+   - Verify that "Users" group has "Read & execute" permissions
+   - Permissions should be inherited by all subdirectories and files
+
+3. **Manual permission fix (if needed):**
+   - Open Command Prompt as Administrator
+   - Run: `icacls "C:\Program Files\DeadlineCloudSubmitter" /grant *S-1-5-32-545:(OI)(CI)(RX) /T`
+   - This grants read and execute permissions to all users
+
+4. **Verify Cinema 4D Python environment:**
+   - Open Cinema 4D as the affected user
+   - Go to `Extensions` > `Console`
+   - Try importing: `import deadline`
+   - If this fails, the permissions may not be correctly applied
+
 ## Glossary
 
 **Adaptor** - Software that runs on compute resources to execute your Cinema 4D renders or projects.

--- a/docs/user_guide/getting-started.md
+++ b/docs/user_guide/getting-started.md
@@ -28,6 +28,33 @@ The submitter adds AWS Deadline Cloud functionality to Cinema 4D's Extensions me
 
 To update the submitter to the latest version, download and run the latest [submitter installer](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html).
 
+## System-Wide Installation for Multiple Users (Windows)
+
+For shared workstations or enterprise environments where multiple users need access to the Cinema 4D submitter, you can perform a system-wide installation.
+
+### Prerequisites
+
+- Administrator account access
+- Cinema 4D installed on the system
+
+### Installation Steps
+
+1. **Install the submitter as Administrator:**
+   - Run the [Deadline Cloud submitter installer](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html) as Administrator
+   - Select "system installation" option during installation
+
+2. **Initial dependency setup:**
+   - Open Cinema 4D as Administrator (right-click → "Run as administrator")
+   - Access the submitter (`Extensions` > `AWS Deadline Cloud Submitter`)
+   - Click "Yes" when prompted to install GUI dependencies
+   - This configures permissions so all users can access the installed packages
+
+3. **Regular usage:**
+   - After initial setup, any user can open Cinema 4D normally (without Administrator privileges)
+   - The AWS Deadline Cloud Submitter will be available to all users
+
+For troubleshooting permission issues, see the [FAQ and Glossary →](faq-and-glossary.md)
+
 ## Step 2: Submit Your First Render (2 minutes)
 
 1. Open Cinema 4D and load a scene.

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -6,9 +6,79 @@ from pathlib import Path
 
 import c4d
 
-from .platform_utils import is_macos
+from .platform_utils import is_macos, is_windows
 
 _logger = _logging.getLogger(__name__)
+
+
+def _has_windows_admin_privileges() -> bool:
+    """
+    Determine if the current process is running with administrator privileges on Windows.
+
+    Returns:
+        True if running as administrator on Windows, False otherwise
+    """
+    # Early return if not running on Windows
+    if not is_windows():
+        return False
+
+    try:
+        import ctypes
+
+        # Use Windows API to check if the current process has admin privileges
+        # IsUserAnAdmin() returns non-zero if the user is an admin, 0 otherwise
+        return ctypes.windll.shell32.IsUserAnAdmin() != 0  # type: ignore[attr-defined]
+    except Exception:
+        # If any exception occurs (e.g., attribute error, access denied),
+        # assume not running as admin and return False
+        return False
+
+
+def _apply_windows_read_execute_permissions_for_all_users(directory: Path) -> None:
+    """
+    Apply read and execute permissions to all users for a directory on Windows.
+
+    This function uses the Windows icacls command to grant permissions following
+    the principle of least privilege. Users receive only the minimum permissions
+    needed to access and use installed Python packages.
+
+    Permission flags explained:
+    - Users: Applies to the built-in Users group (all non-admin users)
+    - (OI) Object Inherit: Files created in the directory inherit these permissions
+    - (CI) Container Inherit: Subdirectories created inherit these permissions
+    - (RX) Read and Execute: Minimum privileges needed to access and run Python packages
+      - R (Read): Users can read Python files and dependencies
+      - X (Execute): Users can execute Python scripts and binaries
+      - Does NOT include Write, Modify, or Full Control permissions
+    - /T: Apply recursively to all existing subdirectories and files
+
+    Args:
+        directory: The directory path to apply permissions to
+    """
+    # If not running as admin early return
+    if not _has_windows_admin_privileges():
+        return
+
+    # Construct icacls command with appropriate parameters
+    # Grant Users group Read and Execute permissions with inheritance
+    icacls_command = ["icacls", str(directory), "/grant", "Users:(OI)(CI)(RX)", "/T"]
+
+    try:
+        # Execute the command without raising exception on non-zero exit
+        result = subprocess.run(icacls_command, check=False, capture_output=True, text=True)
+
+        if result.returncode == 0:
+            _logger.info(f"Successfully applied Windows permissions to {directory}")
+        else:
+            _logger.warning(
+                f"Failed to apply Windows permissions to {directory}. "
+                f"Exit code: {result.returncode}. "
+                f"Error: {result.stderr.strip() if result.stderr else 'No error output'}"
+            )
+    except Exception as e:
+        _logger.warning(
+            f"Exception occurred while applying Windows permissions to {directory}: {e}"
+        )
 
 
 def has_gui_deps():
@@ -68,6 +138,10 @@ def _install_packages(packages, description):
             f"Missing {description} with non-standard set-up, installing into Cinema 4D's python"
         )
     subprocess.run(install_command, check=False)
+
+    # This ensures that system-wide installations grant access to all users
+    if module_directory.exists():
+        _apply_windows_read_execute_permissions_for_all_users(module_directory)
 
 
 def install_gui():

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -61,7 +61,10 @@ def _apply_windows_read_execute_permissions_for_all_users(directory: Path) -> No
 
     # Construct icacls command with appropriate parameters
     # Grant Users group Read and Execute permissions with inheritance
-    icacls_command = ["icacls", str(directory), "/grant", "Users:(OI)(CI)(RX)", "/T"]
+    # The SID for /Users group is "S-1-5-32-545". This ensures that all the
+    # users of the workstation have access to the installed packages.
+    # https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+    icacls_command = ["icacls", str(directory), "/grant", "*S-1-5-32-545:(OI)(CI)(RX)", "/T"]
 
     try:
         # Execute the command without raising exception on non-zero exit

--- a/src/deadline/cinema4d_submitter/__init__.py
+++ b/src/deadline/cinema4d_submitter/__init__.py
@@ -29,8 +29,6 @@ def _has_windows_admin_privileges() -> bool:
         # IsUserAnAdmin() returns non-zero if the user is an admin, 0 otherwise
         return ctypes.windll.shell32.IsUserAnAdmin() != 0  # type: ignore[attr-defined]
     except Exception:
-        # If any exception occurs (e.g., attribute error, access denied),
-        # assume not running as admin and return False
         return False
 
 
@@ -73,15 +71,37 @@ def _apply_windows_read_execute_permissions_for_all_users(directory: Path) -> No
         if result.returncode == 0:
             _logger.info(f"Successfully applied Windows permissions to {directory}")
         else:
+            error_msg = result.stderr.strip() if result.stderr else "No error output"
             _logger.warning(
                 f"Failed to apply Windows permissions to {directory}. "
                 f"Exit code: {result.returncode}. "
-                f"Error: {result.stderr.strip() if result.stderr else 'No error output'}"
+                f"Error: {error_msg}"
             )
+
+            # Show user-facing dialog with actionable guidance
+            dialog_message = (
+                f"Failed to apply permissions for all users to:\n"
+                f"{directory}\n\n"
+                f"Exit code: {result.returncode}\n"
+                f"Error: {error_msg}\n\n"
+                f"To fix this manually, run as Administrator:\n"
+                f'icacls "{directory}" /grant *S-1-5-32-545:(OI)(CI)(RX) /T'
+            )
+            c4d.gui.MessageDialog(dialog_message)
     except Exception as e:
         _logger.warning(
             f"Exception occurred while applying Windows permissions to {directory}: {e}"
         )
+
+        # Show user-facing dialog with actionable guidance
+        dialog_message = (
+            f"Failed to apply permissions for all users to:\n"
+            f"{directory}\n\n"
+            f"Exception: {str(e)}\n\n"
+            f"To fix this manually, run as Administrator:\n"
+            f'icacls "{directory}" /grant *S-1-5-32-545:(OI)(CI)(RX) /T'
+        )
+        c4d.gui.MessageDialog(dialog_message)
 
 
 def has_gui_deps():

--- a/test/unit/deadline_submitter_for_cinema4d/test_init.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_init.py
@@ -1,0 +1,138 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Unit tests for deadline.cinema4d_submitter.__init__ module."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+
+class TestHasWindowsAdminPrivileges:
+    """Tests for _has_windows_admin_privileges function."""
+
+    @patch("deadline.cinema4d_submitter.is_windows")
+    def test_returns_false_on_non_windows(self, mock_is_windows):
+        """Test that function returns False when not running on Windows."""
+        # Arrange
+        mock_is_windows.return_value = False
+
+        # Act
+        from deadline.cinema4d_submitter import _has_windows_admin_privileges
+
+        result = _has_windows_admin_privileges()
+
+        # Assert
+        assert result is False
+        mock_is_windows.assert_called_once()
+
+    @patch("deadline.cinema4d_submitter.is_windows")
+    def test_returns_true_when_admin_on_windows(self, mock_is_windows):
+        """Test that function returns True when running as admin on Windows."""
+        # Arrange
+        mock_is_windows.return_value = True
+
+        # Mock ctypes module
+        mock_ctypes = MagicMock()
+        mock_ctypes.windll.shell32.IsUserAnAdmin.return_value = 1
+
+        # Act
+        with patch.dict("sys.modules", {"ctypes": mock_ctypes}):
+            from deadline.cinema4d_submitter import _has_windows_admin_privileges
+
+            result = _has_windows_admin_privileges()
+
+        # Assert
+        assert result is True
+        mock_is_windows.assert_called_once()
+
+    @patch("deadline.cinema4d_submitter.is_windows")
+    def test_returns_false_when_not_admin_on_windows(self, mock_is_windows):
+        """Test that function returns False when not running as admin on Windows."""
+        # Arrange
+        mock_is_windows.return_value = True
+
+        # Mock ctypes module
+        mock_ctypes = MagicMock()
+        mock_ctypes.windll.shell32.IsUserAnAdmin.return_value = 0
+
+        # Act
+        with patch.dict("sys.modules", {"ctypes": mock_ctypes}):
+            from deadline.cinema4d_submitter import _has_windows_admin_privileges
+
+            result = _has_windows_admin_privileges()
+
+        # Assert
+        assert result is False
+        mock_is_windows.assert_called_once()
+
+    @patch("deadline.cinema4d_submitter.is_windows")
+    def test_returns_false_on_exception(self, mock_is_windows):
+        """Test that function returns False when IsUserAnAdmin raises an exception."""
+        # Arrange
+        mock_is_windows.return_value = True
+
+        # Mock ctypes module to raise exception
+        mock_ctypes = MagicMock()
+        mock_ctypes.windll.shell32.IsUserAnAdmin.side_effect = AttributeError("Simulated error")
+
+        # Act
+        with patch.dict("sys.modules", {"ctypes": mock_ctypes}):
+            from deadline.cinema4d_submitter import _has_windows_admin_privileges
+
+            result = _has_windows_admin_privileges()
+
+        # Assert
+        assert result is False
+        mock_is_windows.assert_called_once()
+
+
+class TestApplyWindowsReadExecutePermissionsForAllUsers:
+    """Tests for _apply_windows_read_execute_permissions_for_all_users function."""
+
+    @patch("deadline.cinema4d_submitter._has_windows_admin_privileges")
+    def test_early_return_when_not_admin(self, mock_has_admin):
+        """Test that function returns early when not running as admin."""
+        # Arrange
+        mock_has_admin.return_value = False
+        test_dir = Path("/test/directory")
+
+        # Act
+        from deadline.cinema4d_submitter import (
+            _apply_windows_read_execute_permissions_for_all_users,
+        )
+
+        with patch("deadline.cinema4d_submitter.subprocess.run") as mock_run:
+            _apply_windows_read_execute_permissions_for_all_users(test_dir)
+
+            # Assert
+            mock_has_admin.assert_called_once()
+            mock_run.assert_not_called()
+
+    @patch("deadline.cinema4d_submitter._has_windows_admin_privileges")
+    @patch("deadline.cinema4d_submitter.subprocess.run")
+    def test_executes_icacls_command_when_admin(self, mock_run, mock_has_admin):
+        """Test that icacls command is executed with correct parameters when running as admin."""
+        # Arrange
+        mock_has_admin.return_value = True
+        test_dir = Path("/test/directory")
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        # Act
+        from deadline.cinema4d_submitter import (
+            _apply_windows_read_execute_permissions_for_all_users,
+        )
+
+        _apply_windows_read_execute_permissions_for_all_users(test_dir)
+
+        # Assert
+        mock_has_admin.assert_called_once()
+        expected_command = [
+            "icacls",
+            str(test_dir),
+            "/grant",
+            "Users:(OI)(CI)(RX)",
+            "/T",
+        ]
+        mock_run.assert_called_once_with(
+            expected_command, check=False, capture_output=True, text=True
+        )

--- a/test/unit/deadline_submitter_for_cinema4d/test_init.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_init.py
@@ -130,7 +130,7 @@ class TestApplyWindowsReadExecutePermissionsForAllUsers:
             "icacls",
             str(test_dir),
             "/grant",
-            "Users:(OI)(CI)(RX)",
+            "*S-1-5-32-545:(OI)(CI)(RX)",
             "/T",
         ]
         mock_run.assert_called_once_with(


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/322

### What was the problem/requirement? (What/Why)

The system installation failed to work for other users even when run as an Administrator with system install. 

### What was the solution? (How)

Added logic to add read and execute permissions so that other users can use the dependencies installed. 

### What is the impact of this change?

Other users when installed as a system install will be able to use the plugin. 

### How was this change tested?

Ran it manually on an EC2 and confirmed that it worked. 

- Have you run the unit tests?
Yes, and also added some. 

- Have you run the integration tests? (Add your integration test report below)
Skipped as this code is not covered in integration tests and we want to get this fix in ASAP. 

- Have you made changes to the submitter?
Yes, but it does not have an impact on the tests. 

### Was this change documented?

This was a bug that is fixed. 

### Is this a breaking change?

No

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*