### PR TITLE
fix: Silently log errors and continue font handling.

### DIFF
--- a/src/deadline/cinema4d_submitter/font_utils.py
+++ b/src/deadline/cinema4d_submitter/font_utils.py
@@ -122,6 +122,7 @@ def get_font_location(font_name: str) -> Optional[str]:
         Optional[str]: Path to the font file if found, None otherwise
     """
     if not font_name or not font_name.strip():
+        logger.error("Failed to locate font: font name is empty")
         return None
 
     font_name = font_name.strip()
@@ -289,16 +290,14 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
     Args:
         font_name (str): Name of the font to copy
         scene_location (Path): Path to the scene location
-
-    Raises:
-        RuntimeError: If there's an error during the copy operation
-        ValueError: If input parameters are not valid
     """
     if not font_name or not font_name.strip():
-        raise ValueError("Font name cannot be empty")
+        logger.error("Failed to copy font: font name is empty")
+        return
 
     if not scene_location or not scene_location.exists():
-        raise ValueError(f"Scene location does not exist: {scene_location}")
+        logger.error(f"Failed to copy font: scene location does not exist at {scene_location}")
+        return
 
     font_name = font_name.strip()
 
@@ -321,7 +320,8 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
     try:
         fonts_dir.mkdir(exist_ok=True, parents=True)
     except OSError as e:
-        raise RuntimeError(f"Failed to create fonts directory '{fonts_dir}': {str(e)}")
+        logger.error(f"Failed to create fonts directory '{fonts_dir}': {str(e)}")
+        return
 
     # Copy the font file to the fonts directory
     font_file_name = os.path.basename(font_location)
@@ -348,17 +348,11 @@ def copy_font_to_scene_folder(font_name: str, scene_location: Path) -> None:
     try:
         shutil.copy2(font_location, destination)
         logger.debug(f"Successfully copied font from {font_location} to {destination}")
-
-        # Verify the copied file
-        if not is_font_file(str(destination)):
-            raise RuntimeError(f"Copied font file failed validation: {destination}")
-
     except (OSError, IOError, shutil.Error) as e:
-        error_msg = (
-            f"Error copying font '{font_name}' from '{font_location}' to '{destination}': {str(e)}"
+        logger.error(
+            f"Failed to copy font '{font_name}' from '{font_location}' to '{destination}': {str(e)}"
         )
-        logger.error(error_msg)
-        raise RuntimeError(error_msg)
+        return
 
 
 def scene_has_fonts(scene_location: Path) -> bool:

--- a/test/unit/deadline_submitter_for_cinema4d/test_font_utils.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_font_utils.py
@@ -9,6 +9,7 @@ from deadline.cinema4d_submitter.font_utils import (
     copy_font_to_scene_folder,
     get_font_manager_environment,
     FONTS_DIR,
+    get_font_location,
 )
 
 
@@ -161,3 +162,132 @@ class TestFontUtils:
             # Check that scene file path is correctly passed to both actions
             assert actions["onEnter"]["args"][3] == scene_file_path
             assert actions["onExit"]["args"][3] == scene_file_path
+
+    # Error Handling Tests
+    def test_copy_font_empty_name(self, tmp_path):
+        """Test copy_font_to_scene_folder with empty font name."""
+        scene_location = tmp_path / "scene"
+        scene_location.mkdir()
+
+        with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
+            # Should not raise exception
+            copy_font_to_scene_folder("", scene_location)
+
+            # Should log error
+            mock_logger.error.assert_called_with("Failed to copy font: font name is empty")
+
+    def test_copy_font_whitespace_only_name(self, tmp_path):
+        """Test copy_font_to_scene_folder with whitespace-only font name."""
+        scene_location = tmp_path / "scene"
+        scene_location.mkdir()
+
+        with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
+            # Should not raise exception
+            copy_font_to_scene_folder("   ", scene_location)
+
+            # Should log error
+            mock_logger.error.assert_called_with("Failed to copy font: font name is empty")
+
+    def test_copy_font_non_valid_scene_location(self, tmp_path):
+        """Test copy_font_to_scene_folder with non-existent scene location."""
+        scene_location = tmp_path / "nonexistent"
+
+        with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
+            # Should not raise exception
+            copy_font_to_scene_folder("TestFont", scene_location)
+
+            # Should log error with path
+            mock_logger.error.assert_called_with(
+                f"Failed to copy font: scene location does not exist at {scene_location}"
+            )
+
+    def test_copy_font_directory_creation_failure(self, tmp_path):
+        """Test copy_font_to_scene_folder when directory creation fails."""
+        scene_location = tmp_path / "scene"
+        scene_location.mkdir()
+
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.font_utils.get_font_location",
+                return_value="/system/fonts/test.ttf",
+            ),
+            mock.patch("deadline.cinema4d_submitter.font_utils.is_font_file", return_value=True),
+            mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger,
+            mock.patch("pathlib.Path.mkdir", side_effect=OSError("Permission denied")),
+        ):
+            # Should not raise exception
+            copy_font_to_scene_folder("TestFont", scene_location)
+
+            # Should log error with directory path and error details
+            fonts_dir = scene_location / FONTS_DIR
+            mock_logger.error.assert_called_with(
+                f"Failed to create fonts directory '{fonts_dir}': Permission denied"
+            )
+
+    def test_copy_font_file_copy_failure(self, tmp_path):
+        """Test copy_font_to_scene_folder when file copy fails."""
+        scene_location = tmp_path / "scene"
+        scene_location.mkdir()
+
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.font_utils.get_font_location",
+                return_value="/system/fonts/test.ttf",
+            ),
+            mock.patch("deadline.cinema4d_submitter.font_utils.is_font_file", return_value=True),
+            mock.patch("os.path.basename", return_value="test.ttf"),
+            mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger,
+            mock.patch("shutil.copy2", side_effect=OSError("Disk full")),
+        ):
+            # Should not raise exception
+            copy_font_to_scene_folder("TestFont", scene_location)
+
+            # Should log error with font name, source, destination, and error details
+            fonts_dir = scene_location / FONTS_DIR
+            destination = fonts_dir / "test.ttf"
+            mock_logger.error.assert_called_with(
+                f"Failed to copy font 'TestFont' from '/system/fonts/test.ttf' to '{destination}': Disk full"
+            )
+
+    def test_get_font_location_empty_name(self):
+        """Test get_font_location with empty font name."""
+        with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
+            result = get_font_location("")
+
+            # Should return None
+            assert result is None
+
+            # Should log error
+            mock_logger.error.assert_called_with("Failed to locate font: font name is empty")
+
+    def test_get_font_location_whitespace_only_name(self):
+        """Test get_font_location with whitespace-only font name."""
+        with mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger:
+            result = get_font_location("   ")
+
+            # Should return None
+            assert result is None
+
+            # Should log error
+            mock_logger.error.assert_called_with("Failed to locate font: font name is empty")
+
+    def test_copy_font_validation_failure_before_copy(self, tmp_path):
+        """Test copy_font_to_scene_folder when font validation fails before copy."""
+        scene_location = tmp_path / "scene"
+        scene_location.mkdir()
+
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.font_utils.get_font_location",
+                return_value="/system/fonts/non_valid.ttf",
+            ),
+            mock.patch("deadline.cinema4d_submitter.font_utils.is_font_file", return_value=False),
+            mock.patch("deadline.cinema4d_submitter.font_utils.logger") as mock_logger,
+        ):
+            # Should not raise exception
+            copy_font_to_scene_folder("non_validFont", scene_location)
+
+            # Should log error
+            mock_logger.error.assert_called_with(
+                "Font file validation failed: /system/fonts/non_valid.ttf"
+            )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Cinema 4D font utilities module was using exception-based error handling that could interrupt the job submission workflow. When font operations encountered errors (missing fonts, permission issues, non valid paths, etc.), the raised exceptions would block the entire submission process, preventing users from submitting render jobs even when the font issues were non-critical.

### What was the solution? (How)

Converted the font_utils.py module from exception-based error handling to a resilient log-and-continue model.

### What is the impact of this change?

Job submissions continue even when font operations fail. 

### How was this change tested?

- Have you run the unit tests?
Yes, also added few unit tests. 

- Have you run the integration tests? (Add your integration test report below)
Running it. 

- Have you made changes to the submitter?
No

### Was this change documented?

This change does not require documentation. 

### Is this a breaking change?

No

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*