### PR TITLE
chore: Update installer instructions to suggest 2026 compatibility

### DIFF
--- a/install_builder/deadline-cloud-for-cinema-4d.xml
+++ b/install_builder/deadline-cloud-for-cinema-4d.xml
@@ -1,8 +1,8 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <component>
     <name>deadline_cloud_for_cinema_4d</name>
-    <description>Deadline Cloud for Cinema 4D 2024-2025</description>
-    <detailedDescription>Cinema 4D plugin for submitting jobs to AWS Deadline Cloud. Compatible with Cinema 4D 2024/2025</detailedDescription>
+    <description>Deadline Cloud for Cinema 4D 2024-2026</description>
+    <detailedDescription>Cinema 4D plugin for submitting jobs to AWS Deadline Cloud. Compatible with Cinema 4D 2024 to 2026</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -65,7 +65,7 @@
     <parameterList>
         <stringParameter name="deadline_cloud_for_cinema_4d_summary" ask="0" cliOptionShow="0">
             <value>Deadline Cloud for Cinema 4D
-- Compatible with Cinema 4D 2024/2025
+- Compatible with Cinema 4D 2024 to 2026
 - Installs the integrated Cinema 4D submitter to the installation directory
 - Registers the extension with Cinema 4D by setting the g_additionalModulePath
 - Sets the C4DPYTHONPATH311 to retrieve deadline modules on Windows. 
@@ -179,8 +179,8 @@
                 <runProgram>
                     <program>bash</program>
                     <programArguments>-c "
-                        # Handle uninstallation for both Cinema 4D 2024 and 2025
-                        for version in 2024 2025; do
+                        # Handle uninstallation for both Cinema 4D 2024 to 2025
+                        for version in 2024 2025 2026; do
                             find \"\$HOME/Library/Preferences/Maxon\" -name 'DeadlineCloud.pyp' -path \"*/Maxon Cinema 4D \$version\_*/plugins/*\" | while read -r file; do
                                 if [ -f \"\$file\" ]; then
                                     rm -f \"\$file\"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are working on updating the installers to work with 2026. Hence, this will update the documentation related to this as well. 

### What was the solution? (How)

Mostly documentation changes for the installers. But also added a fix for the un-installation for Mac systems.  

### What is the impact of this change?

Better instructions for customers. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Running it. 

- Have you made changes to the submitter?
Yes. But it does not affect the integration tests. 

### Was this change documented?
Yes

### Is this a breaking change?

No

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*