### PR TITLE
feat: add support for C4D to Arnold

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ For instructions on installing and using this integration, visit the [user guide
 
 This library requires:
 
-1. Cinema 4D 2024 - 2025
+1. Cinema 4D 2024 - 2026
    * Redshift is supported but not required
+   * Arnold is supported but not required
 2. Python 3.9 or higher; but Python 3.11 is recommended as this is the version Cinema 4D uses natively.
-3. Windows or macOS operating system for job submission and Windows operating system for job rendering. There are some instructions below on how to setup the adaptors for job rendering on Linux but they are experimental.
-4. When rendering using Redshift with Cinema 4D on NVIDIA GPUs, NVIDIA GRID driver version 551.78 or later is required. Using older drivers can result in job failures.
+3. Windows or macOS operating system for job submission
+4. Windows or Linux operating system for job rendering
+    * Cinema 4D 2024 - 2026 is supported on Windows
+    * Cinema 4D 2025 is supported on Linux
+5. When rendering using Redshift with Cinema 4D on NVIDIA GPUs, NVIDIA GRID driver version 551.78 or later is required. Using older drivers can result in job failures.
 
 **Important:** Workers hosts with GPUs that run the Cinema 4D adaptor must have sufficient RAM (at least 2x the amount of VRAM) to run Cinema 4D correctly. For example, if your GPU has 16GB VRAM, your system should have at least 32GB RAM. Insufficient memory can lead to [unstable rendering behavior](https://help.maxon.net/c4d/s26/de-de/Content/_REDSHIFT_/html/Dealing+with+Out-Of-RAM+situations.html).
 
@@ -164,12 +168,11 @@ Both fleet types in Deadline Cloud support the Cinema 4D adaptor:
 1. Service managed fleets
 2. Customer managed fleets
 
-The Cinema 4D integration for Deadline Cloud is supported on Windows fleets (service managed and customer managed).
-Linux support is experimental and can only be done on customer managed fleets.
+The Cinema 4D integration for Deadline Cloud is supported on both Windows and Linux fleets (service managed and customer managed).
 
 ### Service managed fleets
 
-On [service managed fleets][service-managed-fleets], the Cinema 4D adaptor is automatically available via the `deadline-cloud` Conda channel with the [default Queue Environment][default-queue-environment].
+On [service managed fleets][service-managed-fleets], the Cinema 4D adaptor is automatically available via the `deadline-cloud` Conda channel with the [default Queue Environment][default-queue-environment]. This includes Redshift (built into the `cinema4d` package by default) and Arnold (can be used via the `cinema4d-c4dtoa` package).
 
 ### Customer managed fleets
 
@@ -200,7 +203,7 @@ For more information on the commands the OpenJD adaptor runtime provides, see [h
 Cinema 4D Conda packages are available in the "deadline-cloud" Conda channel on service managed Windows fleets.
 
 However, if you prefer, you can build the Cinema 4D Conda packages yourself. There are conda recipes in our samples Github repository for [`cinema4d-2025` on Windows](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-2025) and
-[`cinema4d-openjd` on Windows and Linux](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-openjd).
+[`cinema4d-openjd` on Windows and Linux](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-openjd), and [`cinema4d-c4dtoa` on Windows](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-c4dtoa-2025)
 
 For instructions on building conda recipes on Deadline Cloud, see [this article](https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/).
 Though it refers to Blender, the process applies to Cinema 4D recipes as well.
@@ -209,7 +212,7 @@ Though it refers to Blender, the process applies to Cinema 4D recipes as well.
 
 ### Service Managed Fleets
 
-[Usage based licensing][usage-based-licensing] for Cinema 4D 2024 and 2025 is available on Deadline Cloud service managed fleets with no additional setup.
+[Usage based licensing][usage-based-licensing] for Cinema 4D 2024 - 2026, Redshift 2024 - 2026, and Arnold 2025 - 2026 is available on Deadline Cloud service managed fleets with no additional setup.
 
 If you prefer to use your own licensing for service managed fleets, you can also [connect service-managed fleets to a custom license server](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-byol.html).
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -618,13 +618,19 @@ def setup_attachments(render_settings: RenderSubmitterUISettings) -> AssetRefere
     )
 
 
-def get_conda_packages() -> str:
+def get_conda_packages(doc: Any) -> str:
     """
     Get the required conda packages string based on C4D version.
     """
     c4d_major_version = str(c4d.GetC4DVersion())[:4]
     adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
-    return f"cinema4d={c4d_major_version}.* cinema4d-openjd={adaptor_version}.*"
+    packages = f"cinema4d={c4d_major_version}.* cinema4d-openjd={adaptor_version}.*"
+
+    render_data = doc.GetActiveRenderData()
+    if render_data[c4d.RDATA_RENDERENGINE] == 1029988:  # Arnold
+        packages += " cinema4d-c4dtoa"
+
+    return packages
 
 
 def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> None:
@@ -709,7 +715,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
     auto_detected_attachments = setup_auto_detected_attachments(takes["take_data_list"])
     attachments = setup_attachments(render_settings)
 
-    conda_packages = get_conda_packages()
+    conda_packages = get_conda_packages(doc)
 
     def on_create_job_bundle_callback(
         widget: SubmitJobToDeadlineDialog,

--- a/src/deadline/cinema4d_submitter/integ_test_helpers.py
+++ b/src/deadline/cinema4d_submitter/integ_test_helpers.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # This file is used only for integration tests.
+from typing import Any
+
 from .cinema4d_render_submitter import (
     initialize_render_settings,
     setup_attachments,
@@ -13,7 +15,7 @@ from .takes import TakeSelection
 import c4d
 
 
-def sample_queue_params() -> list:
+def sample_queue_params(doc: Any) -> list:
     """
     This is the default queue parameters that we expect during callbacks when we submit a job.
     """
@@ -28,7 +30,7 @@ def sample_queue_params() -> list:
                 "groupLabel": "Queue Environment: Conda",
                 "label": "Conda Packages",
             },
-            "value": get_conda_packages(),
+            "value": get_conda_packages(doc),
         },
         {
             "default": "deadline-cloud",
@@ -92,6 +94,6 @@ def internal_create_job_bundle(
         takes=takes,
         job_bundle_dir=job_bundle_dir,
         asset_references=auto_detected_attachments,
-        queue_parameters=sample_queue_params(),
+        queue_parameters=sample_queue_params(doc),
         attachments=attachments,
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have added support for Cinema 4D to Arnold on Deadline Cloud SMF!

The following operating systems/years have support for Cinema 4D to Arnold:
* Windows 2025
* Linux 2025
* Windows 2026

### How was this change tested?
- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
No, N/A

- Have you made changes to the submitter?
Yes, `cinema4d-c4dtoa` is now auto-populated in the Conda package list in the submitter when Arnold is used. I used this to submit an Arnold scene to a test farm (it rendered successfully). I also submitted a Redshift scene to ensure other renderers weren't broken.

### Was this change documented?
Yup, I've updated the README in this PR.

### Is this a breaking change?
No, since Arnold was not previously supported.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*