### PR TITLE
chore: Improve the messaging when there are errors.

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -125,7 +125,8 @@ def _get_parameter_values(
     if parameter_overlap:
         raise DeadlineOperationError(
             "The following queue parameters conflict with the Cinema4D job parameters:\n"
-            + f"{', '.join(parameter_overlap)}"
+            + f"{', '.join(parameter_overlap)}\n"
+            "Rename the parameters on the queue to continue job submissions."
         )
 
     # If we're overriding the adaptor with wheels, remove deadline_cloud_for_cinema4d from the CondaPackages
@@ -562,7 +563,8 @@ def generate_take_parameter_names(submit_takes: list[TakeData]) -> None:
         take_name = take_data.name
         if take_name in take_names:
             raise RuntimeError(
-                f"You have multiple takes named '{take_name}'. Please use unique take names."
+                f"You have multiple takes named '{take_name}' with different render settings among the takes. "
+                "Please use unique take names."
             )
         take_names.add(take_name)
 

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -37,7 +37,7 @@ class FileSearchLineEdit(QWidget):
         super().__init__(parent=parent)
 
         if directory_only and file_format is not None:
-            raise ValueError("")
+            raise ValueError("Cannot specify file_format when directory_only is True")
 
         self.file_format = file_format
         self.directory_only = directory_only


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Previously, we had an issue where an unhandled exception was crashing the submitter plugin. So we are trying to improve that experience. 

### What was the solution? (How)

I manually tried to look into the scenarios where we throw exceptions and see if its being handled correctly. 

<img width="1074" height="812" alt="Screenshot 2025-11-13 at 3 44 06 PM" src="https://github.com/user-attachments/assets/697e87ce-8b3b-412b-9047-274ae5ab45f3" />
<img width="563" height="758" alt="Screenshot 2025-11-14 at 12 14 14 PM" src="https://github.com/user-attachments/assets/7f593595-8372-4b47-97bb-ea9d1f4b2c9c" />
<img width="629" height="767" alt="Screenshot 2025-11-13 at 5 11 07 PM" src="https://github.com/user-attachments/assets/caaea906-dd67-4bfd-ab21-9d04e4596e22" />
<img width="562" height="765" alt="Screenshot 2025-11-13 at 3 45 45 PM" src="https://github.com/user-attachments/assets/80c6e0a4-1f7e-45c4-aa4f-7eee31f34569" />

For some we needed better instructions, so updated that. 

I also skipped the adaptor wheels flows as its not used regularly. (We are also wondering if we should just remove it)

I also skipped the font handling feature because we already have a PR for it. https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/340

### What is the impact of this change?

Just for improving existing customer experience. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
No, this only has string changes. No changes to the actual logic. 

### Was this change documented?

Not required for the PR. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*