### PR TITLE
feat: Add detailed Cinema 4D + Redshift logging option while submitting

### DIFF
--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -86,7 +86,7 @@ A: The submitter includes built-in error detection to catch common issues like m
 
 **Q: How do I enable detailed logging for debugging rendering issues?**
 
-A: The submitter includes a "Activate detailed logging" checkbox in the Job-Specific Settings that captures detailed logs for troubleshooting. When enabled:
+A: The submitter includes an "Activate detailed logging" checkbox in the Job-Specific Settings that captures detailed logs for troubleshooting. When enabled:
 
 1. The system automatically enables debug logging during rendering
 2. After rendering completes, all logs are printed to the job output

--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -84,6 +84,31 @@ A: Yes, you can set job priority levels in the submitter to control render queue
 
 A: The submitter includes built-in error detection to catch common issues like missing assets before submission. This can be deactivated in the submitter.
 
+**Q: How do I enable detailed logging for debugging rendering issues?**
+
+A: The submitter includes a "Activate detailed logging" checkbox in the Job-Specific Settings that captures detailed logs for troubleshooting. When enabled:
+
+1. The system automatically enables debug logging during rendering
+2. After rendering completes, all logs are printed to the job output
+
+To view the logs:
+1. Open Deadline Cloud Monitor
+2. Navigate to your completed job
+3. Right-click on a task and select "View logs"
+4. Enable the "View logs for all tasks" button
+5. Scroll through the task run logs to find the "Shut down DetailedLogging" section for detailed logs
+
+The logs are output in HTML format with timestamps. To save and view them in a web browser without timestamps:
+
+```bash
+cd deadline-cloud-for-cinema-4d/scripts
+python clean_redshift_detailed_logs.py /path/to/detailed_logs.log
+```
+
+Or run without arguments and enter the path when prompted. This generates a `redshift_log_cleaned.html` file that's easier to read and compare.
+
+Use detailed logging when you need to debug Redshift rendering issues, investigate rendering artifacts or errors, analyze renderer performance, or capture information for technical support.
+
 **Q: I'm getting permission errors with a system-wide installation on Windows. How do I fix this?**
 
 A: If users encounter permission errors when accessing the submitter after a system-wide installation:

--- a/docs/user_guide/submitter-features.md
+++ b/docs/user_guide/submitter-features.md
@@ -84,7 +84,7 @@ To view the detailed logs:
 2. Navigate to your completed job
 3. Right-click on a task and select "View logs"
 4. Enable the "View logs for all tasks" button.
-4. Scroll through the task run logs to find the "Shut down DetailedLogging" for detailed logs.
+5. Scroll through the task run logs to find the "Shut down DetailedLogging" for detailed logs.
 
 The Redshift logs are output in HTML format and include timestamps at the start of each line. If you want to save and view the logs in a web browser without timestamps, you can use the provided cleanup utility:
 

--- a/docs/user_guide/submitter-features.md
+++ b/docs/user_guide/submitter-features.md
@@ -41,6 +41,7 @@ Settings specific to your Cinema 4D render:
 - **Takes** - Select which Cinema 4D takes to render
 - **Override Frame Range** - Override the frame range from your scene settings
 - **Automatic Error Checking** - Optional checkbox to activate/deactivate error checking during rendering
+- **Activate detailed logging** - Enable detailed logging to capture detailed logs for debugging rendering issues. When enabled, debug logs are automatically captured and printed to the job output for easy review
 - **Task Run Timeout** - Maximum time allowed for each task to complete
 - **Cinema 4D Launch Timeout** - Maximum time allowed for Cinema 4D to start up
 - **Cinema 4D Shutdown Timeout** - Maximum time allowed for Cinema 4D to shut down cleanly
@@ -55,6 +56,58 @@ Settings specific to your Cinema 4D render:
 **Host Requirements** (optional) - Allows you to specify which types of hosts will be eligible for picking up tasks for this job.
 
 The submitter handles the technical details so you can focus on your creative work.
+
+## Detailed Logging for Debugging
+
+The **Activate detailed logging** feature helps you troubleshoot rendering issues by capturing detailed logs.
+
+### When to Use Detailed Logging
+
+Enable detailed logging when you need to:
+- Debug Redshift rendering issues or unexpected behavior
+- Investigate rendering artifacts or errors
+- Analyze renderer performance and behavior
+- Capture detailed information for technical support
+
+### How It Works
+
+When you enable the "Activate detailed logging" checkbox in the Job-Specific Settings:
+
+1. **Log Capture** - The system automatically enables Redshift debug logging by setting the `REDSHIFT_DEBUGCAPTURE` environment variable
+2. **Log Output** - After rendering completes, all Redshift logs are automatically printed to the job output for easy review
+
+### Viewing the Logs
+
+To view the detailed logs:
+
+1. Open Deadline Cloud Monitor
+2. Navigate to your completed job
+3. Right-click on a task and select "View logs"
+4. Enable the "View logs for all tasks" button.
+4. Scroll through the task run logs to find the "Shut down DetailedLogging" for detailed logs.
+
+The Redshift logs are output in HTML format and include timestamps at the start of each line. If you want to save and view the logs in a web browser without timestamps, you can use the provided cleanup utility:
+
+1. Download the detailed log file from Deadline Cloud Monitor (right-click on task → "Download logs")
+2. Run the cleanup script with the log file path:
+   ```bash
+   cd deadline-cloud-for-cinema-4d/scripts
+   python clean_redshift_detailed_logs.py /path/to/detailed_logs.log
+   ```
+   Or run it without arguments and enter the path when prompted:
+   ```bash
+   python clean_redshift_detailed_logs.py
+   ```
+3. Open the generated `redshift_log_cleaned.html` file in your web browser
+
+The cleanup script automatically extracts the Redshift HTML logs from the detailed log file and removes timestamp prefixes (e.g., `2024/11/17 14:23:45-08:00`) from each line, making the logs easier to read and compare.
+
+### Important Notes
+
+- Detailed logging is **disabled by default** to minimize overhead
+- Only enable it when you need to debug specific issues
+- Logs are captured on a per-job basis - each job has its own log output
+- The feature works across Windows, Linux worker nodes
 
 ---
 

--- a/scripts/clean_redshift_detailed_logs.py
+++ b/scripts/clean_redshift_detailed_logs.py
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+Utility script to extract and clean Redshift debug logs from Cinema 4D detailed log files.
+
+This script extracts HTML Redshift debug logs from Cinema 4D detailed log files and
+removes timestamp prefixes to make them easier to read and compare. It's particularly
+useful when viewing detailed logs captured by the Cinema 4D submitter's detailed logging feature.
+
+Usage:
+    python clean_redshift_detailed_logs.py [log_file_path]
+
+If no log file path is provided, the script will prompt for one.
+
+The script will:
+1. Extract the Redshift HTML log content from the detailed log file
+2. Remove timestamp prefixes from each line
+3. Save the cleaned HTML to 'redshift_log_cleaned.html'
+
+Example timestamp format that gets removed:
+    2024/11/17 14:23:45-08:00 [Log message content]
+
+After cleaning:
+    [Log message content]
+"""
+
+import re
+import sys
+import os
+
+
+def extract_redshift_log(log_file_path):
+    """
+    Extract Redshift HTML log content from a Cinema 4D detailed log file.
+
+    The function looks for content between:
+    - Start marker: "REDSHIFT DEBUG LOG: <path>"
+    - End marker: "END OF REDSHIFT DEBUG LOG"
+
+    Args:
+        log_file_path (str): Path to the detailed log file
+
+    Returns:
+        str: The extracted HTML log content, or None if not found
+    """
+    try:
+        with open(log_file_path, "r", encoding="utf-8") as file:
+            content = file.read()
+    except FileNotFoundError:
+        print(f"Error: File '{log_file_path}' not found.")
+        return None
+    except Exception as e:
+        print(f"Error reading file: {e}")
+        return None
+
+    # Find the start marker
+    start_pattern = r"REDSHIFT DEBUG LOG:.*?={70,}"
+    start_match = re.search(start_pattern, content, re.DOTALL)
+
+    if not start_match:
+        print("Error: Could not find 'REDSHIFT DEBUG LOG:' marker in the file.")
+        return None
+
+    start_pos = start_match.end()
+
+    # Find the end marker
+    end_pattern = r"={70,}.*?END OF REDSHIFT DEBUG LOG"
+    end_match = re.search(end_pattern, content[start_pos:], re.DOTALL)
+
+    if not end_match:
+        print("Error: Could not find 'END OF REDSHIFT DEBUG LOG' marker in the file.")
+        return None
+
+    end_pos = start_pos + end_match.start()
+
+    # Extract the content between markers
+    extracted_content = content[start_pos:end_pos].strip()
+
+    return extracted_content
+
+
+def remove_timestamps(input_text):
+    """
+    Remove timestamp prefixes from Redshift log lines.
+
+    Redshift detailed logs include timestamps at the start of each line in the format:
+    YYYY/MM/DD HH:MM:SS-HH:MM (date, time, and timezone offset)
+
+    This function strips these timestamps to make the logs more readable.
+
+    Args:
+        input_text (str): The raw log content with timestamps
+
+    Returns:
+        str: The log content with timestamps removed
+    """
+    # Regular expression to match the timestamp pattern at the start of lines
+    # Pattern: YYYY/MM/DD HH:MM:SS-HH:MM followed by whitespace
+    timestamp_pattern = r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}-\d{2}:\d{2}\s+"
+
+    # Split the text into lines
+    lines = input_text.split("\n")
+
+    # Remove timestamp from each line
+    cleaned_lines = [re.sub(timestamp_pattern, "", line) for line in lines]
+
+    # Join the lines back together
+    return "\n".join(cleaned_lines)
+
+
+def main():
+    """Main function to orchestrate the log extraction and cleaning process."""
+    # Get log file path from command line or prompt user
+    if len(sys.argv) > 1:
+        log_file_path = sys.argv[1]
+    else:
+        log_file_path = input("Enter the path to the detailed log file: ").strip()
+
+    # Validate the file exists
+    if not os.path.exists(log_file_path):
+        print(f"Error: File '{log_file_path}' does not exist.")
+        sys.exit(1)
+
+    print(f"Processing log file: {log_file_path}")
+
+    # Extract Redshift log content
+    print("Extracting Redshift debug log content...")
+    extracted_content = extract_redshift_log(log_file_path)
+
+    if extracted_content is None:
+        sys.exit(1)
+
+    print(f"Extracted {len(extracted_content)} characters of log content.")
+
+    # Remove timestamps
+    print("Removing timestamps...")
+    cleaned_content = remove_timestamps(extracted_content)
+
+    # Write the cleaned content to output file
+    output_file = "redshift_log_cleaned.html"
+    try:
+        with open(output_file, "w", encoding="utf-8") as file:
+            file.write(cleaned_content)
+        print(f"\nSuccess! Cleaned log saved to: {output_file}")
+    except Exception as e:
+        print(f"Error writing output file: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/clean_redshift_detailed_logs.py
+++ b/scripts/clean_redshift_detailed_logs.py
@@ -52,30 +52,33 @@ def extract_redshift_log(log_file_path):
         print(f"Error reading file: {e}")
         return None
 
-    # Find the start marker
-    start_pattern = r"REDSHIFT DEBUG LOG:.*?={70,}"
-    start_match = re.search(start_pattern, content, re.DOTALL)
+    # Split by start marker
+    start_marker = "REDSHIFT DEBUG LOG:"
+    parts = content.split(start_marker, 1)
 
-    if not start_match:
+    if len(parts) < 2:
         print("Error: Could not find 'REDSHIFT DEBUG LOG:' marker in the file.")
         return None
 
-    start_pos = start_match.end()
+    # Split by end marker
+    end_marker = "END OF REDSHIFT DEBUG LOG"
+    middle_parts = parts[1].split(end_marker, 1)
 
-    # Find the end marker
-    end_pattern = r"END OF REDSHIFT DEBUG LOG"
-    end_match = re.search(end_pattern, content[start_pos:])
-
-    if not end_match:
+    if len(middle_parts) < 2:
         print("Error: Could not find 'END OF REDSHIFT DEBUG LOG' marker in the file.")
         return None
 
-    end_pos = start_pos + end_match.start() - 2
+    # Extract content and remove the separator lines (first 2 lines and last 2 lines)
+    raw_content = middle_parts[0]
+    lines = raw_content.split("\n")
 
-    # Extract the content between markers
-    extracted_content = content[start_pos:end_pos].strip()
+    # Skip first 2 lines (path line and equals line) and last 2 lines (empty and equals line)
+    if len(lines) > 4:
+        extracted_content = "\n".join(lines[2:-2])
+    else:
+        extracted_content = ""
 
-    return extracted_content
+    return extracted_content.strip()
 
 
 def remove_timestamps(input_text):

--- a/scripts/clean_redshift_detailed_logs.py
+++ b/scripts/clean_redshift_detailed_logs.py
@@ -63,14 +63,14 @@ def extract_redshift_log(log_file_path):
     start_pos = start_match.end()
 
     # Find the end marker
-    end_pattern = r"={70,}.*?END OF REDSHIFT DEBUG LOG"
-    end_match = re.search(end_pattern, content[start_pos:], re.DOTALL)
+    end_pattern = r"END OF REDSHIFT DEBUG LOG"
+    end_match = re.search(end_pattern, content[start_pos:])
 
     if not end_match:
         print("Error: Could not find 'END OF REDSHIFT DEBUG LOG' marker in the file.")
         return None
 
-    end_pos = start_pos + end_match.start()
+    end_pos = start_pos + end_match.start() - 2
 
     # Extract the content between markers
     extracted_content = content[start_pos:end_pos].strip()

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -55,6 +55,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: DetailedLogging
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Enable Detailed Logging
+    groupLabel: Cinema4D Settings
+  description: Enable detailed Cinema 4D + Redshift renderer logging for debugging.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Render
   parameterSpace:

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -28,6 +28,7 @@ from .assets import AssetIntrospector
 from .data_classes import (
     RenderSubmitterUISettings,
 )
+from .detailed_logging_utils import get_detailed_logging_environment
 from .font_utils import scene_has_fonts, get_font_manager_environment, FONTS_DIR
 from .warning_collector import warning_collector
 from .platform_utils import is_windows
@@ -100,6 +101,9 @@ def _get_parameter_values(
     parameter_values.append({"name": "MultiPassPath", "value": settings.multi_pass_path})
     parameter_values.append(
         {"name": "ActivateErrorChecking", "value": settings.activate_error_checking}
+    )
+    parameter_values.append(
+        {"name": "DetailedLogging", "value": "1" if settings.activate_detailed_logging else "0"}
     )
 
     if per_take_frames_parameters:
@@ -284,6 +288,13 @@ def _get_job_template(
         if "jobEnvironments" not in job_template:
             job_template["jobEnvironments"] = []
         job_template["jobEnvironments"].append(override_environment["environment"])
+
+    # Add DetailedLogging job environment
+    if adaptor:
+        detailed_logging_environment = get_detailed_logging_environment()
+        if "jobEnvironments" not in job_template:
+            job_template["jobEnvironments"] = []
+        job_template["jobEnvironments"].append(detailed_logging_environment)
 
     # Conditionally add FontManager job environment if fonts are detected (Windows only)
     if adaptor and is_windows() and scene_has_fonts(Path(Scene.name()).parent):
@@ -740,7 +751,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
 
             if not continue_submission:
                 # User chose to cancel submission
-                raise RuntimeError("Submission cancelled due to issues")
+                raise RuntimeError("Submission cancelled")
 
         return create_job_bundle(
             settings,

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -74,6 +74,10 @@ class RenderSubmitterUISettings:
     activate_error_checking: str = field(
         default=ErrorChecking.ACTIVATE.value, metadata={"sticky": True}
     )
+    # Activating detailed logging can significantly slow the rendering.
+    # Hence, this setting is not sticky and customers would have to manually
+    # click it everytime they want to submit such a job.
+    activate_detailed_logging: bool = field(default=False, metadata={"sticky": False})
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}
     )

--- a/src/deadline/cinema4d_submitter/detailed_logging_scripts/__init__.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_scripts/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/deadline/cinema4d_submitter/detailed_logging_scripts/print_logs.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_scripts/print_logs.py
@@ -1,0 +1,205 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Find and print Cinema 4D and Redshift log files after rendering."""
+from dataclasses import dataclass, field
+import os
+import sys
+
+
+@dataclass
+class FoundLogs:
+    """Container for discovered log files."""
+
+    redshift: list[str] = field(default_factory=list)
+    bugreport: list[str] = field(default_factory=list)
+
+
+def _find_redshift_log(conda_prefix: str, path_components: list[str]) -> list[str]:
+    """Search for Redshift log file in the specified path.
+
+    Args:
+        conda_prefix: The CONDA_PREFIX environment variable value.
+        path_components: List of path components to join with conda_prefix.
+
+    Returns:
+        List containing the Redshift log path if found, empty list otherwise.
+    """
+    if not conda_prefix or not os.path.exists(conda_prefix):
+        print("CONDA_PREFIX not set or doesn't exist, skipping Redshift log search")
+        return []
+
+    redshift_log_path = os.path.join(conda_prefix, *path_components)
+    print(f"Checking for Redshift log at: {redshift_log_path}")
+
+    if os.path.exists(redshift_log_path):
+        print(f"Found Redshift log: {redshift_log_path}")
+        return [redshift_log_path]
+    else:
+        print("Redshift log not found at expected location")
+        return []
+
+
+def _find_bug_reports(base_path: str, dir_prefix: str) -> list[str]:
+    """Search for Cinema 4D bug report files.
+
+    Args:
+        base_path: Base directory to search in (e.g., ~/Maxon or %APPDATA%/Maxon).
+        dir_prefix: Prefix of directories to search (e.g., "bin_" or "cinema4d_").
+
+    Returns:
+        List of bug report file paths found.
+    """
+    bug_reports: list[str] = []
+
+    if not os.path.exists(base_path):
+        print(f"{base_path} doesn't exist, skipping bug report search")
+        return bug_reports
+
+    print(f"Checking for bug reports in: {base_path}")
+    bugreports_dirs_found = []
+
+    try:
+        for item in os.listdir(base_path):
+            if item.startswith(dir_prefix):
+                bugreports_dir = os.path.join(base_path, item, "_bugreports")
+                if os.path.exists(bugreports_dir):
+                    bugreports_dirs_found.append(bugreports_dir)
+                    print(f"Found _bugreports directory: {bugreports_dir}")
+
+                    bug_reports_in_dir = []
+                    for file in os.listdir(bugreports_dir):
+                        if file.endswith("_BugReport.txt"):
+                            bug_report_path = os.path.join(bugreports_dir, file)
+                            bug_reports.append(bug_report_path)
+                            bug_reports_in_dir.append(bug_report_path)
+                            print(f"Found bug report: {bug_report_path}")
+
+                    if not bug_reports_in_dir:
+                        print(
+                            f"_bugreports directory exists but no bug report files found inside: {bugreports_dir}"
+                        )
+
+        if not bugreports_dirs_found:
+            print("No _bugreports directories found")
+    except Exception as e:
+        print(f"Error searching for bug reports: {e}")
+
+    return bug_reports
+
+
+def find_log_files_linux() -> FoundLogs:
+    """Search for log files on Linux/Mac using known paths.
+
+    Returns:
+        FoundLogs: Container with redshift and bugreport log file paths.
+    """
+    found_logs = FoundLogs()
+    conda_prefix = os.environ.get("CONDA_PREFIX", "")
+    home_dir = os.path.expanduser("~")
+
+    print("Searching for log files...")
+
+    # Check for Redshift log.html: $CONDA_PREFIX/redshiftlocaldata/log/log.latest.0/log.html
+    found_logs.redshift = _find_redshift_log(
+        conda_prefix, ["redshiftlocaldata", "log", "log.latest.0", "log.html"]
+    )
+
+    # Check for bug reports: ~/Maxon/bin_*/_bugreports/*_BugReport.txt
+    maxon_path = os.path.join(home_dir, "Maxon")
+    found_logs.bugreport = _find_bug_reports(maxon_path, "bin_")
+
+    return found_logs
+
+
+def find_log_files_windows() -> FoundLogs:
+    """Search for log files on Windows using known paths.
+
+    Returns:
+        FoundLogs: Container with redshift and bugreport log file paths.
+    """
+    found_logs = FoundLogs()
+    conda_prefix = os.environ.get("CONDA_PREFIX", "")
+    appdata = os.environ.get("APPDATA", "")
+
+    print("Searching for log files...")
+
+    # Check for Redshift log.html: $CONDA_PREFIX\cinema4d\RedshiftData\Log\Log.Latest.0\log.html
+    found_logs.redshift = _find_redshift_log(
+        conda_prefix, ["cinema4d", "RedshiftData", "Log", "Log.Latest.0", "log.html"]
+    )
+    # Check for bug reports: %APPDATA%\Maxon\cinema4d_*\_bugreports\*_BugReport.txt
+    if appdata and os.path.exists(appdata):
+        maxon_path = os.path.join(appdata, "Maxon")
+        found_logs.bugreport = _find_bug_reports(maxon_path, "cinema4d_")
+    else:
+        print("APPDATA not set or doesn't exist, skipping bug report search")
+
+    return found_logs
+
+
+def find_log_files() -> FoundLogs:
+    """Search for Cinema 4D and Redshift log files.
+
+    Returns:
+        FoundLogs: Container with redshift and bugreport log file paths.
+    """
+    # Print environment variables for debugging
+    print("Environment variables:")
+    print(f"  CONDA_PREFIX: {os.environ.get('CONDA_PREFIX', 'NOT SET')}")
+    print(f"  HOME: {os.environ.get('HOME', 'NOT SET')}")
+    print(f"  USER: {os.environ.get('USER', 'NOT SET')}")
+
+    # Use platform-specific search
+    if sys.platform == "win32":
+        return find_log_files_windows()
+    else:
+        return find_log_files_linux()
+
+
+def print_log_file(log_file, log_type="LOG"):
+    """Print the contents of a log file.
+
+    Args:
+        log_file: Path to the log file to print.
+        log_type: Type of log file (for display purposes).
+    """
+    print(f"\n{'='*80}")
+    print(f"{log_type}: {log_file}")
+    print(f"{'='*80}\n")
+
+    try:
+        with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+            print(f.read())
+    except Exception as e:
+        print(f"Error: Error reading log file {log_file}: {e}")
+        return
+
+    print(f"\n{'='*80}")
+    print(f"END OF {log_type}")
+    print(f"{'='*80}\n")
+
+
+if __name__ == "__main__":
+    enabled = sys.argv[1] if len(sys.argv) > 1 else "0"
+
+    if enabled != "1":
+        print("Detailed logging is disabled, skipping log output.")
+    else:
+        found_logs = find_log_files()
+
+        # Print all Redshift logs
+        if found_logs.redshift:
+            print(f"\nFound {len(found_logs.redshift)} Redshift log file(s)")
+            for log_file in found_logs.redshift:
+                print_log_file(log_file, "REDSHIFT DEBUG LOG")
+        else:
+            print("\nNo Redshift debug logs (log.html) found.")
+            print("This may be normal if Redshift was not used for rendering.")
+
+        # Print all bug report logs
+        if found_logs.bugreport:
+            print(f"\nFound {len(found_logs.bugreport)} Cinema 4D bug report(s)")
+            for log_file in found_logs.bugreport:
+                print_log_file(log_file, "CINEMA 4D BUG REPORT")
+        else:
+            print("\nNo Cinema 4D bug reports (*_BugReport.txt) found.")
+            print("This may be normal if no crashes occurred.")

--- a/src/deadline/cinema4d_submitter/detailed_logging_scripts/print_logs.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_scripts/print_logs.py
@@ -170,7 +170,7 @@ def print_log_file(log_file, log_type="LOG"):
         with open(log_file, "r", encoding="utf-8", errors="replace") as f:
             print(f.read())
     except Exception as e:
-        print(f"Error: Error reading log file {log_file}: {e}")
+        print(f"Error reading log file {log_file}: {e}")
         return
 
     print(f"\n{'='*80}")

--- a/src/deadline/cinema4d_submitter/detailed_logging_scripts/setup_logging.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_scripts/setup_logging.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Verify Redshift debug logging environment variable is enabled."""
+import os
+import sys
+
+
+def verify_debug_environment_variables(enabled: str):
+    """Verify that debug logging is enabled and environment variable is set."""
+    if enabled != "1":
+        print("Detailed logging is disabled, skipping setup.")
+        return
+
+    redshift_debug = os.environ.get("REDSHIFT_DEBUGCAPTURE")
+    if redshift_debug == "1":
+        print("Redshift debug logging is enabled (REDSHIFT_DEBUGCAPTURE=1)")
+    else:
+        print("Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'")
+
+
+if __name__ == "__main__":
+    enabled = sys.argv[1] if len(sys.argv) > 1 else "0"
+    # Currently, this EnvEnter is not particularly useful
+    # But is a required field.
+    # Although, we can add more logic if necessary in the future
+    verify_debug_environment_variables(enabled)

--- a/src/deadline/cinema4d_submitter/detailed_logging_utils.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_utils.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from pathlib import Path
+from typing import Any
+
+
+def get_detailed_logging_environment() -> dict[str, Any]:
+    """
+    Returns the DetailedLogging job environment definition.
+
+    Returns:
+        dict[str, Any]: The DetailedLogging job environment configuration
+    """
+
+    # Read the setup_logging script from file
+    setup_logging_path = Path(__file__).parent / "detailed_logging_scripts" / "setup_logging.py"
+    with open(setup_logging_path, "r", encoding="utf-8") as f:
+        setup_logging_script = f.read()
+
+    # Read the print_logs script from file
+    print_logs_path = Path(__file__).parent / "detailed_logging_scripts" / "print_logs.py"
+    with open(print_logs_path, "r", encoding="utf-8") as f:
+        print_logs_script = f.read()
+
+    return {
+        "name": "DetailedLogging",
+        "description": "Captures and outputs debug logs for troubleshooting when enabled.",
+        "variables": {
+            "REDSHIFT_DEBUGCAPTURE": "{{Param.DetailedLogging}}",
+        },
+        "script": {
+            "embeddedFiles": [
+                {
+                    "name": "setupLogging",
+                    "filename": "setup_logging.py",
+                    "type": "TEXT",
+                    "data": setup_logging_script,
+                },
+                {
+                    "name": "printLogs",
+                    "filename": "print_logs.py",
+                    "type": "TEXT",
+                    "data": print_logs_script,
+                },
+            ],
+            "actions": {
+                "onEnter": {
+                    "command": "python",
+                    "args": [
+                        "{{Env.File.setupLogging}}",
+                        "{{Param.DetailedLogging}}",
+                    ],
+                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                },
+                "onExit": {
+                    "command": "python",
+                    "args": [
+                        "{{Env.File.printLogs}}",
+                        "{{Param.DetailedLogging}}",
+                    ],
+                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                },
+            },
+        },
+    }

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -135,8 +135,11 @@ class SceneSettingsWidget(QWidget):
         self.activate_error_checking_chck = QCheckBox("Activate automatic error checking", self)
         lyt.addWidget(self.activate_error_checking_chck, 5, 0)
 
+        self.activate_detailed_logging_chck = QCheckBox("Activate detailed logging", self)
+        lyt.addWidget(self.activate_detailed_logging_chck, 6, 0)
+
         self.timeout_settings_box = TimeoutTableWidget(timeouts=settings.timeouts, parent=self)
-        lyt.addWidget(self.timeout_settings_box, 6, 0, 1, 2)
+        lyt.addWidget(self.timeout_settings_box, 7, 0, 1, 2)
 
         # Create a group box for the export job bundle option
         export_group_box = QGroupBox("Cinema 4D submission options", self)
@@ -154,15 +157,15 @@ class SceneSettingsWidget(QWidget):
         warning_label.setWordWrap(True)
         export_layout.addWidget(warning_label)
 
-        lyt.addWidget(export_group_box, 7, 0, 1, 2)
+        lyt.addWidget(export_group_box, 8, 0, 1, 2)
 
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 8, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 9, 0)
 
-        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
+        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 11, 0)
 
     def _configure_settings(self, settings):
         self.op_path_chck.setChecked(settings.override_output_path)
@@ -175,6 +178,7 @@ class SceneSettingsWidget(QWidget):
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)
         self.activate_error_checking_chck.setChecked(bool(int(settings.activate_error_checking)))
+        self.activate_detailed_logging_chck.setChecked(settings.activate_detailed_logging)
 
         index = self.layers_box.findData(settings.take_selection)
         if index >= 0:
@@ -205,6 +209,8 @@ class SceneSettingsWidget(QWidget):
             if self.activate_error_checking_chck.isChecked()
             else ErrorChecking.DEACTIVATE.value
         )
+
+        settings.activate_detailed_logging = self.activate_detailed_logging_chck.isChecked()
 
         self.timeout_settings_box.update_settings(settings.timeouts)
 

--- a/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/__init__.py
+++ b/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_print_logs.py
+++ b/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_print_logs.py
@@ -396,7 +396,7 @@ class TestPrintLogFile:
 
         # THEN
         assert "ERROR LOG:" in captured.out
-        assert "Error: Error reading log file" in captured.out
+        assert "Error reading log file" in captured.out
 
     def test_handles_unicode_errors(self, capsys):
         """Test that unicode errors are handled with replace strategy"""

--- a/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_print_logs.py
+++ b/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_print_logs.py
@@ -1,0 +1,440 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from deadline.cinema4d_submitter.detailed_logging_scripts.print_logs import (
+    FoundLogs,
+    _find_redshift_log,
+    _find_bug_reports,
+    find_log_files_linux,
+    find_log_files_windows,
+    find_log_files,
+    print_log_file,
+)
+
+
+class TestFoundLogs:
+    """Test the FoundLogs dataclass"""
+
+    def test_default_initialization(self):
+        """Test that FoundLogs initializes with empty lists"""
+        # WHEN
+        found_logs = FoundLogs()
+
+        # THEN
+        assert found_logs.redshift == []
+        assert found_logs.bugreport == []
+
+    def test_initialization_with_values(self):
+        """Test that FoundLogs can be initialized with values"""
+        # GIVEN
+        redshift_logs = ["/path/to/redshift.log"]
+        bug_reports = ["/path/to/bugreport.txt"]
+
+        # WHEN
+        found_logs = FoundLogs(redshift=redshift_logs, bugreport=bug_reports)
+
+        # THEN
+        assert found_logs.redshift == redshift_logs
+        assert found_logs.bugreport == bug_reports
+
+
+class TestFindRedshiftLog:
+    """Test the _find_redshift_log function"""
+
+    def test_returns_empty_list_when_conda_prefix_not_set(self, capsys):
+        """Test that empty list is returned when CONDA_PREFIX is not set"""
+        # WHEN
+        result = _find_redshift_log("", ["redshiftlocaldata", "log", "log.html"])
+        captured = capsys.readouterr()
+
+        # THEN
+        assert result == []
+        assert "CONDA_PREFIX not set or doesn't exist" in captured.out
+
+    def test_returns_empty_list_when_conda_prefix_does_not_exist(self, capsys):
+        """Test that empty list is returned when CONDA_PREFIX path doesn't exist"""
+        # WHEN
+        result = _find_redshift_log("/nonexistent/path", ["redshiftlocaldata", "log"])
+        captured = capsys.readouterr()
+
+        # THEN
+        assert result == []
+        assert "CONDA_PREFIX not set or doesn't exist" in captured.out
+
+    def test_returns_empty_list_when_log_file_not_found(self, capsys):
+        """Test that empty list is returned when log file doesn't exist"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # WHEN
+            result = _find_redshift_log(tmpdir, ["redshiftlocaldata", "log", "log.html"])
+            captured = capsys.readouterr()
+
+            # THEN
+            assert result == []
+            assert "Checking for Redshift log at:" in captured.out
+            assert "Redshift log not found at expected location" in captured.out
+
+    def test_returns_log_path_when_file_exists(self, capsys):
+        """Test that log path is returned when file exists"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_dir = Path(tmpdir) / "redshiftlocaldata" / "log" / "log.latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("test log content")
+
+            # WHEN
+            result = _find_redshift_log(
+                tmpdir, ["redshiftlocaldata", "log", "log.latest.0", "log.html"]
+            )
+            captured = capsys.readouterr()
+
+            # THEN
+            assert len(result) == 1
+            assert result[0] == str(log_file)
+            assert "Found Redshift log:" in captured.out
+
+
+class TestFindBugReports:
+    """Test the _find_bug_reports function"""
+
+    def test_returns_empty_list_when_base_path_does_not_exist(self, capsys):
+        """Test that empty list is returned when base path doesn't exist"""
+        # WHEN
+        result = _find_bug_reports("/nonexistent/path", "bin_")
+        captured = capsys.readouterr()
+
+        # THEN
+        assert result == []
+        assert "doesn't exist, skipping bug report search" in captured.out
+
+    def test_returns_empty_list_when_no_matching_directories(self, capsys):
+        """Test that empty list is returned when no directories match prefix"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a directory that doesn't match the prefix
+            (Path(tmpdir) / "other_dir").mkdir()
+
+            # WHEN
+            result = _find_bug_reports(tmpdir, "bin_")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert result == []
+            assert "No _bugreports directories found" in captured.out
+
+    def test_returns_empty_list_when_bugreports_dir_exists_but_no_files(self, capsys):
+        """Test that empty list is returned when _bugreports dir exists but has no bug report files"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bugreports_dir = Path(tmpdir) / "bin_12345" / "_bugreports"
+            bugreports_dir.mkdir(parents=True)
+
+            # WHEN
+            result = _find_bug_reports(tmpdir, "bin_")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert result == []
+            assert "Found _bugreports directory:" in captured.out
+            assert "no bug report files found inside" in captured.out
+
+    def test_finds_bug_report_files(self, capsys):
+        """Test that bug report files are found correctly"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bugreports_dir = Path(tmpdir) / "bin_12345" / "_bugreports"
+            bugreports_dir.mkdir(parents=True)
+            bug_report = bugreports_dir / "_BugReport.txt"
+            bug_report.write_text("bug report")
+
+            # WHEN
+            result = _find_bug_reports(tmpdir, "bin_")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert len(result) == 1
+            assert str(bug_report) in result
+            assert "Found bug report:" in captured.out
+
+    def test_finds_bug_reports_in_multiple_directories(self, capsys):
+        """Test that bug reports are found in multiple matching directories"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create first directory with bug report
+            bugreports_dir1 = Path(tmpdir) / "bin_12345" / "_bugreports"
+            bugreports_dir1.mkdir(parents=True)
+            bug_report1 = bugreports_dir1 / "_BugReport.txt"
+            bug_report1.write_text("bug report 1")
+
+            # Create second directory with bug report
+            bugreports_dir2 = Path(tmpdir) / "bin_67890" / "_bugreports"
+            bugreports_dir2.mkdir(parents=True)
+            bug_report2 = bugreports_dir2 / "_BugReport.txt"
+            bug_report2.write_text("bug report 2")
+
+            # WHEN
+            result = _find_bug_reports(tmpdir, "bin_")
+
+            # THEN
+            assert len(result) == 2
+            assert str(bug_report1) in result
+            assert str(bug_report2) in result
+
+    def test_ignores_non_bug_report_files(self, capsys):
+        """Test that non-bug report files are ignored"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bugreports_dir = Path(tmpdir) / "bin_12345" / "_bugreports"
+            bugreports_dir.mkdir(parents=True)
+            bug_report = bugreports_dir / "_BugReport.txt"
+            other_file = bugreports_dir / "other_file.txt"
+            bug_report.write_text("bug report")
+            other_file.write_text("other content")
+
+            # WHEN
+            result = _find_bug_reports(tmpdir, "bin_")
+
+            # THEN
+            assert len(result) == 1
+            assert str(bug_report) in result
+            assert str(other_file) not in result
+
+    def test_handles_exception_gracefully(self, capsys):
+        """Test that exceptions during search are handled gracefully"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch("os.listdir", side_effect=PermissionError("Access denied")):
+                # WHEN
+                result = _find_bug_reports(tmpdir, "bin_")
+                captured = capsys.readouterr()
+
+                # THEN
+                assert result == []
+                assert "Error searching for bug reports:" in captured.out
+
+
+class TestFindLogFilesLinux:
+    """Test the find_log_files_linux function"""
+
+    def test_finds_redshift_log_on_linux(self, capsys):
+        """Test that Redshift log is found on Linux"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create Redshift log
+            log_dir = Path(tmpdir) / "redshiftlocaldata" / "log" / "log.latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("redshift log")
+
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    # WHEN
+                    result = find_log_files_linux()
+
+                    # THEN
+                    assert len(result.redshift) == 1
+                    assert result.redshift[0] == str(log_file)
+
+    def test_finds_bug_reports_on_linux(self, capsys):
+        """Test that bug reports are found on Linux"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home_dir = Path(tmpdir) / "home"
+            maxon_dir = home_dir / "Maxon" / "bin_12345" / "_bugreports"
+            maxon_dir.mkdir(parents=True)
+            bug_report = maxon_dir / "_BugReport.txt"
+            bug_report.write_text("bug report")
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    # WHEN
+                    result = find_log_files_linux()
+
+                    # THEN
+                    assert len(result.bugreport) == 1
+                    assert result.bugreport[0] == str(bug_report)
+
+
+class TestFindLogFilesWindows:
+    """Test the find_log_files_windows function"""
+
+    def test_searches_for_redshift_and_bug_reports(self, capsys):
+        """Test that both Redshift logs and bug reports are searched"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            appdata_dir = Path(tmpdir) / "appdata"
+            appdata_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir, "APPDATA": str(appdata_dir)}):
+                # WHEN
+                result = find_log_files_windows()
+                captured = capsys.readouterr()
+
+                # THEN
+                assert isinstance(result, FoundLogs)
+                assert "Searching for log files..." in captured.out
+
+    def test_finds_redshift_log_on_windows(self, capsys):
+        """Test that Redshift log is found on Windows"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create Redshift log
+            log_dir = Path(tmpdir) / "cinema4d" / "RedshiftData" / "Log" / "Log.Latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("redshift log")
+
+            appdata_dir = Path(tmpdir) / "appdata"
+            appdata_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir, "APPDATA": str(appdata_dir)}):
+                # WHEN
+                result = find_log_files_windows()
+
+                # THEN
+                assert len(result.redshift) == 1
+                assert result.redshift[0] == str(log_file)
+
+    def test_finds_bug_reports_on_windows(self, capsys):
+        """Test that bug reports are found on Windows"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            appdata_dir = Path(tmpdir) / "appdata"
+            maxon_dir = appdata_dir / "Maxon" / "cinema4d_12345" / "_bugreports"
+            maxon_dir.mkdir(parents=True)
+            bug_report = maxon_dir / "_BugReport.txt"
+            bug_report.write_text("bug report")
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir, "APPDATA": str(appdata_dir)}):
+                # WHEN
+                result = find_log_files_windows()
+
+                # THEN
+                assert len(result.bugreport) == 1
+                assert result.bugreport[0] == str(bug_report)
+
+    def test_handles_missing_appdata(self, capsys):
+        """Test that missing APPDATA is handled gracefully"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}, clear=True):
+                # WHEN
+                result = find_log_files_windows()
+                captured = capsys.readouterr()
+
+                # THEN
+                assert result.bugreport == []
+                assert "APPDATA not set or doesn't exist" in captured.out
+
+
+class TestFindLogFiles:
+    """Test the find_log_files function"""
+
+    def test_prints_environment_variables(self, capsys):
+        """Test that environment variables are printed for debugging"""
+        # GIVEN
+        with mock.patch.dict(
+            os.environ, {"CONDA_PREFIX": "/test/path", "HOME": "/home/user", "USER": "testuser"}
+        ):
+            with mock.patch("sys.platform", "linux"):
+                with mock.patch("os.path.expanduser", return_value="/home/user"):
+                    # WHEN
+                    find_log_files()
+                    captured = capsys.readouterr()
+
+                    # THEN
+                    assert "Environment variables:" in captured.out
+                    assert "CONDA_PREFIX: /test/path" in captured.out
+                    assert "HOME: /home/user" in captured.out
+                    assert "USER: testuser" in captured.out
+
+
+class TestPrintLogFile:
+    """Test the print_log_file function"""
+
+    def test_prints_log_file_content(self, capsys):
+        """Test that log file content is printed correctly"""
+        # GIVEN
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log") as tmp:
+            tmp.write("Test log content\nLine 2\nLine 3")
+            tmp_path = tmp.name
+
+        try:
+            # WHEN
+            print_log_file(tmp_path, "TEST LOG")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "TEST LOG:" in captured.out
+            assert tmp_path in captured.out
+            assert "Test log content" in captured.out
+            assert "Line 2" in captured.out
+            assert "Line 3" in captured.out
+            assert "END OF TEST LOG" in captured.out
+            assert "=" * 80 in captured.out
+        finally:
+            os.unlink(tmp_path)
+
+    def test_handles_file_read_error(self, capsys):
+        """Test that file read errors are handled gracefully"""
+        # GIVEN
+        nonexistent_file = "/nonexistent/file.log"
+
+        # WHEN
+        print_log_file(nonexistent_file, "ERROR LOG")
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "ERROR LOG:" in captured.out
+        assert "Error: Error reading log file" in captured.out
+
+    def test_handles_unicode_errors(self, capsys):
+        """Test that unicode errors are handled with replace strategy"""
+        # GIVEN
+        with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".log") as tmp:
+            # Write some valid UTF-8 and some invalid bytes
+            tmp.write(b"Valid text\n")
+            tmp.write(b"\xff\xfe Invalid bytes\n")
+            tmp.write(b"More valid text")
+            tmp_path = tmp.name
+
+        try:
+            # WHEN
+            print_log_file(tmp_path, "UNICODE LOG")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "UNICODE LOG:" in captured.out
+            assert "Valid text" in captured.out
+            assert "More valid text" in captured.out
+            # The invalid bytes should be replaced with replacement character
+        finally:
+            os.unlink(tmp_path)
+
+    def test_uses_default_log_type(self, capsys):
+        """Test that default log type is used when not specified"""
+        # GIVEN
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log") as tmp:
+            tmp.write("Test content")
+            tmp_path = tmp.name
+
+        try:
+            # WHEN
+            print_log_file(tmp_path)
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "LOG:" in captured.out
+            assert "END OF LOG" in captured.out
+        finally:
+            os.unlink(tmp_path)

--- a/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_setup_logging.py
+++ b/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_setup_logging.py
@@ -1,0 +1,75 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+from deadline.cinema4d_submitter.detailed_logging_scripts.setup_logging import (
+    verify_debug_environment_variables,
+)
+
+
+class TestVerifyDebugEnvironmentVariables:
+    """Test the verify_debug_environment_variables function"""
+
+    def test_prints_confirmation_when_environment_variable_is_set(self, capsys):
+        """Test that confirmation message is printed when REDSHIFT_DEBUGCAPTURE is set"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "1"}, clear=True):
+            # WHEN
+            verify_debug_environment_variables("1")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "Redshift debug logging is enabled (REDSHIFT_DEBUGCAPTURE=1)" in captured.out
+
+    def test_prints_warning_when_environment_variable_not_set(self, capsys):
+        """Test that warning is printed when REDSHIFT_DEBUGCAPTURE is not set"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            verify_debug_environment_variables("1")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert (
+                "Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'"
+                in captured.out
+            )
+
+    def test_prints_warning_when_environment_variable_has_wrong_value(self, capsys):
+        """Test that warning is printed when REDSHIFT_DEBUGCAPTURE has wrong value"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "0"}, clear=True):
+            # WHEN
+            verify_debug_environment_variables("1")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert (
+                "Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'"
+                in captured.out
+            )
+
+    def test_skips_verification_when_disabled(self, capsys):
+        """Test that verification is skipped when disabled"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            verify_debug_environment_variables("0")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "Detailed logging is disabled, skipping setup." in captured.out
+
+    def test_skips_verification_with_invalid_value(self, capsys):
+        """Test that verification is skipped with invalid value"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            verify_debug_environment_variables("invalid")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "Detailed logging is disabled, skipping setup." in captured.out

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -13,6 +13,73 @@ from deadline.cinema4d_submitter.data_classes import (
 )
 
 
+class TestCinema4dRenderSubmitterDetailedLogging:
+    """Test cases for detailed logging functionality in cinema4d_render_submitter.py."""
+
+    def test_get_job_template_adds_detailed_logging_environment(self, tmp_path):
+        """Test DetailedLogging environment is added when using adaptor template."""
+        # Create mock settings
+        settings = RenderSubmitterUISettings()
+        settings.name = "Test Job"
+        settings.include_adaptor_wheels = False
+        settings.timeouts = default_timeout_entries()
+
+        # Create minimal take
+        takes = [TakeData("Main", "Main", "standard", "", None, "1-10", set(), False)]
+
+        # Create a scene file
+        scene_file = tmp_path / "test_scene.c4d"
+        scene_file.write_text("dummy scene content")
+
+        # Test: Adaptor template should include DetailedLogging environment
+        with (
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
+                return_value=str(scene_file),
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.is_windows",
+                return_value=False,
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.scene_has_fonts",
+                return_value=False,
+            ),
+        ):
+            # Test the function
+            result = _get_job_template(settings, set(), takes)
+
+            # Verify DetailedLogging environment was added
+            assert "jobEnvironments" in result
+            assert len(result["jobEnvironments"]) >= 1
+
+            # Find the DetailedLogging environment
+            detailed_logging_env = None
+            for env in result["jobEnvironments"]:
+                if env["name"] == "DetailedLogging":
+                    detailed_logging_env = env
+                    break
+
+            assert detailed_logging_env is not None, "DetailedLogging environment not found"
+            assert (
+                detailed_logging_env["description"]
+                == "Captures and outputs debug logs for troubleshooting when enabled."
+            )
+            assert "script" in detailed_logging_env
+            assert "embeddedFiles" in detailed_logging_env["script"]
+            assert len(detailed_logging_env["script"]["embeddedFiles"]) == 2
+
+            # Verify the embedded files
+            file_names = [f["name"] for f in detailed_logging_env["script"]["embeddedFiles"]]
+            assert "setupLogging" in file_names
+            assert "printLogs" in file_names
+
+            # Verify actions
+            assert "actions" in detailed_logging_env["script"]
+            assert "onEnter" in detailed_logging_env["script"]["actions"]
+            assert "onExit" in detailed_logging_env["script"]["actions"]
+
+
 class TestCinema4dRenderSubmitterFonts:
     """Test cases for font-related functionality in cinema4d_render_submitter.py."""
 
@@ -51,8 +118,10 @@ class TestCinema4dRenderSubmitterFonts:
 
             # Verify FontManager environment was added
             assert "jobEnvironments" in result
-            assert len(result["jobEnvironments"]) == 1
-            assert result["jobEnvironments"][0]["name"] == "FontManager"
+            assert len(result["jobEnvironments"]) == 2  # DetailedLogging + FontManager
+            env_names = [env["name"] for env in result["jobEnvironments"]]
+            assert "FontManager" in env_names
+            assert "DetailedLogging" in env_names
 
     def test_get_job_template_skips_font_manager_non_windows(self, tmp_path):
         """Test FontManager environment is NOT added on non-Windows platforms."""
@@ -87,8 +156,10 @@ class TestCinema4dRenderSubmitterFonts:
             # Test the function
             result = _get_job_template(settings, set(), takes)
 
-            # Verify FontManager environment was NOT added
-            assert "jobEnvironments" not in result or len(result.get("jobEnvironments", [])) == 0
+            # Verify FontManager environment was NOT added (but DetailedLogging should be present)
+            assert "jobEnvironments" in result
+            assert len(result["jobEnvironments"]) == 1  # Only DetailedLogging
+            assert result["jobEnvironments"][0]["name"] == "DetailedLogging"
 
     def test_get_job_template_skips_font_manager_no_fonts(self, tmp_path):
         """Test FontManager environment is NOT added when no fonts are detected."""
@@ -123,5 +194,7 @@ class TestCinema4dRenderSubmitterFonts:
             # Test the function
             result = _get_job_template(settings, set(), takes)
 
-            # Verify FontManager environment was NOT added
-            assert "jobEnvironments" not in result or len(result.get("jobEnvironments", [])) == 0
+            # Verify FontManager environment was NOT added (but DetailedLogging should be present)
+            assert "jobEnvironments" in result
+            assert len(result["jobEnvironments"]) == 1  # Only DetailedLogging
+            assert result["jobEnvironments"][0]["name"] == "DetailedLogging"

--- a/test/unit/deadline_submitter_for_cinema4d/test_detailed_logging_utils.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_detailed_logging_utils.py
@@ -1,0 +1,117 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from deadline.cinema4d_submitter.detailed_logging_utils import (
+    get_detailed_logging_environment,
+)
+
+
+class TestGetDetailedLoggingEnvironment:
+    """Test the get_detailed_logging_environment function"""
+
+    def test_returns_environment_with_correct_structure(self):
+        """Test that the function returns a properly structured environment"""
+        # WHEN
+        result = get_detailed_logging_environment()
+
+        # THEN
+        assert result["name"] == "DetailedLogging"
+        assert "description" in result
+        assert "variables" in result
+        assert "script" in result
+
+    def test_sets_redshift_debugcapture_variable(self):
+        """Test that REDSHIFT_DEBUGCAPTURE variable is configured"""
+        # WHEN
+        result = get_detailed_logging_environment()
+
+        # THEN
+        assert "REDSHIFT_DEBUGCAPTURE" in result["variables"]
+        assert result["variables"]["REDSHIFT_DEBUGCAPTURE"] == "{{Param.DetailedLogging}}"
+
+    def test_includes_setup_logging_embedded_file(self):
+        """Test that setup_logging.py is included as an embedded file"""
+        # WHEN
+        result = get_detailed_logging_environment()
+
+        # THEN
+        embedded_files = result["script"]["embeddedFiles"]
+        setup_logging_file = next((f for f in embedded_files if f["name"] == "setupLogging"), None)
+        assert setup_logging_file is not None
+        assert setup_logging_file["filename"] == "setup_logging.py"
+        assert setup_logging_file["type"] == "TEXT"
+        assert len(setup_logging_file["data"]) > 0
+
+    def test_includes_print_logs_embedded_file(self):
+        """Test that print_logs.py is included as an embedded file"""
+        # WHEN
+        result = get_detailed_logging_environment()
+
+        # THEN
+        embedded_files = result["script"]["embeddedFiles"]
+        print_logs_file = next((f for f in embedded_files if f["name"] == "printLogs"), None)
+        assert print_logs_file is not None
+        assert print_logs_file["filename"] == "print_logs.py"
+        assert print_logs_file["type"] == "TEXT"
+        assert len(print_logs_file["data"]) > 0
+
+    def test_has_on_enter_action_for_setup_logging(self):
+        """Test that onEnter action is configured to run setup_logging.py"""
+        # WHEN
+        result = get_detailed_logging_environment()
+
+        # THEN
+        actions = result["script"]["actions"]
+        assert "onEnter" in actions
+        assert actions["onEnter"]["command"] == "python"
+        assert actions["onEnter"]["args"] == [
+            "{{Env.File.setupLogging}}",
+            "{{Param.DetailedLogging}}",
+        ]
+        assert actions["onEnter"]["cancelation"]["mode"] == "NOTIFY_THEN_TERMINATE"
+
+    def test_has_on_exit_action_for_print_logs(self):
+        """Test that onExit action is configured to run print_logs.py"""
+        # WHEN
+        result = get_detailed_logging_environment()
+
+        # THEN
+        actions = result["script"]["actions"]
+        assert "onExit" in actions
+        assert actions["onExit"]["command"] == "python"
+        assert actions["onExit"]["args"] == [
+            "{{Env.File.printLogs}}",
+            "{{Param.DetailedLogging}}",
+        ]
+        assert actions["onExit"]["cancelation"]["mode"] == "NOTIFY_THEN_TERMINATE"
+
+    def test_embedded_files_contain_actual_script_content(self):
+        """Test that embedded files contain the actual script content from files"""
+        # GIVEN
+        scripts_dir = (
+            Path(__file__).parent.parent.parent.parent
+            / "src"
+            / "deadline"
+            / "cinema4d_submitter"
+            / "detailed_logging_scripts"
+        )
+
+        with open(scripts_dir / "setup_logging.py", "r", encoding="utf-8") as f:
+            expected_setup_content = f.read()
+
+        with open(scripts_dir / "print_logs.py", "r", encoding="utf-8") as f:
+            expected_print_content = f.read()
+
+        # WHEN
+        result = get_detailed_logging_environment()
+
+        # THEN
+        embedded_files = result["script"]["embeddedFiles"]
+        setup_file = next(f for f in embedded_files if f["name"] == "setupLogging")
+        print_file = next(f for f in embedded_files if f["name"] == "printLogs")
+
+        assert setup_file["data"] == expected_setup_content
+        assert print_file["data"] == expected_print_content


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Currently, there are times when the current logs are not sufficient. 
We need a way to help customers to run the same job with detailed logging which they can share with us to deep dive. 

### What was the solution? (How)

Added a new queue environment that starts running Cinema 4D + Redshift with debug logging enabled. 
This can slow down the rendering (hence its not the default), but it can give us more information in the logs which we can then use to debug or share with Maxon. 
Also, I added logic to extract the bugreports generated by Cinema 4D. 

### What is the impact of this change?

Customers can easily resubmit a job with detailed logging enabled which can be then be shared with us. 

### How was this change tested?
I manually tested this feature and also added unit tests.

<img width="559" height="745" alt="image" src="https://github.com/user-attachments/assets/eae6e90d-1325-4941-908c-84bb95a52547" />

As this is a job parameter, we can also use it in Resubmit job flows. 

<img width="1189" height="481" alt="image" src="https://github.com/user-attachments/assets/f4ef7b3d-2c34-444b-8f16-9e3185f869a7" />

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Integration test require a little tweaking as this changes the template. I'll be making a follow-up PR with that fix. 

- Have you made changes to the submitter?
Yes. But this does not require a change to integ_helpers. 

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*