### PR TITLE
docs: Update documentation to suggest Cinema 4D 2026 support.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -244,7 +244,7 @@ You can also run `c4dpy` and `Commandline.exe` separately and set the license in
       1. The default location for `Cinema 4D` on Windows is `C:\Program Files\Maxon Cinema 4D 2026\`. This location would be automatically used if the directory exists.
 2. For running the adaptor tests, we would need to install `pywin32` to the installation paths as its an adaptor dependency.
    2.1 Run `pip install pywin32==308 -t <your Python site-packages location>`
-       * e.g. `pip install pywin32==308 -t "C:\Program Files\Maxon Cinema 4D 2025\resource\modules\python\libs\win64\lib\site-packages"`
+       * e.g. `pip install pywin32==308 -t "C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\lib\site-packages"`
    
    During testing, pywin32's version 308 was required because of other dependencies requiring this version.
    2.2. Copy PyWin32 DLLs (there are some post installation things required for PyWin32):

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ In Windows `cmd`
 set SUBMITTER_LOCATION=%APPDATA%\DeadlineCloudSubmitter
 
 :: Install pip using Cinema 4D's bundled Python
-"C:\Program Files\Maxon Cinema 4D 2025\resource\modules\python\libs\win64\python.exe" -m ensurepip
+"C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\python.exe" -m ensurepip
 
 :: Install required Python packages to our custom location
-"C:\Program Files\Maxon Cinema 4D 2025\resource\modules\python\libs\win64\python.exe" -m pip install deadline-cloud-for-cinema-4d "deadline[gui]" -t %SUBMITTER_LOCATION%
+"C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\python.exe" -m pip install deadline-cloud-for-cinema-4d "deadline[gui]" -t %SUBMITTER_LOCATION%
 
 :: Create plugins directory
 md %SUBMITTER_LOCATION%\cinema_4d_plugins
@@ -144,7 +144,7 @@ curl https://raw.githubusercontent.com/aws-deadline/deadline-cloud-for-cinema-4d
 echo "#!/bin/zsh" > ~/Desktop/Cinema4D.command
 eval echo "export C4DPYTHONPATH311=${SUBMITTER_LOCATION}\${C4DPYTHONPATH311:+:\$C4DPYTHONPATH311}" >> ~/Desktop/Cinema4D.command
 eval echo "export g_additionalModulePath=${SUBMITTER_LOCATION}/cinema_4d_plugins\${g_additionalModulePath:+:\$g_additionalModulePath}" >> ~/Desktop/Cinema4D.command
-echo '"/Applications/Maxon Cinema 4D 2025/Cinema 4D.app/Contents/MacOS/Cinema 4D"' >> ~/Desktop/Cinema4D.command
+echo '"/Applications/Maxon Cinema 4D 2026/Cinema 4D.app/Contents/MacOS/Cinema 4D"' >> ~/Desktop/Cinema4D.command
 
 # Make the launch script executable
 chmod +x ~/Desktop/Cinema4D.command

--- a/docs/user_guide/getting-started.md
+++ b/docs/user_guide/getting-started.md
@@ -4,7 +4,7 @@ Set up Cinema 4D and AWS Deadline Cloud in just a few steps.
 
 ## What You'll Need
 
-- **Cinema 4D 2024 or 2025** installed on your workstation
+- **Cinema 4D 2024 - 2026** installed on your workstation
 - **AWS Account** with Deadline Cloud access
 - **Windows or macOS** workstation for job submission
 - **Deadline Cloud monitor** ([download here](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/monitor-onboarding.html))

--- a/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
@@ -10,7 +10,7 @@ parameterValues:
 - name: Frames
   value: '1'
 - name: CondaPackages
-  value: cinema4d=2025.* cinema4d-openjd=0.7.*
+  value: cinema4d=2026.* cinema4d-openjd=0.8.*
 - name: CondaChannels
   value: deadline-cloud
 - name: deadline:targetTaskRunStatus

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
@@ -38,7 +38,7 @@ parameterValues:
 - name: AFrames
   value: '1'
 - name: CondaPackages
-  value: cinema4d=2025.* cinema4d-openjd=0.7.*
+  value: cinema4d=2026.* cinema4d-openjd=0.8.*
 - name: CondaChannels
   value: deadline-cloud
 - name: deadline:targetTaskRunStatus

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
@@ -10,7 +10,7 @@ parameterValues:
 - name: Frames
   value: '1'
 - name: CondaPackages
-  value: cinema4d=2025.* cinema4d-openjd=0.7.*
+  value: cinema4d=2026.* cinema4d-openjd=0.8.*
 - name: CondaChannels
   value: deadline-cloud
 - name: deadline:targetTaskRunStatus

--- a/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
@@ -10,7 +10,7 @@ parameterValues:
 - name: Frames
   value: '1'
 - name: CondaPackages
-  value: cinema4d=2025.* cinema4d-openjd=0.7.*
+  value: cinema4d=2026.* cinema4d-openjd=0.8.*
 - name: CondaChannels
   value: deadline-cloud
 - name: deadline:targetTaskRunStatus

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
@@ -10,7 +10,7 @@ parameterValues:
 - name: Frames
   value: '1'
 - name: CondaPackages
-  value: cinema4d=2025.* cinema4d-openjd=0.7.*
+  value: cinema4d=2026.* cinema4d-openjd=0.8.*
 - name: CondaChannels
   value: deadline-cloud
 - name: deadline:targetTaskRunStatus

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
@@ -10,7 +10,7 @@ parameterValues:
 - name: Frames
   value: '1'
 - name: CondaPackages
-  value: cinema4d=2025.* cinema4d-openjd=0.7.*
+  value: cinema4d=2026.* cinema4d-openjd=0.8.*
 - name: CondaChannels
   value: deadline-cloud
 - name: deadline:targetTaskRunStatus

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
@@ -14,7 +14,7 @@ parameterValues:
 - name: Frames
   value: '1'
 - name: CondaPackages
-  value: cinema4d=2025.* cinema4d-openjd=0.7.*
+  value: cinema4d=2026.* cinema4d-openjd=0.8.*
 - name: CondaChannels
   value: deadline-cloud
 - name: deadline:targetTaskRunStatus

--- a/test/integ/utils.py
+++ b/test/integ/utils.py
@@ -194,7 +194,7 @@ def _normalize_conda_packages_version(content: str) -> str:
 
     content = re.sub(
         r"cinema4d=202[4-9].\* cinema4d-openjd=0.\d.\*",
-        "cinema4d=2025.* cinema4d-openjd=0.7.*",
+        "cinema4d=2026.* cinema4d-openjd=0.8.*",
         content,
     )
     return content


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/319

### What was the problem/requirement? (What/Why)

We have the conda packages available in `deadline-cloud` package and the submitter installer installs for Cinema 4D 2026. 

We should update our documentation and tests so that we use the latest version i.e. 2026 everywhere. 

### What was the solution? (How)

Update the documentation and also the tests to verify that 2026 works. 

### What is the impact of this change?

Only documentation and test changes, so customers will know that 2026 works. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes

### Was this change documented?

Yes

### Is this a breaking change?

No

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*