### PR TITLE
docs: update user guide to include C4D 2026 and Arnold

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,7 +15,7 @@ Table of Contents:
       * [Running the Adaptor Locally](#running-the-adaptor-locally)
       * [Running the Adaptor on a Farm](#running-the-adaptor-on-a-farm)
       * [Testing the Adaptor](#testing-the-adaptor)
-   * [Running the integration tests](#integration-tests-currently-wip)
+   * [Running the integration tests](#integration-tests)
 
 ## Development Environment Setup
 

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -21,8 +21,9 @@ Transform your Cinema 4D rendering workflow with AWS Deadline Cloud - a fully ma
 
 ## Supported Versions
 
-- **Cinema 4D 2024 - 2025**
+- **Cinema 4D 2024 - 2026**
 - **Redshift** (optional)
+- **Arnold** (optional)
 - **Windows and macOS** for job submission
 
 ## Get Started in 4 Simple Steps


### PR DESCRIPTION
We now support Cinema 4D 2026 and Arnold! Updated the user guide to reflect that.

Also updated a link in the dev guide.