### PR TITLE
feat!: add cross-platform font support

### DIFF
--- a/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
@@ -43,9 +43,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. Increases rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
@@ -39,6 +39,17 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:

--- a/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
@@ -39,17 +39,6 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: UseCachedText
-  type: STRING
-  userInterface:
-    control: CHECK_BOX
-    label: Use cached text during render
-    groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text by using cached fonts. Increases rendering time.
-  default: '0'
-  allowedValues:
-  - '1'
-  - '0'
 steps:
 - name: Main
   parameterSpace:

--- a/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/redshift_multipass/expected_job_bundle/template.yaml
@@ -39,7 +39,7 @@ parameterDefinitions:
     label: Multi-pass output path
     groupLabel: Cinema4D Settings
   description: Multi-pass image output
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -28,7 +28,7 @@ class Cinema4DNotRunningError(Exception):
     """Error that is raised when attempting to use Cinema4D while it is not running"""
 
 
-_FIRST_CINEMA4D_ACTIONS = ["scene_file", "take", "output_path", "multi_pass_path"]
+_FIRST_CINEMA4D_ACTIONS = ["scene_file", "take", "output_path", "multi_pass_path", "cache_text"]
 _CINEMA4D_RUN_KEYS = {
     "frame",
 }
@@ -110,7 +110,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
-        return SemanticVersion(major=0, minor=2)
+        return SemanticVersion(major=0, minor=3)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -28,7 +28,13 @@ class Cinema4DNotRunningError(Exception):
     """Error that is raised when attempting to use Cinema4D while it is not running"""
 
 
-_FIRST_CINEMA4D_ACTIONS = ["scene_file", "take", "output_path", "multi_pass_path", "cache_text"]
+_FIRST_CINEMA4D_ACTIONS = [
+    "scene_file",
+    "take",
+    "output_path",
+    "multi_pass_path",
+    "use_cached_text",
+]
 _CINEMA4D_RUN_KEYS = {
     "frame",
 }

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
@@ -7,7 +7,7 @@
         "output_path": { "type": "string" },
         "multi_pass_path": { "type": "string" },
         "activate_error_checking": { "type": "string" },
-        "cache_text": {"type": "string"}
+        "use_cached_text": {"type": "string"}
     },
     "required": [ "scene_file" ]
 }

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json
@@ -6,7 +6,8 @@
         "take": { "type": "string" },
         "output_path": { "type": "string" },
         "multi_pass_path": { "type": "string" },
-        "activate_error_checking": { "type": "string" }
+        "activate_error_checking": { "type": "string" },
+        "cache_text": {"type": "string"}
     },
     "required": [ "scene_file" ]
 }

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -336,7 +336,7 @@ class Cinema4DHandler:
         Args:
             data (dict): the data of whether to cache the text in the format {USE_CACHED_TEXT_KEY: bool}
         """
-        self.render_kwargs[USE_CACHED_TEXT_KEY] = data.get(USE_CACHED_TEXT_KEY, False)
+        self.render_kwargs[USE_CACHED_TEXT_KEY] = bool(int(data.get(USE_CACHED_TEXT_KEY, 0)))
 
     def set_frame(self, data: dict) -> None:
         """
@@ -414,14 +414,14 @@ class Cinema4DHandler:
         On cross-platform submissions, Cinema 4D sometimes handles fonts incorrectly.
 
         To work around this, the user can select the `Use cached text during render` option in the submitter
-        This will convert the text to polygons first for each frame, rather than procedurally generating text.
+        This will convert the text to polygons for each frame, rather than procedurally generating text.
 
         This option is most often used on Linux, which doesn't support procedural font rendering.
         However, it is also relevant to cross-platform submissions from Mac -> Windows.
 
         If text caching is needed, this function will cache the text. Otherwise, it is a no-op.
 
-        Returns True if text has been cached. Returns False otherwise
+        Returns True if text has been cached. Returns False otherwise.
         """
         if (
             USE_CACHED_TEXT_KEY not in self.render_kwargs

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -66,6 +66,10 @@ class Cinema4DHandler:
     render_kwargs: Dict[str, Any]
     map_path: Callable[[str], str]
 
+    C4D_FONT_INDEX = c4d.DescID(
+        c4d.DescLevel(c4d.PRIM_TEXT_FONT, c4d.FONTCHOOSER_DATA, c4d.OBJECT_SPLINETEXT)
+    )
+
     def __init__(self, map_path: Callable[[str], str]) -> None:
         """
         Constructor for the c4dpy handler. Initializes action_dict and render variables
@@ -377,16 +381,31 @@ class Cinema4DHandler:
             self.doc = doc
             self._remap_assets()
 
-    def _has_cached_text(self) -> bool:
-        for object in self.doc.GetObjects():
-            font_index = c4d.DescID(
-                c4d.DescLevel(c4d.PRIM_TEXT_FONT, c4d.FONTCHOOSER_DATA, c4d.OBJECT_SPLINETEXT)
-            )
-            font_container = object[font_index]
+    def _has_cached_text(self, objects: list[Any]) -> bool:
+        for obj in objects:
+            font_container = obj[self.C4D_FONT_INDEX]
             font = font_container.GetFont()
             if font:
                 return True
+            children = obj.GetChildren()
+            if children:
+                if self._has_cached_text(children):
+                    return True
         return False
+
+    def _get_all_text_objects(self, objects: list[Any]) -> list[Any]:
+        text_objects = []
+        for obj in objects:
+            font_container = obj[self.C4D_FONT_INDEX]
+            font = font_container.GetFont()
+            if font:
+                text_objects.append(obj)
+            # all objects, including text itself, can have nested text objects that also need to be cached
+            children = obj.GetChildren()
+            if children:
+                text_objects += self._get_all_text_objects(children)
+
+        return text_objects
 
     def _cache_text_if_needed(self, frame_time: c4d.BaseTime) -> bool:
         """
@@ -415,7 +434,7 @@ class Cinema4DHandler:
             )
             return False
 
-        found_font = self._has_cached_text()
+        found_font = self._has_cached_text(self.doc.GetObjects())
 
         if not found_font:
             print("No fonts were found in the scene, no need to cache text.")
@@ -431,16 +450,9 @@ class Cinema4DHandler:
             bt=None, animation=True, expressions=True, caches=True, flags=c4d.BUILDFLAGS_NONE
         )
         print("The location of the text was recalculated. Refreshing the text object list.")
+
         # we do this a second time in case objects are recalculated and have different references
-        text_objects = []
-        for object in self.doc.GetObjects():
-            font_index = c4d.DescID(
-                c4d.DescLevel(c4d.PRIM_TEXT_FONT, c4d.FONTCHOOSER_DATA, c4d.OBJECT_SPLINETEXT)
-            )
-            bc = object[font_index]
-            font = bc.GetFont()
-            if font:
-                text_objects.append(object)
+        text_objects = self._get_all_text_objects(self.doc.GetObjects())
 
         if not text_objects:
             print("No text objects were found in the scene after animation.")

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import traceback
 from typing import Any, Callable, Dict
 
@@ -408,13 +407,15 @@ class Cinema4DHandler:
 
     def _cache_text_if_needed(self, frame_time: c4d.BaseTime) -> bool:
         """
-        On Linux, Cinema 4D cannot handle fonts procedurally, so we need to convert them to polygons first,
-        for every frame. This is a setting that the user can opt into using `use_cached_text` init data.
+        On cross-platform submissions, Cinema 4D sometimes handles fonts incorrectly.
 
-        On Windows, fonts are handled correctly, so we don't need to cache it.
+        To work around this, the user can select the `Use cached text during render` option in the submitter
+        This will convert the text to polygons first for each frame, rather than procedurally generating text.
 
-        If text caching is needed (i.e. this is Linux, the use_cached_text setting is True, and there is text in the scene),
-        this will cache the text. Otherwise, it is a no-op.
+        This option is most often used on Linux, which doesn't support procedural font rendering.
+        However, it is also relevant to cross-platform submissions from Mac -> Windows.
+
+        If text caching is needed, this function will cache the text. Otherwise, it is a no-op.
 
         Returns True if text has been cached. Returns False otherwise
         """
@@ -422,17 +423,9 @@ class Cinema4DHandler:
             USE_CACHED_TEXT_KEY not in self.render_kwargs
             or not self.render_kwargs[USE_CACHED_TEXT_KEY]
         ):
-            if sys.platform == "linux":
-                print(
-                    "If you use text in your scene, it may render incorrectly on Linux. Please set the "
-                    "'Use cached text during render' option if you see incorrect fonts or missing text."
-                )
-            return False
-
-        if sys.platform != "linux":
             print(
-                "Text is only cached on Linux. On other operating systems, text is calculated procedurally, so the "
-                + "text caching option is ignored."
+                "If you see incorrect fonts or missing text, try the 'Use cached text during render' option "
+                "under 'Job-specific settings' in the submitter."
             )
             return False
 

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -31,6 +31,7 @@ FRAME_KEY = "frame"
 OUTPUT_PATH_KEY = "output_path"
 MULTIPASS_PATH_KEY = "multi_pass_path"
 SCENE_FILE_KEY = "scene_file"
+START_RENDER_KEY = "start_render"
 TAKE_KEY = "take"
 
 
@@ -73,7 +74,7 @@ class Cinema4DHandler:
             SCENE_FILE_KEY: self.set_scene_file,
             TAKE_KEY: self.set_take,
             FRAME_KEY: self.set_frame,
-            "start_render": self.start_render,
+            START_RENDER_KEY: self.start_render,
             OUTPUT_PATH_KEY: self.output_path,
             MULTIPASS_PATH_KEY: self.multi_pass_path,
             CACHE_TEXT_KEY: self.should_cache_text,
@@ -378,7 +379,9 @@ class Cinema4DHandler:
 
     def _has_cached_text(self) -> bool:
         for object in self.doc.GetObjects():
-            font_index = c4d.DescID(c4d.DescLevel(2117, 1009372, 5178))  # font
+            font_index = c4d.DescID(
+                c4d.DescLevel(c4d.PRIM_TEXT_FONT, c4d.FONTCHOOSER_DATA, c4d.OBJECT_SPLINETEXT)
+            )
             font_container = object[font_index]
             font = font_container.GetFont()
             if font:
@@ -431,7 +434,9 @@ class Cinema4DHandler:
         # we do this a second time in case objects are recalculated and have different references
         text_objects = []
         for object in self.doc.GetObjects():
-            font_index = c4d.DescID(c4d.DescLevel(2117, 1009372, 5178))  # font
+            font_index = c4d.DescID(
+                c4d.DescLevel(c4d.PRIM_TEXT_FONT, c4d.FONTCHOOSER_DATA, c4d.OBJECT_SPLINETEXT)
+            )
             bc = object[font_index]
             font = bc.GetFont()
             if font:
@@ -445,11 +450,11 @@ class Cinema4DHandler:
 
         print("Converting all parameterized text objects to polygons for correct rendering.")
         c4d.utils.SendModelingCommand(
-            command=c4d.MCOMMAND_MAKEEDITABLE,
+            command=c4d.MCOMMAND_MAKEEDITABLE,  # convert the cached parameterized text to polygons
             list=text_objects,
-            mode=c4d.MODELINGCOMMANDMODE_ALL,
+            mode=c4d.MODELINGCOMMANDMODE_ALL,  # apply to all points/polygons
             doc=self.doc,
-            flags=c4d.MODELINGCOMMANDFLAGS_CREATEUNDO,
+            flags=c4d.MODELINGCOMMANDFLAGS_CREATEUNDO,  # apply to the current document
         )
         print("Successfully converted all text objects to polygons.")
 

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -26,7 +26,7 @@ _RENDERRESULT = {
     c4d.RENDERRESULT_NOOUTPUTSPECIFIED: "Output was not specified.",
 }
 
-CACHE_TEXT_KEY = "cache_text"
+USE_CACHED_TEXT_KEY = "use_cached_text"
 FRAME_KEY = "frame"
 OUTPUT_PATH_KEY = "output_path"
 MULTIPASS_PATH_KEY = "multi_pass_path"
@@ -81,12 +81,12 @@ class Cinema4DHandler:
             START_RENDER_KEY: self.start_render,
             OUTPUT_PATH_KEY: self.output_path,
             MULTIPASS_PATH_KEY: self.multi_pass_path,
-            CACHE_TEXT_KEY: self.should_cache_text,
+            USE_CACHED_TEXT_KEY: self.use_cached_text,
         }
         self.render_kwargs = {}
         self.take = "Main"
         self.map_path = map_path
-        self.text_was_cached = False
+        self.cached_text_was_used_in_previous_frame = False
 
     def _remap_assets(self) -> None:
         """
@@ -231,7 +231,7 @@ class Cinema4DHandler:
         return True
 
     def start_render(self, data: dict) -> None:
-        if self.text_was_cached:
+        if self.cached_text_was_used_in_previous_frame:
             # Close and then reload document since we collapsed some text in the previous frame
             # and it can no longer be animated.
             # Reloading the document will allow the next frame to have correct data.
@@ -264,7 +264,7 @@ class Cinema4DHandler:
         )
         rd = self.render_data.GetDataInstance()
 
-        self.text_was_cached = self._cache_text_if_needed(frame_time)
+        self.cached_text_was_used_in_previous_frame = self._cache_text_if_needed(frame_time)
 
         result = c4d.documents.RenderDocument(
             self.doc,
@@ -330,14 +330,14 @@ class Cinema4DHandler:
             print("Error: take not found: %s" % take_name)
         take_data.SetCurrentTake(take)
 
-    def should_cache_text(self, data: dict) -> None:
+    def use_cached_text(self, data: dict) -> None:
         """
         Sets whether text should be cached on Linux
 
         Args:
-            data (dict): the data of whether to cache the text in the format {CACHE_TEXT_KEY: bool}
+            data (dict): the data of whether to cache the text in the format {USE_CACHED_TEXT_KEY: bool}
         """
-        self.render_kwargs[CACHE_TEXT_KEY] = data.get(CACHE_TEXT_KEY, False)
+        self.render_kwargs[USE_CACHED_TEXT_KEY] = data.get(USE_CACHED_TEXT_KEY, False)
 
     def set_frame(self, data: dict) -> None:
         """
@@ -388,9 +388,8 @@ class Cinema4DHandler:
             if font:
                 return True
             children = obj.GetChildren()
-            if children:
-                if self._has_cached_text(children):
-                    return True
+            if children and self._has_cached_text(children):
+                return True
         return False
 
     def _get_all_text_objects(self, objects: list[Any]) -> list[Any]:
@@ -410,16 +409,19 @@ class Cinema4DHandler:
     def _cache_text_if_needed(self, frame_time: c4d.BaseTime) -> bool:
         """
         On Linux, Cinema 4D cannot handle fonts procedurally, so we need to convert them to polygons first,
-        for every frame. This is a setting that the user can opt into using `cache_text` init data.
+        for every frame. This is a setting that the user can opt into using `use_cached_text` init data.
 
         On Windows, fonts are handled correctly, so we don't need to cache it.
 
-        If text caching is needed (i.e. this is Linux, the cache_text setting is True, and there is text in the scene),
+        If text caching is needed (i.e. this is Linux, the use_cached_text setting is True, and there is text in the scene),
         this will cache the text. Otherwise, it is a no-op.
 
         Returns True if text has been cached. Returns False otherwise
         """
-        if CACHE_TEXT_KEY not in self.render_kwargs or not self.render_kwargs[CACHE_TEXT_KEY]:
+        if (
+            USE_CACHED_TEXT_KEY not in self.render_kwargs
+            or not self.render_kwargs[USE_CACHED_TEXT_KEY]
+        ):
             if sys.platform == "linux":
                 print(
                     "If you use text in your scene, it may render incorrectly on Linux. Please set the "

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -392,6 +392,10 @@ class Cinema4DHandler:
         return False
 
     def _get_all_text_objects(self, objects: list[Any]) -> list[Any]:
+        """
+        Retrieves all text objects in the scene. They will be listed with
+        all children objects AFTER (higher index in the list than) their parent objects.
+        """
         text_objects = []
         for obj in objects:
             font_container = obj[self.C4D_FONT_INDEX]
@@ -454,6 +458,17 @@ class Cinema4DHandler:
             return False
 
         print(f"Text objects found in scene after animation: {text_objects}")
+
+        # The _get_all_text_objects() function returns all text objects with the parent objects first, then children
+        # objects. However, in the modeling command below, we actually need to list the children objects before the
+        # parent objects so that each object reference remains valid when modified in order.
+        #
+        # For example, if there is parent text and child text, and the parent text is made editable (converted to
+        # polygons) first, then the child reference will no longer be valid. This breaks the child reference and causes
+        # a segmentation fault.
+        # However, if we convert the child text to polygons first, the parent text will still be valid and can be converted
+        # to polygons as well.
+        text_objects.reverse()
 
         print("Converting all parameterized text objects to polygons for correct rendering.")
         c4d.utils.SendModelingCommand(

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import traceback
 from typing import Any, Callable, Dict
 
@@ -24,6 +25,13 @@ _RENDERRESULT = {
     c4d.RENDERRESULT_ERRORLOADINGPROJECT: "There was an error while loading the project.",
     c4d.RENDERRESULT_NOOUTPUTSPECIFIED: "Output was not specified.",
 }
+
+CACHE_TEXT_KEY = "cache_text"
+FRAME_KEY = "frame"
+OUTPUT_PATH_KEY = "output_path"
+MULTIPASS_PATH_KEY = "multi_pass_path"
+SCENE_FILE_KEY = "scene_file"
+TAKE_KEY = "take"
 
 
 def progress_callback(progress_percent, progress_type_int):
@@ -62,16 +70,18 @@ class Cinema4DHandler:
         Constructor for the c4dpy handler. Initializes action_dict and render variables
         """
         self.action_dict = {
-            "scene_file": self.set_scene_file,
-            "take": self.set_take,
-            "frame": self.set_frame,
+            SCENE_FILE_KEY: self.set_scene_file,
+            TAKE_KEY: self.set_take,
+            FRAME_KEY: self.set_frame,
             "start_render": self.start_render,
-            "output_path": self.output_path,
-            "multi_pass_path": self.multi_pass_path,
+            OUTPUT_PATH_KEY: self.output_path,
+            MULTIPASS_PATH_KEY: self.multi_pass_path,
+            CACHE_TEXT_KEY: self.should_cache_text,
         }
         self.render_kwargs = {}
         self.take = "Main"
         self.map_path = map_path
+        self.text_was_cached = False
 
     def _remap_assets(self) -> None:
         """
@@ -216,12 +226,20 @@ class Cinema4DHandler:
         return True
 
     def start_render(self, data: dict) -> None:
+        if self.text_was_cached:
+            # Close and then reload document since we collapsed some text in the previous frame
+            # and it can no longer be animated.
+            # Reloading the document will allow the next frame to have correct data.
+            self._reload_document()
+
         self.render_data = self.doc.GetActiveRenderData()
         self.render_data[c4d.RDATA_FRAMESEQUENCE] = c4d.RDATA_FRAMESEQUENCE_MANUAL
-        frame = int(self.render_kwargs.get("frame", data["frame"]))
+        self.render_kwargs[FRAME_KEY] = int(self.render_kwargs.get(FRAME_KEY, data[FRAME_KEY]))
+        frame = self.render_kwargs[FRAME_KEY]
         fps = self.doc.GetFps()
-        self.render_data[c4d.RDATA_FRAMEFROM] = c4d.BaseTime(frame, fps)
-        self.render_data[c4d.RDATA_FRAMETO] = c4d.BaseTime(frame, fps)
+        frame_time = c4d.BaseTime(frame, fps)
+        self.render_data[c4d.RDATA_FRAMEFROM] = frame_time
+        self.render_data[c4d.RDATA_FRAMETO] = frame_time
         self.render_data[c4d.RDATA_FRAMESTEP] = 1
 
         if self.render_data[c4d.RDATA_PATH]:
@@ -240,6 +258,9 @@ class Cinema4DHandler:
             c4d.COLORMODE_RGB,
         )
         rd = self.render_data.GetDataInstance()
+
+        self.text_was_cached = self._cache_text_if_needed(frame_time)
+
         result = c4d.documents.RenderDocument(
             self.doc,
             rd,
@@ -256,14 +277,16 @@ class Cinema4DHandler:
             print("Finished Rendering")
 
     def output_path(self, data: dict) -> None:
-        output_path = data.get("output_path", "")
+        output_path = data.get(OUTPUT_PATH_KEY, "")
+        self.render_kwargs[OUTPUT_PATH_KEY] = output_path
         if output_path:
             doc = c4d.documents.GetActiveDocument()
             render_data = doc.GetActiveRenderData()
             render_data[c4d.RDATA_PATH] = self.map_path(output_path)
 
     def multi_pass_path(self, data: dict) -> None:
-        multi_pass_path = data.get("multi_pass_path", "")
+        multi_pass_path = data.get(MULTIPASS_PATH_KEY, "")
+        self.render_kwargs[MULTIPASS_PATH_KEY] = multi_pass_path
         if multi_pass_path:
             doc = c4d.documents.GetActiveDocument()
             render_data = doc.GetActiveRenderData()
@@ -276,7 +299,8 @@ class Cinema4DHandler:
         Args:
             data (dict):
         """
-        take_name = data.get("take", "")
+        take_name = data.get(TAKE_KEY, "")
+        self.render_kwargs[TAKE_KEY] = take_name
         doc = c4d.documents.GetActiveDocument()
         take_data = doc.GetTakeData()
         if not take_data:
@@ -301,6 +325,15 @@ class Cinema4DHandler:
             print("Error: take not found: %s" % take_name)
         take_data.SetCurrentTake(take)
 
+    def should_cache_text(self, data: dict) -> None:
+        """
+        Sets whether text should be cached on Linux
+
+        Args:
+            data (dict): the data of whether to cache the text in the format {CACHE_TEXT_KEY: bool}
+        """
+        self.render_kwargs[CACHE_TEXT_KEY] = data.get(CACHE_TEXT_KEY, False)
+
     def set_frame(self, data: dict) -> None:
         """
         Sets the frame to render
@@ -308,7 +341,7 @@ class Cinema4DHandler:
         Args:
             data (dict):
         """
-        self.render_kwargs["frame"] = int(data["frame"])
+        self.render_kwargs[FRAME_KEY] = int(data[FRAME_KEY])
 
     def set_scene_file(self, data: dict) -> None:
         """
@@ -320,7 +353,8 @@ class Cinema4DHandler:
         Raises:
             FileNotFoundError: If path to the scene file does not yield a file
         """
-        scene_file = data.get("scene_file", "")
+        scene_file = data.get(SCENE_FILE_KEY, "")
+        self.render_kwargs[SCENE_FILE_KEY] = data[SCENE_FILE_KEY]
         if not os.path.isfile(scene_file):
             raise FileNotFoundError(f"The scene file '{scene_file}' does not exist")
         doc = c4d.documents.LoadDocument(
@@ -341,3 +375,88 @@ class Cinema4DHandler:
             c4d.documents.SetActiveDocument(doc)
             self.doc = doc
             self._remap_assets()
+
+    def _has_cached_text(self) -> bool:
+        for object in self.doc.GetObjects():
+            font_index = c4d.DescID(c4d.DescLevel(2117, 1009372, 5178))  # font
+            font_container = object[font_index]
+            font = font_container.GetFont()
+            if font:
+                return True
+        return False
+
+    def _cache_text_if_needed(self, frame_time: c4d.BaseTime) -> bool:
+        """
+        On Linux, Cinema 4D cannot handle fonts procedurally, so we need to convert them to polygons first,
+        for every frame. This is a setting that the user can opt into using `cache_text` init data.
+
+        On Windows, fonts are handled correctly, so we don't need to cache it.
+
+        If text caching is needed (i.e. this is Linux, the cache_text setting is True, and there is text in the scene),
+        this will cache the text. Otherwise, it is a no-op.
+
+        Returns True if text has been cached. Returns False otherwise
+        """
+        if CACHE_TEXT_KEY not in self.render_kwargs or not self.render_kwargs[CACHE_TEXT_KEY]:
+            if sys.platform == "linux":
+                print(
+                    "If you use text in your scene, it may render incorrectly on Linux. Please set the "
+                    "'Use cached text during render' option if you see incorrect fonts or missing text."
+                )
+            return False
+
+        if sys.platform != "linux":
+            print(
+                "Text is only cached on Linux. On other operating systems, text is calculated procedurally, so the "
+                + "text caching option is ignored."
+            )
+            return False
+
+        found_font = self._has_cached_text()
+
+        if not found_font:
+            print("No fonts were found in the scene, no need to cache text.")
+            return False
+
+        print("Fonts were found in the scene")
+
+        print("Setting the correct frame/time to determine text location.")
+        c4d.documents.SetDocumentTime(self.doc, frame_time)
+
+        print(f"Animating the text for frame {self.render_kwargs[FRAME_KEY]}.")
+        self.doc.ExecutePasses(
+            bt=None, animation=True, expressions=True, caches=True, flags=c4d.BUILDFLAGS_NONE
+        )
+        print("The location of the text was recalculated. Refreshing the text object list.")
+        # we do this a second time in case objects are recalculated and have different references
+        text_objects = []
+        for object in self.doc.GetObjects():
+            font_index = c4d.DescID(c4d.DescLevel(2117, 1009372, 5178))  # font
+            bc = object[font_index]
+            font = bc.GetFont()
+            if font:
+                text_objects.append(object)
+
+        if not text_objects:
+            print("No text objects were found in the scene after animation.")
+            return False
+
+        print(f"Text objects found in scene after animation: {text_objects}")
+
+        print("Converting all parameterized text objects to polygons for correct rendering.")
+        c4d.utils.SendModelingCommand(
+            command=c4d.MCOMMAND_MAKEEDITABLE,
+            list=text_objects,
+            mode=c4d.MODELINGCOMMANDMODE_ALL,
+            doc=self.doc,
+            flags=c4d.MODELINGCOMMANDFLAGS_CREATEUNDO,
+        )
+        print("Successfully converted all text objects to polygons.")
+
+        return True
+
+    def _reload_document(self) -> None:
+        c4d.documents.KillDocument(c4d.documents.GetActiveDocument())
+        for action in [SCENE_FILE_KEY, TAKE_KEY, OUTPUT_PATH_KEY, MULTIPASS_PATH_KEY]:
+            if action in self.render_kwargs:
+                self.action_dict[action]({action: self.render_kwargs[action]})

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -66,17 +66,6 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: DetailedLogging
-  type: STRING
-  userInterface:
-    control: CHECK_BOX
-    label: Enable Detailed Logging
-    groupLabel: Cinema4D Settings
-  description: Enable detailed Cinema 4D + Redshift renderer logging for debugging.
-  default: '0'
-  allowedValues:
-  - '1'
-  - '0'
 - name: UseCachedText
   type: STRING
   userInterface:

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -66,6 +66,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Render
   parameterSpace:
@@ -90,6 +101,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -81,9 +81,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -77,7 +77,7 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX
@@ -112,7 +112,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -222,7 +222,7 @@ def _get_job_template(
             # Update the init data of the step
             init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
             init_data["data"] = (
-                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\ncache_text: '{{Param.UseCachedText}}'"
+                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\nuse_cached_text: '{{Param.UseCachedText}}'"
                 % take_data.name
             )
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -105,7 +105,7 @@ def _get_parameter_values(
     parameter_values.append(
         {"name": "DetailedLogging", "value": "1" if settings.activate_detailed_logging else "0"}
     )
-    parameter_values.append({"name": "CacheText", "value": settings.cache_text})
+    parameter_values.append({"name": "UseCachedText", "value": settings.use_cached_text})
 
     if per_take_frames_parameters:
         for take_data in submit_takes:
@@ -222,7 +222,7 @@ def _get_job_template(
             # Update the init data of the step
             init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
             init_data["data"] = (
-                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\ncache_text: '{{Param.CacheText}}'"
+                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\ncache_text: '{{Param.UseCachedText}}'"
                 % take_data.name
             )
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -105,6 +105,7 @@ def _get_parameter_values(
     parameter_values.append(
         {"name": "DetailedLogging", "value": "1" if settings.activate_detailed_logging else "0"}
     )
+    parameter_values.append({"name": "CacheText", "value": settings.cache_text})
 
     if per_take_frames_parameters:
         for take_data in submit_takes:
@@ -130,7 +131,7 @@ def _get_parameter_values(
     if parameter_overlap:
         raise DeadlineOperationError(
             "The following queue parameters conflict with the Cinema4D job parameters:\n"
-            + f"{', '.join(parameter_overlap)}\n"
+            + f"{', '.join(parameter_overlap)}"
             "Rename the parameters on the queue to continue job submissions."
         )
 
@@ -221,7 +222,7 @@ def _get_job_template(
             # Update the init data of the step
             init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
             init_data["data"] = (
-                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'"
+                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\ncache_text: '{{Param.CacheText}}'"
                 % take_data.name
             )
 

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -78,7 +78,7 @@ class RenderSubmitterUISettings:
     # Hence, this setting is not sticky and customers would have to manually
     # click it everytime they want to submit such a job.
     activate_detailed_logging: bool = field(default=False, metadata={"sticky": False})
-    cache_text: str = field(default=TextCaching.DEACTIVATE.value, metadata={"sticky": True})
+    use_cached_text: str = field(default=TextCaching.DEACTIVATE.value, metadata={"sticky": True})
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}
     )

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from deadline.client.ui.dataclasses.timeouts import TimeoutEntry, TimeoutTableEntries
 
 from .takes import TakeSelection  # type: ignore
-from .error_checking import ErrorChecking
+from .enums import ErrorChecking, TextCaching
 from datetime import timedelta
 
 RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
@@ -78,6 +78,7 @@ class RenderSubmitterUISettings:
     # Hence, this setting is not sticky and customers would have to manually
     # click it everytime they want to submit such a job.
     activate_detailed_logging: bool = field(default=False, metadata={"sticky": False})
+    cache_text: str = field(default=TextCaching.DEACTIVATE.value, metadata={"sticky": True})
     timeouts: TimeoutTableEntries = field(
         default_factory=default_timeout_entries, metadata={"sticky": True}
     )

--- a/src/deadline/cinema4d_submitter/enums.py
+++ b/src/deadline/cinema4d_submitter/enums.py
@@ -5,3 +5,8 @@ from enum import Enum
 class ErrorChecking(Enum):
     DEACTIVATE = "0"
     ACTIVATE = "1"
+
+
+class TextCaching(Enum):
+    DEACTIVATE = "0"
+    ACTIVATE = "1"

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -209,7 +209,7 @@ class SceneSettingsWidget(QWidget):
         self.frame_override_txt.setText(settings.frame_list)
         self.activate_error_checking_chck.setChecked(bool(int(settings.activate_error_checking)))
         self.activate_detailed_logging_chck.setChecked(settings.activate_detailed_logging)
-        self.cache_text_chck.setChecked(bool(int(settings.cache_text)))
+        self.cache_text_chck.setChecked(bool(int(settings.use_cached_text)))
 
         index = self.layers_box.findData(settings.take_selection)
         if index >= 0:
@@ -243,7 +243,7 @@ class SceneSettingsWidget(QWidget):
 
         settings.activate_detailed_logging = self.activate_detailed_logging_chck.isChecked()
 
-        settings.cache_text = (
+        settings.use_cached_text = (
             TextCaching.ACTIVATE.value
             if self.cache_text_chck.isChecked()
             else TextCaching.DEACTIVATE.value

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -172,17 +172,15 @@ class SceneSettingsWidget(QWidget):
         rendering_options_box = QGroupBox("Cinema 4D rendering options", self)
         rendering_options_layout = QVBoxLayout(rendering_options_box)
 
-        self.cache_text_chck = QCheckBox(
-            "Use cached text during render", self
-        )
-        rendering_options_layout.addWidget(self.cache_text_chck)
+        self.use_cached_text_chck = QCheckBox("Use cached text during render", self)
+        rendering_options_layout.addWidget(self.use_cached_text_chck)
 
-        cache_text_warning_label = QLabel(
+        use_cached_text_warning_label = QLabel(
             "Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is "
             "ignored. If there are fonts in the scene, this will increase rendering time."
         )
-        cache_text_warning_label.setWordWrap(True)
-        rendering_options_layout.addWidget(cache_text_warning_label)
+        use_cached_text_warning_label.setWordWrap(True)
+        rendering_options_layout.addWidget(use_cached_text_warning_label)
 
         lyt.addWidget(rendering_options_box, widget_row, 0, 1, 2)
         widget_row += 1
@@ -208,7 +206,7 @@ class SceneSettingsWidget(QWidget):
         self.frame_override_txt.setText(settings.frame_list)
         self.activate_error_checking_chck.setChecked(bool(int(settings.activate_error_checking)))
         self.activate_detailed_logging_chck.setChecked(settings.activate_detailed_logging)
-        self.cache_text_chck.setChecked(bool(int(settings.use_cached_text)))
+        self.use_cached_text_chck.setChecked(bool(int(settings.use_cached_text)))
 
         index = self.layers_box.findData(settings.take_selection)
         if index >= 0:
@@ -244,7 +242,7 @@ class SceneSettingsWidget(QWidget):
 
         settings.use_cached_text = (
             TextCaching.ACTIVATE.value
-            if self.cache_text_chck.isChecked()
+            if self.use_cached_text_chck.isChecked()
             else TextCaching.DEACTIVATE.value
         )
 

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -173,14 +173,13 @@ class SceneSettingsWidget(QWidget):
         rendering_options_layout = QVBoxLayout(rendering_options_box)
 
         self.cache_text_chck = QCheckBox(
-            "Use cached text during render (only affects Linux workers)", self
+            "Use cached text during render", self
         )
         rendering_options_layout.addWidget(self.cache_text_chck)
 
         cache_text_warning_label = QLabel(
-            "Prevents incorrect or missing text on Linux renders by using cached fonts. Ignored on Windows renders. "
-            + "If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase "
-            + "rendering time."
+            "Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is "
+            "ignored. If there are fonts in the scene, this will increase rendering time."
         )
         cache_text_warning_label.setWordWrap(True)
         rendering_options_layout.addWidget(cache_text_warning_label)

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -21,7 +21,7 @@ from qtpy.QtWidgets import (  # type: ignore
 from deadline.client.ui.widgets.job_timeouts_widget import TimeoutTableWidget
 
 from ...takes import TakeSelection
-from ...error_checking import ErrorChecking
+from ...enums import ErrorChecking, TextCaching
 
 """
 UI widgets for the Scene Settings tab.
@@ -101,17 +101,22 @@ class SceneSettingsWidget(QWidget):
 
     def _build_ui(self, settings):
         lyt = QGridLayout(self)
+
+        widget_row = 1
+
         self.op_path_chck = QCheckBox("Override Output Path", self)
         self.op_path_txt = FileSearchLineEdit(directory_only=True)
-        lyt.addWidget(self.op_path_chck, 1, 0)
-        lyt.addWidget(self.op_path_txt, 1, 1)
+        lyt.addWidget(self.op_path_chck, widget_row, 0)
+        lyt.addWidget(self.op_path_txt, widget_row, 1)
         self.op_path_chck.stateChanged.connect(self.activate_path_changed)
+        widget_row += 1
 
         self.op_multi_path_chck = QCheckBox("Override Multi-Pass Path", self)
         self.op_multi_path_txt = FileSearchLineEdit(directory_only=True)
-        lyt.addWidget(self.op_multi_path_chck, 2, 0)
-        lyt.addWidget(self.op_multi_path_txt, 2, 1)
+        lyt.addWidget(self.op_multi_path_chck, widget_row, 0)
+        lyt.addWidget(self.op_multi_path_txt, widget_row, 1)
         self.op_multi_path_chck.stateChanged.connect(self.activate_multi_path_changed)
+        widget_row += 1
 
         self.layers_box = QComboBox(self)
         layer_items = [
@@ -122,24 +127,29 @@ class SceneSettingsWidget(QWidget):
         ]
         for layer_value, text in layer_items:
             self.layers_box.addItem(text, layer_value)
-        lyt.addWidget(QLabel("Takes"), 3, 0)
-        lyt.addWidget(self.layers_box, 3, 1)
+        lyt.addWidget(QLabel("Takes"), widget_row, 0)
+        lyt.addWidget(self.layers_box, widget_row, 1)
+        widget_row += 1
 
         self.frame_override_chck = QCheckBox("Override Frame Range", self)
         self.frame_override_txt = QLineEdit(self)
         self.frame_override_txt.setMaxLength(32767)
-        lyt.addWidget(self.frame_override_chck, 4, 0)
-        lyt.addWidget(self.frame_override_txt, 4, 1)
+        lyt.addWidget(self.frame_override_chck, widget_row, 0)
+        lyt.addWidget(self.frame_override_txt, widget_row, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)
+        widget_row += 1
 
         self.activate_error_checking_chck = QCheckBox("Activate automatic error checking", self)
-        lyt.addWidget(self.activate_error_checking_chck, 5, 0)
+        lyt.addWidget(self.activate_error_checking_chck, widget_row, 0)
+        widget_row += 1
 
         self.activate_detailed_logging_chck = QCheckBox("Activate detailed logging", self)
-        lyt.addWidget(self.activate_detailed_logging_chck, 6, 0)
+        lyt.addWidget(self.activate_detailed_logging_chck, widget_row, 0)
+        widget_row += 1
 
         self.timeout_settings_box = TimeoutTableWidget(timeouts=settings.timeouts, parent=self)
-        lyt.addWidget(self.timeout_settings_box, 7, 0, 1, 2)
+        lyt.addWidget(self.timeout_settings_box, widget_row, 0, 1, 2)
+        widget_row += 1
 
         # Create a group box for the export job bundle option
         export_group_box = QGroupBox("Cinema 4D submission options", self)
@@ -156,16 +166,36 @@ class SceneSettingsWidget(QWidget):
         )
         warning_label.setWordWrap(True)
         export_layout.addWidget(warning_label)
+        lyt.addWidget(export_group_box, widget_row, 0, 1, 2)
+        widget_row += 1
 
-        lyt.addWidget(export_group_box, 8, 0, 1, 2)
+        rendering_options_box = QGroupBox("Cinema 4D rendering options", self)
+        rendering_options_layout = QVBoxLayout(rendering_options_box)
+
+        self.cache_text_chck = QCheckBox(
+            "Use cached text during render (only affects Linux workers)", self
+        )
+        rendering_options_layout.addWidget(self.cache_text_chck)
+
+        cache_text_warning_label = QLabel(
+            "Prevents incorrect or missing text on Linux renders by using cached fonts. Ignored on Windows renders. "
+            + "If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase "
+            + "rendering time."
+        )
+        cache_text_warning_label.setWordWrap(True)
+        rendering_options_layout.addWidget(cache_text_warning_label)
+
+        lyt.addWidget(rendering_options_box, widget_row, 0, 1, 2)
+        widget_row += 1
 
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 9, 0)
+            lyt.addWidget(self.include_adaptor_wheels, widget_row, 0)
+            widget_row += 1
 
-        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 11, 0)
+        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), widget_row, 0)
 
     def _configure_settings(self, settings):
         self.op_path_chck.setChecked(settings.override_output_path)
@@ -179,6 +209,7 @@ class SceneSettingsWidget(QWidget):
         self.frame_override_txt.setText(settings.frame_list)
         self.activate_error_checking_chck.setChecked(bool(int(settings.activate_error_checking)))
         self.activate_detailed_logging_chck.setChecked(settings.activate_detailed_logging)
+        self.cache_text_chck.setChecked(bool(int(settings.cache_text)))
 
         index = self.layers_box.findData(settings.take_selection)
         if index >= 0:
@@ -211,6 +242,12 @@ class SceneSettingsWidget(QWidget):
         )
 
         settings.activate_detailed_logging = self.activate_detailed_logging_chck.isChecked()
+
+        settings.cache_text = (
+            TextCaching.ACTIVATE.value
+            if self.cache_text_chck.isChecked()
+            else TextCaching.DEACTIVATE.value
+        )
 
         self.timeout_settings_box.update_settings(settings.timeouts)
 

--- a/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
@@ -9,7 +9,7 @@ parameterValues:
   value: '1'
 - name: DetailedLogging
   value: '0'
-- name: CacheText
+- name: UseCachedText
   value: '0'
 - name: Frames
   value: '1'

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -54,6 +54,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:
@@ -77,6 +88,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -69,9 +69,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -65,7 +65,7 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX
@@ -99,7 +99,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
@@ -9,7 +9,7 @@ parameterValues:
   value: '1'
 - name: DetailedLogging
   value: '0'
-- name: CacheText
+- name: UseCachedText
   value: '0'
 - name: MainFrames
   value: '1'

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -57,7 +57,7 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX
@@ -211,7 +211,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -279,7 +279,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -344,7 +344,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -409,7 +409,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -474,7 +474,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -539,7 +539,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -604,7 +604,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -669,7 +669,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -734,7 +734,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -799,7 +799,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -864,7 +864,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -929,7 +929,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -994,7 +994,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -1059,7 +1059,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -1124,7 +1124,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -61,9 +61,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -46,6 +46,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 - name: MainFrames
   type: STRING
   userInterface:
@@ -189,6 +200,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -256,6 +268,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -320,6 +333,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -384,6 +398,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -448,6 +463,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -512,6 +528,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -576,6 +593,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -640,6 +658,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -704,6 +723,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -768,6 +788,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -832,6 +853,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -896,6 +918,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -960,6 +983,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -1024,6 +1048,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd
@@ -1088,6 +1113,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
@@ -9,7 +9,7 @@ parameterValues:
   value: '1'
 - name: DetailedLogging
   value: '0'
-- name: CacheText
+- name: UseCachedText
   value: '0'
 - name: Frames
   value: '1'

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -54,6 +54,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:
@@ -77,6 +88,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -69,9 +69,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -65,7 +65,7 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX
@@ -99,7 +99,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
@@ -9,7 +9,7 @@ parameterValues:
   value: '1'
 - name: DetailedLogging
   value: '0'
-- name: CacheText
+- name: UseCachedText
   value: '0'
 - name: Frames
   value: '1'

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -54,6 +54,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:
@@ -77,6 +88,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -69,9 +69,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -65,7 +65,7 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX
@@ -99,7 +99,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
@@ -9,7 +9,7 @@ parameterValues:
   value: '1'
 - name: DetailedLogging
   value: '0'
-- name: CacheText
+- name: UseCachedText
   value: '0'
 - name: Frames
   value: '1'

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -54,6 +54,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:
@@ -77,6 +88,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -69,9 +69,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -65,7 +65,7 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX
@@ -99,7 +99,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
@@ -9,7 +9,7 @@ parameterValues:
   value: '1'
 - name: DetailedLogging
   value: '0'
-- name: CacheText
+- name: UseCachedText
   value: '0'
 - name: Frames
   value: '1'

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -54,6 +54,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:
@@ -77,6 +88,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -69,9 +69,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -65,7 +65,7 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX
@@ -99,7 +99,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
@@ -13,7 +13,7 @@ parameterValues:
   value: '1'
 - name: DetailedLogging
   value: '0'
-- name: CacheText
+- name: UseCachedText
   value: '0'
 - name: Frames
   value: '1'

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -54,6 +54,17 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
+- name: CacheText
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Use cached text during render (only affects Linux workers)
+    groupLabel: Cinema4D Settings
+  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  default: '0'
+  allowedValues:
+  - '1'
+  - '0'
 steps:
 - name: Main
   parameterSpace:
@@ -77,6 +88,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
+          cache_text: '{{Param.CacheText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -69,9 +69,9 @@ parameterDefinitions:
   type: STRING
   userInterface:
     control: CHECK_BOX
-    label: Use cached text during render (only affects Linux workers)
+    label: Use cached text during render
     groupLabel: Cinema4D Settings
-  description: Prevents incorrect or missing text on Linux renders by using cached fonts. Increases rendering time.
+  description: Prevents incorrect or missing text by using cached fonts. If there are no fonts in the scene, this is ignored. If there are fonts in the scene, this will increase rendering time.
   default: '0'
   allowedValues:
   - '1'

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -65,7 +65,7 @@ parameterDefinitions:
   allowedValues:
   - '1'
   - '0'
-- name: CacheText
+- name: UseCachedText
   type: STRING
   userInterface:
     control: CHECK_BOX
@@ -99,7 +99,7 @@ steps:
           output_path: '{{Param.OutputPath}}'
           multi_pass_path: '{{Param.MultiPassPath}}'
           activate_error_checking: '{{Param.ActivateErrorChecking}}'
-          cache_text: '{{Param.CacheText}}'
+          use_cached_text: '{{Param.UseCachedText}}'
       actions:
         onEnter:
           command: cinema4d-openjd

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -26,7 +26,7 @@ REFERENCE_INIT_DATA_SCHEMA = {
         "output_path": {"type": "string"},
         "multi_pass_path": {"type": "string"},
         "activate_error_checking": {"type": "string"},
-        "cache_text": {"type": "string"},
+        "use_cached_text": {"type": "string"},
     },
     "required": ["scene_file"],
 }
@@ -53,7 +53,7 @@ def init_data() -> dict:
         "output_path": "C:\\Users\\user123\\test_render",
         "multi_pass_path": "",
         "activate_error_checking": "1",
-        "cache_text": "0",
+        "use_cached_text": "0",
     }
 
 
@@ -423,7 +423,7 @@ class TestCinema4DAdaptor_populate_action_queue:
             "take": "Main",
             "output_path": "/output",
             "multi_pass_path": "/multipass",
-            "cache_text": "1",
+            "use_cached_text": "1",
             "activate_error_checking": "1",
         }
         adaptor = Cinema4DAdaptor(init_data_with_all_actions)
@@ -444,16 +444,16 @@ class TestCinema4DAdaptor_populate_action_queue:
         assert "take" in action_names
         assert "output_path" in action_names
         assert "multi_pass_path" in action_names
-        assert "cache_text" in action_names
+        assert "use_cached_text" in action_names
 
         # Verify the order matches _FIRST_CINEMA4D_ACTIONS
-        expected_order = ["scene_file", "take", "output_path", "multi_pass_path", "cache_text"]
+        expected_order = ["scene_file", "take", "output_path", "multi_pass_path", "use_cached_text"]
         assert action_names == expected_order
 
     def test_populate_action_queue_with_cache_text(self, init_data: dict):
-        """Tests that _populate_action_queue includes cache_text when present in init_data"""
+        """Tests that _populate_action_queue includes use_cached_text when present in init_data"""
         # GIVEN
-        init_data["cache_text"] = "1"
+        init_data["use_cached_text"] = "1"
         adaptor = Cinema4DAdaptor(init_data)
 
         # WHEN
@@ -466,13 +466,13 @@ class TestCinema4DAdaptor_populate_action_queue:
             if action:
                 actions.append(action)
 
-        # Find the cache_text action
-        cache_text_action = next((a for a in actions if a.name == "cache_text"), None)
-        assert cache_text_action is not None, "cache_text action should be in the queue"
-        assert cache_text_action.args == {"cache_text": "1"}
+        # Find the use_cached_text action
+        cache_text_action = next((a for a in actions if a.name == "use_cached_text"), None)
+        assert cache_text_action is not None, "use_cached_text action should be in the queue"
+        assert cache_text_action.args == {"use_cached_text": "1"}
 
     def test_populate_action_queue_without_cache_text(self):
-        """Tests that _populate_action_queue works when cache_text is not in init_data"""
+        """Tests that _populate_action_queue works when use_cached_text is not in init_data"""
         # GIVEN
         init_data_without_cache_text = {
             "scene_file": "test.c4d",
@@ -492,7 +492,7 @@ class TestCinema4DAdaptor_populate_action_queue:
                 actions.append(action)
 
         action_names = [action.name for action in actions]
-        assert "cache_text" not in action_names
+        assert "use_cached_text" not in action_names
         assert "scene_file" in action_names
         assert "take" in action_names
 
@@ -502,7 +502,7 @@ class TestCinema4DAdaptor_populate_action_queue:
         init_data_with_extra = {
             "scene_file": "test.c4d",
             "take": "Main",
-            "cache_text": "0",
+            "use_cached_text": "0",
             "activate_error_checking": "1",
             "frame": 42,  # This is a run action, not an init action
             "extra_field": "should_not_be_included",
@@ -523,7 +523,7 @@ class TestCinema4DAdaptor_populate_action_queue:
         # Should only include actions from _FIRST_CINEMA4D_ACTIONS
         assert "scene_file" in action_names
         assert "take" in action_names
-        assert "cache_text" in action_names
+        assert "use_cached_text" in action_names
         # Should NOT include run actions or extra fields
         assert "frame" not in action_names
         assert "extra_field" not in action_names

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -450,7 +450,7 @@ class TestCinema4DAdaptor_populate_action_queue:
         expected_order = ["scene_file", "take", "output_path", "multi_pass_path", "use_cached_text"]
         assert action_names == expected_order
 
-    def test_populate_action_queue_with_cache_text(self, init_data: dict):
+    def test_populate_action_queue_with_use_cached_text(self, init_data: dict):
         """Tests that _populate_action_queue includes use_cached_text when present in init_data"""
         # GIVEN
         init_data["use_cached_text"] = "1"
@@ -467,19 +467,19 @@ class TestCinema4DAdaptor_populate_action_queue:
                 actions.append(action)
 
         # Find the use_cached_text action
-        cache_text_action = next((a for a in actions if a.name == "use_cached_text"), None)
-        assert cache_text_action is not None, "use_cached_text action should be in the queue"
-        assert cache_text_action.args == {"use_cached_text": "1"}
+        use_cached_text_action = next((a for a in actions if a.name == "use_cached_text"), None)
+        assert use_cached_text_action is not None, "use_cached_text action should be in the queue"
+        assert use_cached_text_action.args == {"use_cached_text": "1"}
 
-    def test_populate_action_queue_without_cache_text(self):
+    def test_populate_action_queue_without_use_cached_text(self):
         """Tests that _populate_action_queue works when use_cached_text is not in init_data"""
         # GIVEN
-        init_data_without_cache_text = {
+        init_data_without_use_cached_text = {
             "scene_file": "test.c4d",
             "take": "Main",
             "activate_error_checking": "1",
         }
-        adaptor = Cinema4DAdaptor(init_data_without_cache_text)
+        adaptor = Cinema4DAdaptor(init_data_without_use_cached_text)
 
         # WHEN
         adaptor._populate_action_queue()

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -1,6 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
+# NOTE: All tests in this file use @pytest.mark.xdist_group(name="adaptor_tests")
+# to run serially on the same worker. This is necessary because all tests share
+# the same Cinema4DAdaptor action queue, which can cause race conditions and
+# test failures when tests run in parallel across multiple workers.
+
 import json
 from pathlib import Path
 from unittest.mock import Mock, PropertyMock, patch
@@ -21,6 +26,7 @@ REFERENCE_INIT_DATA_SCHEMA = {
         "output_path": {"type": "string"},
         "multi_pass_path": {"type": "string"},
         "activate_error_checking": {"type": "string"},
+        "cache_text": {"type": "string"},
     },
     "required": ["scene_file"],
 }
@@ -47,9 +53,11 @@ def init_data() -> dict:
         "output_path": "C:\\Users\\user123\\test_render",
         "multi_pass_path": "",
         "activate_error_checking": "1",
+        "cache_text": "0",
     }
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 class TestCinema4DAdaptor_errors_on_cleanup:
     @pytest.mark.parametrize(
         "stdout,error_expected",
@@ -138,18 +146,21 @@ class TestCinema4DAdaptor_errors_on_cleanup:
         )
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 def test_adaptor_rejects_malformed_init_data():
     adapter = Cinema4DAdaptor({"invalid": "data"})
     with pytest.raises(ValidationError):
         adapter.on_start()
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 def test_adaptor_rejects_malformed_run_data(init_data: dict):
     adapter = Cinema4DAdaptor(init_data)
     with pytest.raises(ValidationError):
         adapter.on_run({"invalid": "data"})
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(init_data):
     """
     Test to validate that if the init data or run data schema are changed, we also bump the
@@ -157,7 +168,7 @@ def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(i
     """
     # Expected version for these reference schemas
     EXPECTED_MAJOR = 0
-    EXPECTED_MINOR = 2
+    EXPECTED_MINOR = 3
 
     # Get the current version from the adaptor
     adapter = Cinema4DAdaptor(init_data)
@@ -192,6 +203,7 @@ def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(i
     )
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 def test_adaptor_prints_version_on_init(init_data, capfd):
     """
     Test that the adaptor prints its version during initialization
@@ -204,6 +216,7 @@ def test_adaptor_prints_version_on_init(init_data, capfd):
     ), f"Expected output to contain {expected_output}, but got {captured.out}"
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 @pytest.mark.parametrize("activate_error_checking", [0, 1])
 def test_activate_error_checking(init_data: dict, activate_error_checking: int) -> None:
     """
@@ -243,6 +256,7 @@ def run_data() -> dict:
     return {"frame": 42}
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 class TestCinema4DAdaptor_on_start:
     @patch("deadline.cinema4d_adaptor.Cinema4DAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.cinema4d_adaptor.Cinema4DAdaptor.adaptor.LoggingSubprocess")
@@ -286,6 +300,7 @@ class TestCinema4DAdaptor_on_start:
         assert mock_sleep.call_count == 3
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 class TestCinema4DAdaptor_on_run:
     @patch("time.sleep")
     @patch("deadline.cinema4d_adaptor.Cinema4DAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
@@ -316,6 +331,7 @@ class TestCinema4DAdaptor_on_run:
         mock_sleep.assert_called_once_with(0.1)
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 class TestCinema4DAdaptor_on_cleanup:
     @patch("time.sleep")
     @patch("deadline.cinema4d_adaptor.Cinema4DAdaptor.adaptor._logger")
@@ -344,6 +360,7 @@ class TestCinema4DAdaptor_on_cleanup:
         mock_client.terminate.assert_called_once()
 
 
+@pytest.mark.xdist_group(name="adaptor_tests")
 class TestCinema4DAdaptor_on_cancel:
     """Tests for Cinema4DAdaptor.on_cancel"""
 
@@ -376,3 +393,160 @@ class TestCinema4DAdaptor_on_cancel:
         # THEN
         assert "CANCEL REQUESTED" in caplog.text
         assert "Nothing to cancel because Cinema4D is not running" in caplog.text
+
+
+@pytest.mark.xdist_group(name="adaptor_tests")
+class TestCinema4DAdaptor_populate_action_queue:
+    """Tests for Cinema4DAdaptor._populate_action_queue"""
+
+    @pytest.fixture(autouse=True)
+    def cleanup_action_queue(self):
+        """Fixture to clean up the shared action queue before and after each test"""
+        # Create a temporary adaptor to access the shared action queue
+        temp_adaptor = Cinema4DAdaptor({"scene_file": "test.c4d"})
+
+        # Clear the queue before the test
+        while len(temp_adaptor._action_queue) > 0:
+            temp_adaptor._action_queue.dequeue_action()
+
+        yield
+
+        # Clear the queue after the test
+        while len(temp_adaptor._action_queue) > 0:
+            temp_adaptor._action_queue.dequeue_action()
+
+    def test_populate_action_queue_with_all_actions(self):
+        """Tests that _populate_action_queue adds all available actions from init_data"""
+        # GIVEN
+        init_data_with_all_actions = {
+            "scene_file": "test.c4d",
+            "take": "Main",
+            "output_path": "/output",
+            "multi_pass_path": "/multipass",
+            "cache_text": "1",
+            "activate_error_checking": "1",
+        }
+        adaptor = Cinema4DAdaptor(init_data_with_all_actions)
+
+        # WHEN
+        adaptor._populate_action_queue()
+
+        # THEN
+        # Verify that all expected actions are in the queue
+        actions = []
+        while len(adaptor._action_queue) > 0:
+            action = adaptor._action_queue.dequeue_action()
+            if action:
+                actions.append(action)
+
+        action_names = [action.name for action in actions]
+        assert "scene_file" in action_names
+        assert "take" in action_names
+        assert "output_path" in action_names
+        assert "multi_pass_path" in action_names
+        assert "cache_text" in action_names
+
+        # Verify the order matches _FIRST_CINEMA4D_ACTIONS
+        expected_order = ["scene_file", "take", "output_path", "multi_pass_path", "cache_text"]
+        assert action_names == expected_order
+
+    def test_populate_action_queue_with_cache_text(self, init_data: dict):
+        """Tests that _populate_action_queue includes cache_text when present in init_data"""
+        # GIVEN
+        init_data["cache_text"] = "1"
+        adaptor = Cinema4DAdaptor(init_data)
+
+        # WHEN
+        adaptor._populate_action_queue()
+
+        # THEN
+        actions = []
+        while len(adaptor._action_queue) > 0:
+            action = adaptor._action_queue.dequeue_action()
+            if action:
+                actions.append(action)
+
+        # Find the cache_text action
+        cache_text_action = next((a for a in actions if a.name == "cache_text"), None)
+        assert cache_text_action is not None, "cache_text action should be in the queue"
+        assert cache_text_action.args == {"cache_text": "1"}
+
+    def test_populate_action_queue_without_cache_text(self):
+        """Tests that _populate_action_queue works when cache_text is not in init_data"""
+        # GIVEN
+        init_data_without_cache_text = {
+            "scene_file": "test.c4d",
+            "take": "Main",
+            "activate_error_checking": "1",
+        }
+        adaptor = Cinema4DAdaptor(init_data_without_cache_text)
+
+        # WHEN
+        adaptor._populate_action_queue()
+
+        # THEN
+        actions = []
+        while len(adaptor._action_queue) > 0:
+            action = adaptor._action_queue.dequeue_action()
+            if action:
+                actions.append(action)
+
+        action_names = [action.name for action in actions]
+        assert "cache_text" not in action_names
+        assert "scene_file" in action_names
+        assert "take" in action_names
+
+    def test_populate_action_queue_only_includes_first_actions(self):
+        """Tests that _populate_action_queue only includes actions from _FIRST_CINEMA4D_ACTIONS"""
+        # GIVEN
+        init_data_with_extra = {
+            "scene_file": "test.c4d",
+            "take": "Main",
+            "cache_text": "0",
+            "activate_error_checking": "1",
+            "frame": 42,  # This is a run action, not an init action
+            "extra_field": "should_not_be_included",
+        }
+        adaptor = Cinema4DAdaptor(init_data_with_extra)
+
+        # WHEN
+        adaptor._populate_action_queue()
+
+        # THEN
+        actions = []
+        while len(adaptor._action_queue) > 0:
+            action = adaptor._action_queue.dequeue_action()
+            if action:
+                actions.append(action)
+
+        action_names = [action.name for action in actions]
+        # Should only include actions from _FIRST_CINEMA4D_ACTIONS
+        assert "scene_file" in action_names
+        assert "take" in action_names
+        assert "cache_text" in action_names
+        # Should NOT include run actions or extra fields
+        assert "frame" not in action_names
+        assert "extra_field" not in action_names
+        assert "activate_error_checking" not in action_names
+
+    def test_populate_action_queue_with_minimal_init_data(self):
+        """Tests that _populate_action_queue works with minimal init_data (only scene_file)"""
+        # GIVEN
+        minimal_init_data = {
+            "scene_file": "test.c4d",
+        }
+        adaptor = Cinema4DAdaptor(minimal_init_data)
+
+        # WHEN
+        adaptor._populate_action_queue()
+
+        # THEN
+        actions = []
+        while len(adaptor._action_queue) > 0:
+            action = adaptor._action_queue.dequeue_action()
+            if action:
+                actions.append(action)
+
+        action_names = [action.name for action in actions]
+        assert action_names == ["scene_file"]
+        assert len(actions) == 1

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -48,16 +48,18 @@ class TestCinema4DHandler:
 class TestShouldCacheText:
     """Tests for the use_cached_text method"""
 
-    def test_should_cache_text_sets_true(self):
-        """Tests that use_cached_text correctly sets use_cached_text to True"""
+    @pytest.mark.parametrize("value", [True, 1, "1"])
+    def test_should_cache_text_sets_truthy_values(self, value):
+        """Tests that use_cached_text correctly sets use_cached_text to True for truthy values"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.use_cached_text({USE_CACHED_TEXT_KEY: True})
+        handler.use_cached_text({USE_CACHED_TEXT_KEY: value})
         assert handler.render_kwargs[USE_CACHED_TEXT_KEY] is True
 
-    def test_should_cache_text_sets_false(self):
-        """Tests that use_cached_text correctly sets use_cached_text to False"""
+    @pytest.mark.parametrize("value", [False, 0, "0"])
+    def test_should_cache_text_sets_falsy_values(self, value):
+        """Tests that use_cached_text correctly sets use_cached_text to False for falsy values"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.use_cached_text({USE_CACHED_TEXT_KEY: False})
+        handler.use_cached_text({USE_CACHED_TEXT_KEY: value})
         assert handler.render_kwargs[USE_CACHED_TEXT_KEY] is False
 
     def test_should_cache_text_defaults_to_false(self):

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -322,6 +322,140 @@ class TestGetAllTextObjects:
         assert mock_parent_text_object in result
         assert mock_child_text_object in result
 
+    def test_get_all_text_objects_returns_children_after_parents(self):
+        """Tests that _get_all_text_objects returns children at higher indices than their parents"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock font
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        # Create mock child text object with font
+        mock_child_text_object = Mock()
+        mock_child_text_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_child_text_object.GetChildren.return_value = []
+
+        # Create mock parent text object with font and child
+        mock_parent_text_object = Mock()
+        mock_parent_text_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_parent_text_object.GetChildren.return_value = [mock_child_text_object]
+
+        result = handler._get_all_text_objects([mock_parent_text_object])
+
+        # Verify parent comes before child in the list
+        assert len(result) == 2
+        parent_index = result.index(mock_parent_text_object)
+        child_index = result.index(mock_child_text_object)
+        assert parent_index < child_index, "Parent should appear before child in the list"
+
+    def test_get_all_text_objects_returns_multiple_children_after_parent(self):
+        """Tests that _get_all_text_objects returns multiple children after their parent"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock font
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        # Create mock child text objects with fonts
+        mock_child1 = Mock()
+        mock_child1.__getitem__ = Mock(return_value=mock_font_container)
+        mock_child1.GetChildren.return_value = []
+
+        mock_child2 = Mock()
+        mock_child2.__getitem__ = Mock(return_value=mock_font_container)
+        mock_child2.GetChildren.return_value = []
+
+        # Create mock parent text object with font and children
+        mock_parent = Mock()
+        mock_parent.__getitem__ = Mock(return_value=mock_font_container)
+        mock_parent.GetChildren.return_value = [mock_child1, mock_child2]
+
+        result = handler._get_all_text_objects([mock_parent])
+
+        # Verify parent comes before all children
+        assert len(result) == 3
+        parent_index = result.index(mock_parent)
+        child1_index = result.index(mock_child1)
+        child2_index = result.index(mock_child2)
+        assert parent_index < child1_index, "Parent should appear before child1"
+        assert parent_index < child2_index, "Parent should appear before child2"
+
+    def test_get_all_text_objects_returns_nested_children_after_all_ancestors(self):
+        """Tests that _get_all_text_objects returns deeply nested children after all their ancestors"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock font
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        # Create mock grandchild text object with font
+        mock_grandchild = Mock()
+        mock_grandchild.__getitem__ = Mock(return_value=mock_font_container)
+        mock_grandchild.GetChildren.return_value = []
+
+        # Create mock child text object with font and grandchild
+        mock_child = Mock()
+        mock_child.__getitem__ = Mock(return_value=mock_font_container)
+        mock_child.GetChildren.return_value = [mock_grandchild]
+
+        # Create mock parent text object with font and child
+        mock_parent = Mock()
+        mock_parent.__getitem__ = Mock(return_value=mock_font_container)
+        mock_parent.GetChildren.return_value = [mock_child]
+
+        result = handler._get_all_text_objects([mock_parent])
+
+        # Verify ordering: parent < child < grandchild
+        assert len(result) == 3
+        parent_index = result.index(mock_parent)
+        child_index = result.index(mock_child)
+        grandchild_index = result.index(mock_grandchild)
+        assert (
+            parent_index < child_index < grandchild_index
+        ), "Objects should be ordered: parent, child, grandchild"
+
+    def test_get_all_text_objects_returns_siblings_in_order_after_parent(self):
+        """Tests that _get_all_text_objects maintains sibling order and places all siblings after their parent"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock font
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        # Create two parent objects with children
+        mock_child1_parent1 = Mock()
+        mock_child1_parent1.__getitem__ = Mock(return_value=mock_font_container)
+        mock_child1_parent1.GetChildren.return_value = []
+
+        mock_parent1 = Mock()
+        mock_parent1.__getitem__ = Mock(return_value=mock_font_container)
+        mock_parent1.GetChildren.return_value = [mock_child1_parent1]
+
+        mock_child1_parent2 = Mock()
+        mock_child1_parent2.__getitem__ = Mock(return_value=mock_font_container)
+        mock_child1_parent2.GetChildren.return_value = []
+
+        mock_parent2 = Mock()
+        mock_parent2.__getitem__ = Mock(return_value=mock_font_container)
+        mock_parent2.GetChildren.return_value = [mock_child1_parent2]
+
+        result = handler._get_all_text_objects([mock_parent1, mock_parent2])
+
+        # Verify ordering: parent1 < child1_parent1 < parent2 < child1_parent2
+        assert len(result) == 4
+        parent1_index = result.index(mock_parent1)
+        child1_parent1_index = result.index(mock_child1_parent1)
+        parent2_index = result.index(mock_parent2)
+        child1_parent2_index = result.index(mock_child1_parent2)
+
+        assert parent1_index < child1_parent1_index, "Parent1 should appear before its child"
+        assert child1_parent1_index < parent2_index, "Parent1's child should appear before parent2"
+        assert parent2_index < child1_parent2_index, "Parent2 should appear before its child"
+
 
 class TestCacheTextIfNeeded:
     """Tests for the _cache_text_if_needed method"""
@@ -346,20 +480,6 @@ class TestCacheTextIfNeeded:
 
         assert result is False
 
-    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.sys.platform", "win32")
-    def test_cache_text_returns_false_on_windows(self, capsys):
-        """Tests that _cache_text_if_needed returns False on Windows"""
-        handler = Cinema4DHandler(mock_map_path)
-        handler.render_kwargs = {USE_CACHED_TEXT_KEY: True}
-
-        mock_frame_time = Mock()
-        result = handler._cache_text_if_needed(mock_frame_time)
-
-        assert result is False
-        captured = capsys.readouterr()
-        assert "Text is only cached on Linux" in captured.out
-
-    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.sys.platform", "linux")
     def test_cache_text_returns_false_when_no_fonts(self, capsys):
         """Tests that _cache_text_if_needed returns False when no fonts are found"""
         handler = Cinema4DHandler(mock_map_path)
@@ -376,7 +496,6 @@ class TestCacheTextIfNeeded:
         captured = capsys.readouterr()
         assert "No fonts were found in the scene" in captured.out
 
-    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.sys.platform", "linux")
     @patch(
         "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.SetDocumentTime"
     )
@@ -417,7 +536,6 @@ class TestCacheTextIfNeeded:
         assert "Converting all parameterized text objects to polygons" in captured.out
         assert "Successfully converted all text objects to polygons" in captured.out
 
-    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.sys.platform", "linux")
     @patch(
         "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.SetDocumentTime"
     )

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, MagicMock, patch
 import pytest
 from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler
 from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import progress_callback
-from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import CACHE_TEXT_KEY
+from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import USE_CACHED_TEXT_KEY
 import c4d
 
 
@@ -46,25 +46,25 @@ class TestCinema4DHandler:
 
 
 class TestShouldCacheText:
-    """Tests for the should_cache_text method"""
+    """Tests for the use_cached_text method"""
 
     def test_should_cache_text_sets_true(self):
-        """Tests that should_cache_text correctly sets cache_text to True"""
+        """Tests that use_cached_text correctly sets use_cached_text to True"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.should_cache_text({CACHE_TEXT_KEY: True})
-        assert handler.render_kwargs[CACHE_TEXT_KEY] is True
+        handler.use_cached_text({USE_CACHED_TEXT_KEY: True})
+        assert handler.render_kwargs[USE_CACHED_TEXT_KEY] is True
 
     def test_should_cache_text_sets_false(self):
-        """Tests that should_cache_text correctly sets cache_text to False"""
+        """Tests that use_cached_text correctly sets use_cached_text to False"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.should_cache_text({CACHE_TEXT_KEY: False})
-        assert handler.render_kwargs[CACHE_TEXT_KEY] is False
+        handler.use_cached_text({USE_CACHED_TEXT_KEY: False})
+        assert handler.render_kwargs[USE_CACHED_TEXT_KEY] is False
 
     def test_should_cache_text_defaults_to_false(self):
-        """Tests that should_cache_text defaults to False when key is missing"""
+        """Tests that use_cached_text defaults to False when key is missing"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.should_cache_text({})
-        assert handler.render_kwargs[CACHE_TEXT_KEY] is False
+        handler.use_cached_text({})
+        assert handler.render_kwargs[USE_CACHED_TEXT_KEY] is False
 
 
 class TestHasCachedText:
@@ -327,7 +327,7 @@ class TestCacheTextIfNeeded:
     """Tests for the _cache_text_if_needed method"""
 
     def test_cache_text_returns_false_when_not_enabled(self):
-        """Tests that _cache_text_if_needed returns False when cache_text is not enabled"""
+        """Tests that _cache_text_if_needed returns False when use_cached_text is not enabled"""
         handler = Cinema4DHandler(mock_map_path)
         handler.render_kwargs = {}
 
@@ -337,9 +337,9 @@ class TestCacheTextIfNeeded:
         assert result is False
 
     def test_cache_text_returns_false_when_disabled(self):
-        """Tests that _cache_text_if_needed returns False when cache_text is False"""
+        """Tests that _cache_text_if_needed returns False when use_cached_text is False"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.render_kwargs = {CACHE_TEXT_KEY: False}
+        handler.render_kwargs = {USE_CACHED_TEXT_KEY: False}
 
         mock_frame_time = Mock()
         result = handler._cache_text_if_needed(mock_frame_time)
@@ -350,7 +350,7 @@ class TestCacheTextIfNeeded:
     def test_cache_text_returns_false_on_windows(self, capsys):
         """Tests that _cache_text_if_needed returns False on Windows"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.render_kwargs = {CACHE_TEXT_KEY: True}
+        handler.render_kwargs = {USE_CACHED_TEXT_KEY: True}
 
         mock_frame_time = Mock()
         result = handler._cache_text_if_needed(mock_frame_time)
@@ -363,7 +363,7 @@ class TestCacheTextIfNeeded:
     def test_cache_text_returns_false_when_no_fonts(self, capsys):
         """Tests that _cache_text_if_needed returns False when no fonts are found"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.render_kwargs = {CACHE_TEXT_KEY: True}
+        handler.render_kwargs = {USE_CACHED_TEXT_KEY: True}
 
         mock_doc = Mock()
         mock_doc.GetObjects.return_value = []
@@ -388,7 +388,7 @@ class TestCacheTextIfNeeded:
     ):
         """Tests that _cache_text_if_needed converts text objects to polygons on Linux"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.render_kwargs = {CACHE_TEXT_KEY: True, "frame": 42}
+        handler.render_kwargs = {USE_CACHED_TEXT_KEY: True, "frame": 42}
 
         # Create mock font and text objects
         mock_font = Mock()
@@ -426,7 +426,7 @@ class TestCacheTextIfNeeded:
     ):
         """Tests that _cache_text_if_needed returns False when no text objects exist after animation"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.render_kwargs = {CACHE_TEXT_KEY: True, "frame": 42}
+        handler.render_kwargs = {USE_CACHED_TEXT_KEY: True, "frame": 42}
 
         # Create mock font for initial check
         mock_font = Mock()
@@ -540,7 +540,7 @@ class TestStartRenderWithTextCaching:
     ):
         """Tests that start_render reloads the document when text was cached in previous frame"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.text_was_cached = True
+        handler.cached_text_was_used_in_previous_frame = True
 
         # Set up mock document and render data
         mock_doc = Mock()
@@ -568,7 +568,7 @@ class TestStartRenderWithTextCaching:
     ):
         """Tests that start_render does not reload the document when text was not cached"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.text_was_cached = False
+        handler.cached_text_was_used_in_previous_frame = False
 
         # Set up mock document and render data
         mock_doc = Mock()
@@ -594,9 +594,9 @@ class TestStartRenderWithTextCaching:
     def test_start_render_updates_text_was_cached_flag(
         self, mock_base_time: Mock, mock_bitmap: Mock, mock_render_document: Mock
     ):
-        """Tests that start_render updates the text_was_cached flag based on _cache_text_if_needed result"""
+        """Tests that start_render updates the cached_text_was_used_in_previous_frame flag based on _cache_text_if_needed result"""
         handler = Cinema4DHandler(mock_map_path)
-        handler.text_was_cached = False
+        handler.cached_text_was_used_in_previous_frame = False
 
         # Set up mock document and render data
         mock_doc = Mock()
@@ -615,7 +615,7 @@ class TestStartRenderWithTextCaching:
         ):
             handler.start_render({"frame": 1})
 
-        assert handler.text_was_cached is True
+        assert handler.cached_text_was_used_in_previous_frame is True
 
         # Second call: _cache_text_if_needed returns False (no text to cache this time)
         with (
@@ -624,4 +624,4 @@ class TestStartRenderWithTextCaching:
         ):
             handler.start_render({"frame": 1})
 
-        assert handler.text_was_cached is False
+        assert handler.cached_text_was_used_in_previous_frame is False

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -81,12 +81,13 @@ class TestHasCachedText:
 
         mock_object = Mock()
         mock_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_object.GetChildren.return_value = []
 
         mock_doc = Mock()
         mock_doc.GetObjects.return_value = [mock_object]
         handler.doc = mock_doc
 
-        assert handler._has_cached_text() is True
+        assert handler._has_cached_text([mock_object]) is True
 
     def test_has_cached_text_returns_false_when_no_font(self):
         """Tests that _has_cached_text returns False when no font is found"""
@@ -98,12 +99,13 @@ class TestHasCachedText:
 
         mock_object = Mock()
         mock_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_object.GetChildren.return_value = []
 
         mock_doc = Mock()
         mock_doc.GetObjects.return_value = [mock_object]
         handler.doc = mock_doc
 
-        assert handler._has_cached_text() is False
+        assert handler._has_cached_text([mock_object]) is False
 
     def test_has_cached_text_returns_false_when_no_objects(self):
         """Tests that _has_cached_text returns False when there are no objects"""
@@ -113,7 +115,220 @@ class TestHasCachedText:
         mock_doc.GetObjects.return_value = []
         handler.doc = mock_doc
 
-        assert handler._has_cached_text() is False
+        assert handler._has_cached_text([]) is False
+
+    def test_has_cached_text_returns_true_for_child_objects(self):
+        """Tests that _has_cached_text returns True when child objects have fonts"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock child object with font
+        mock_font = Mock()
+        mock_child_font_container = Mock()
+        mock_child_font_container.GetFont.return_value = mock_font
+
+        mock_child_object = Mock()
+        mock_child_object.__getitem__ = Mock(return_value=mock_child_font_container)
+        mock_child_object.GetChildren.return_value = []
+
+        # Create mock parent object without font but with child
+        mock_parent_font_container = Mock()
+        mock_parent_font_container.GetFont.return_value = None
+
+        mock_parent_object = Mock()
+        mock_parent_object.__getitem__ = Mock(return_value=mock_parent_font_container)
+        mock_parent_object.GetChildren.return_value = [mock_child_object]
+
+        mock_doc = Mock()
+        mock_doc.GetObjects.return_value = [mock_parent_object]
+        handler.doc = mock_doc
+
+        assert handler._has_cached_text([mock_parent_object]) is True
+
+    def test_has_cached_text_returns_true_for_nested_child_objects(self):
+        """Tests that _has_cached_text returns True when deeply nested child objects have fonts"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock grandchild object with font
+        mock_font = Mock()
+        mock_grandchild_font_container = Mock()
+        mock_grandchild_font_container.GetFont.return_value = mock_font
+
+        mock_grandchild_object = Mock()
+        mock_grandchild_object.__getitem__ = Mock(return_value=mock_grandchild_font_container)
+        mock_grandchild_object.GetChildren.return_value = []
+
+        # Create mock child object without font but with grandchild
+        mock_child_font_container = Mock()
+        mock_child_font_container.GetFont.return_value = None
+
+        mock_child_object = Mock()
+        mock_child_object.__getitem__ = Mock(return_value=mock_child_font_container)
+        mock_child_object.GetChildren.return_value = [mock_grandchild_object]
+
+        # Create mock parent object without font but with child
+        mock_parent_font_container = Mock()
+        mock_parent_font_container.GetFont.return_value = None
+
+        mock_parent_object = Mock()
+        mock_parent_object.__getitem__ = Mock(return_value=mock_parent_font_container)
+        mock_parent_object.GetChildren.return_value = [mock_child_object]
+
+        assert handler._has_cached_text([mock_parent_object]) is True
+
+
+class TestGetAllTextObjects:
+    """Tests for the _get_all_text_objects method"""
+
+    def test_get_all_text_objects_returns_empty_list_when_no_objects(self):
+        """Tests that _get_all_text_objects returns empty list when there are no objects"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        result = handler._get_all_text_objects([])
+
+        assert result == []
+
+    def test_get_all_text_objects_returns_text_object(self):
+        """Tests that _get_all_text_objects returns text objects with fonts"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock text object with font
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        mock_text_object = Mock()
+        mock_text_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_text_object.GetChildren.return_value = []
+
+        result = handler._get_all_text_objects([mock_text_object])
+
+        assert len(result) == 1
+        assert result[0] == mock_text_object
+
+    def test_get_all_text_objects_returns_multiple_text_objects(self):
+        """Tests that _get_all_text_objects returns multiple text objects"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create two mock text objects with fonts
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        mock_text_object1 = Mock()
+        mock_text_object1.__getitem__ = Mock(return_value=mock_font_container)
+        mock_text_object1.GetChildren.return_value = []
+
+        mock_text_object2 = Mock()
+        mock_text_object2.__getitem__ = Mock(return_value=mock_font_container)
+        mock_text_object2.GetChildren.return_value = []
+
+        result = handler._get_all_text_objects([mock_text_object1, mock_text_object2])
+
+        assert len(result) == 2
+        assert mock_text_object1 in result
+        assert mock_text_object2 in result
+
+    def test_get_all_text_objects_skips_objects_without_fonts(self):
+        """Tests that _get_all_text_objects skips objects without fonts"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock object without font
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = None
+
+        mock_object = Mock()
+        mock_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_object.GetChildren.return_value = []
+
+        result = handler._get_all_text_objects([mock_object])
+
+        assert result == []
+
+    def test_get_all_text_objects_finds_text_in_child_objects(self):
+        """Tests that _get_all_text_objects recursively finds text objects in children"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock child text object with font
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        mock_child_text_object = Mock()
+        mock_child_text_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_child_text_object.GetChildren.return_value = []
+
+        # Create mock parent object without font but with child
+        mock_parent_font_container = Mock()
+        mock_parent_font_container.GetFont.return_value = None
+
+        mock_parent_object = Mock()
+        mock_parent_object.__getitem__ = Mock(return_value=mock_parent_font_container)
+        mock_parent_object.GetChildren.return_value = [mock_child_text_object]
+
+        result = handler._get_all_text_objects([mock_parent_object])
+
+        assert len(result) == 1
+        assert result[0] == mock_child_text_object
+
+    def test_get_all_text_objects_finds_text_in_nested_children(self):
+        """Tests that _get_all_text_objects recursively finds text objects in deeply nested children"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock grandchild text object with font
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        mock_grandchild_text_object = Mock()
+        mock_grandchild_text_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_grandchild_text_object.GetChildren.return_value = []
+
+        # Create mock child object without font but with grandchild
+        mock_child_font_container = Mock()
+        mock_child_font_container.GetFont.return_value = None
+
+        mock_child_object = Mock()
+        mock_child_object.__getitem__ = Mock(return_value=mock_child_font_container)
+        mock_child_object.GetChildren.return_value = [mock_grandchild_text_object]
+
+        # Create mock parent object without font but with child
+        mock_parent_font_container = Mock()
+        mock_parent_font_container.GetFont.return_value = None
+
+        mock_parent_object = Mock()
+        mock_parent_object.__getitem__ = Mock(return_value=mock_parent_font_container)
+        mock_parent_object.GetChildren.return_value = [mock_child_object]
+
+        result = handler._get_all_text_objects([mock_parent_object])
+
+        assert len(result) == 1
+        assert result[0] == mock_grandchild_text_object
+
+    def test_get_all_text_objects_finds_parent_and_child_text_objects(self):
+        """Tests that _get_all_text_objects finds both parent and child text objects when both have fonts"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock font
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        # Create mock child text object with font
+        mock_child_text_object = Mock()
+        mock_child_text_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_child_text_object.GetChildren.return_value = []
+
+        # Create mock parent text object with font and child
+        mock_parent_text_object = Mock()
+        mock_parent_text_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_parent_text_object.GetChildren.return_value = [mock_child_text_object]
+
+        result = handler._get_all_text_objects([mock_parent_text_object])
+
+        # Both parent and child should be returned since both have fonts
+        assert len(result) == 2
+        assert mock_parent_text_object in result
+        assert mock_child_text_object in result
 
 
 class TestCacheTextIfNeeded:
@@ -190,6 +405,7 @@ class TestCacheTextIfNeeded:
 
         mock_text_object = Mock()
         mock_text_object.__getitem__ = Mock(return_value=mock_font_container)
+        mock_text_object.GetChildren.return_value = []
 
         mock_doc = Mock()
         mock_doc.GetObjects.return_value = [mock_text_object]

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -83,10 +83,6 @@ class TestHasCachedText:
         mock_object.__getitem__ = Mock(return_value=mock_font_container)
         mock_object.GetChildren.return_value = []
 
-        mock_doc = Mock()
-        mock_doc.GetObjects.return_value = [mock_object]
-        handler.doc = mock_doc
-
         assert handler._has_cached_text([mock_object]) is True
 
     def test_has_cached_text_returns_false_when_no_font(self):
@@ -100,10 +96,6 @@ class TestHasCachedText:
         mock_object = Mock()
         mock_object.__getitem__ = Mock(return_value=mock_font_container)
         mock_object.GetChildren.return_value = []
-
-        mock_doc = Mock()
-        mock_doc.GetObjects.return_value = [mock_object]
-        handler.doc = mock_doc
 
         assert handler._has_cached_text([mock_object]) is False
 

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -1,8 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, MagicMock, patch
 import pytest
 from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import Cinema4DHandler
 from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import progress_callback
+from deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler import CACHE_TEXT_KEY
 import c4d
 
 
@@ -42,3 +43,377 @@ class TestCinema4DHandler:
         handler = Cinema4DHandler(mock_map_path)
         with pytest.raises(FileNotFoundError):
             handler.set_scene_file({"scene_file": "file.c4d"})
+
+
+class TestShouldCacheText:
+    """Tests for the should_cache_text method"""
+
+    def test_should_cache_text_sets_true(self):
+        """Tests that should_cache_text correctly sets cache_text to True"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.should_cache_text({CACHE_TEXT_KEY: True})
+        assert handler.render_kwargs[CACHE_TEXT_KEY] is True
+
+    def test_should_cache_text_sets_false(self):
+        """Tests that should_cache_text correctly sets cache_text to False"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.should_cache_text({CACHE_TEXT_KEY: False})
+        assert handler.render_kwargs[CACHE_TEXT_KEY] is False
+
+    def test_should_cache_text_defaults_to_false(self):
+        """Tests that should_cache_text defaults to False when key is missing"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.should_cache_text({})
+        assert handler.render_kwargs[CACHE_TEXT_KEY] is False
+
+
+class TestHasCachedText:
+    """Tests for the _has_cached_text method"""
+
+    def test_has_cached_text_returns_true_when_font_exists(self):
+        """Tests that _has_cached_text returns True when a font is found"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock objects with fonts
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        mock_object = Mock()
+        mock_object.__getitem__ = Mock(return_value=mock_font_container)
+
+        mock_doc = Mock()
+        mock_doc.GetObjects.return_value = [mock_object]
+        handler.doc = mock_doc
+
+        assert handler._has_cached_text() is True
+
+    def test_has_cached_text_returns_false_when_no_font(self):
+        """Tests that _has_cached_text returns False when no font is found"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Create mock objects without fonts
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = None
+
+        mock_object = Mock()
+        mock_object.__getitem__ = Mock(return_value=mock_font_container)
+
+        mock_doc = Mock()
+        mock_doc.GetObjects.return_value = [mock_object]
+        handler.doc = mock_doc
+
+        assert handler._has_cached_text() is False
+
+    def test_has_cached_text_returns_false_when_no_objects(self):
+        """Tests that _has_cached_text returns False when there are no objects"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        mock_doc = Mock()
+        mock_doc.GetObjects.return_value = []
+        handler.doc = mock_doc
+
+        assert handler._has_cached_text() is False
+
+
+class TestCacheTextIfNeeded:
+    """Tests for the _cache_text_if_needed method"""
+
+    def test_cache_text_returns_false_when_not_enabled(self):
+        """Tests that _cache_text_if_needed returns False when cache_text is not enabled"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.render_kwargs = {}
+
+        mock_frame_time = Mock()
+        result = handler._cache_text_if_needed(mock_frame_time)
+
+        assert result is False
+
+    def test_cache_text_returns_false_when_disabled(self):
+        """Tests that _cache_text_if_needed returns False when cache_text is False"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.render_kwargs = {CACHE_TEXT_KEY: False}
+
+        mock_frame_time = Mock()
+        result = handler._cache_text_if_needed(mock_frame_time)
+
+        assert result is False
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.sys.platform", "win32")
+    def test_cache_text_returns_false_on_windows(self, capsys):
+        """Tests that _cache_text_if_needed returns False on Windows"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.render_kwargs = {CACHE_TEXT_KEY: True}
+
+        mock_frame_time = Mock()
+        result = handler._cache_text_if_needed(mock_frame_time)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Text is only cached on Linux" in captured.out
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.sys.platform", "linux")
+    def test_cache_text_returns_false_when_no_fonts(self, capsys):
+        """Tests that _cache_text_if_needed returns False when no fonts are found"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.render_kwargs = {CACHE_TEXT_KEY: True}
+
+        mock_doc = Mock()
+        mock_doc.GetObjects.return_value = []
+        handler.doc = mock_doc
+
+        mock_frame_time = Mock()
+        result = handler._cache_text_if_needed(mock_frame_time)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "No fonts were found in the scene" in captured.out
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.sys.platform", "linux")
+    @patch(
+        "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.SetDocumentTime"
+    )
+    @patch(
+        "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.utils.SendModelingCommand"
+    )
+    def test_cache_text_converts_text_to_polygons(
+        self, mock_send_modeling_command: Mock, mock_set_document_time: Mock, capsys
+    ):
+        """Tests that _cache_text_if_needed converts text objects to polygons on Linux"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.render_kwargs = {CACHE_TEXT_KEY: True, "frame": 42}
+
+        # Create mock font and text objects
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        mock_text_object = Mock()
+        mock_text_object.__getitem__ = Mock(return_value=mock_font_container)
+
+        mock_doc = Mock()
+        mock_doc.GetObjects.return_value = [mock_text_object]
+        mock_doc.ExecutePasses = Mock()
+        handler.doc = mock_doc
+
+        mock_frame_time = Mock()
+        result = handler._cache_text_if_needed(mock_frame_time)
+
+        assert result is True
+        mock_set_document_time.assert_called_once_with(mock_doc, mock_frame_time)
+        mock_doc.ExecutePasses.assert_called_once()
+        mock_send_modeling_command.assert_called_once()
+
+        captured = capsys.readouterr()
+        assert "Fonts were found in the scene" in captured.out
+        assert "Converting all parameterized text objects to polygons" in captured.out
+        assert "Successfully converted all text objects to polygons" in captured.out
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.sys.platform", "linux")
+    @patch(
+        "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.SetDocumentTime"
+    )
+    def test_cache_text_returns_false_when_no_text_objects_after_animation(
+        self, mock_set_document_time: Mock, capsys
+    ):
+        """Tests that _cache_text_if_needed returns False when no text objects exist after animation"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.render_kwargs = {CACHE_TEXT_KEY: True, "frame": 42}
+
+        # Create mock font for initial check
+        mock_font = Mock()
+        mock_font_container = Mock()
+        mock_font_container.GetFont.return_value = mock_font
+
+        mock_text_object = Mock()
+        mock_text_object.__getitem__ = Mock(return_value=mock_font_container)
+
+        # First call returns text object, second call (after animation) returns empty
+        mock_doc = Mock()
+        mock_doc.GetObjects.side_effect = [[mock_text_object], []]
+        mock_doc.ExecutePasses = Mock()
+        handler.doc = mock_doc
+
+        mock_frame_time = Mock()
+        result = handler._cache_text_if_needed(mock_frame_time)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "No text objects were found in the scene after animation" in captured.out
+
+
+class TestReloadDocument:
+    """Tests for the _reload_document method"""
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.KillDocument")
+    @patch(
+        "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.GetActiveDocument"
+    )
+    def test_reload_document_calls_actions(
+        self, mock_get_active_doc: Mock, mock_kill_document: Mock
+    ):
+        """Tests that _reload_document kills the document and reloads necessary actions"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Set up render_kwargs with actions to reload
+        handler.render_kwargs = {
+            "scene_file": "test.c4d",
+            "take": "Main",
+            "output_path": "/output",
+            "multi_pass_path": "/multipass",
+        }
+
+        # Mock the action_dict methods to avoid actual file operations
+        mock_scene_file = Mock()
+        mock_take = Mock()
+        mock_output_path = Mock()
+        mock_multi_pass_path = Mock()
+        handler.action_dict["scene_file"] = mock_scene_file
+        handler.action_dict["take"] = mock_take
+        handler.action_dict["output_path"] = mock_output_path
+        handler.action_dict["multi_pass_path"] = mock_multi_pass_path
+
+        mock_doc = Mock()
+        mock_get_active_doc.return_value = mock_doc
+
+        handler._reload_document()
+
+        mock_kill_document.assert_called_once_with(mock_doc)
+        mock_scene_file.assert_called_once_with({"scene_file": "test.c4d"})
+        mock_take.assert_called_once_with({"take": "Main"})
+        mock_output_path.assert_called_once_with({"output_path": "/output"})
+        mock_multi_pass_path.assert_called_once_with({"multi_pass_path": "/multipass"})
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.KillDocument")
+    @patch(
+        "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.GetActiveDocument"
+    )
+    def test_reload_document_only_reloads_existing_actions(
+        self, mock_get_active_doc: Mock, mock_kill_document: Mock
+    ):
+        """Tests that _reload_document only reloads actions that exist in render_kwargs"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Set up render_kwargs with only some actions
+        handler.render_kwargs = {
+            "scene_file": "test.c4d",
+        }
+
+        # Mock the action_dict methods
+        mock_scene_file = Mock()
+        mock_take = Mock()
+        mock_output_path = Mock()
+        mock_multi_pass_path = Mock()
+        handler.action_dict["scene_file"] = mock_scene_file
+        handler.action_dict["take"] = mock_take
+        handler.action_dict["output_path"] = mock_output_path
+        handler.action_dict["multi_pass_path"] = mock_multi_pass_path
+
+        mock_doc = Mock()
+        mock_get_active_doc.return_value = mock_doc
+
+        handler._reload_document()
+
+        mock_kill_document.assert_called_once_with(mock_doc)
+        mock_scene_file.assert_called_once_with({"scene_file": "test.c4d"})
+        mock_take.assert_not_called()
+        mock_output_path.assert_not_called()
+        mock_multi_pass_path.assert_not_called()
+
+
+class TestStartRenderWithTextCaching:
+    """Tests for start_render method with text caching functionality"""
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.RenderDocument")
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.bitmaps.MultipassBitmap")
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.BaseTime")
+    def test_start_render_reloads_document_when_text_was_cached(
+        self, mock_base_time: Mock, mock_bitmap: Mock, mock_render_document: Mock
+    ):
+        """Tests that start_render reloads the document when text was cached in previous frame"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.text_was_cached = True
+
+        # Set up mock document and render data
+        mock_doc = Mock()
+        mock_render_data = MagicMock()
+        mock_render_data.GetDataInstance = Mock()
+        mock_doc.GetActiveRenderData.return_value = mock_render_data
+        mock_doc.GetFps.return_value = 30
+        handler.doc = mock_doc
+
+        mock_render_document.return_value = c4d.RENDERRESULT_OK
+
+        with (
+            patch.object(handler, "_reload_document") as mock_reload,
+            patch.object(handler, "_cache_text_if_needed", return_value=False),
+        ):
+            handler.start_render({"frame": 1})
+
+        mock_reload.assert_called_once()
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.RenderDocument")
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.bitmaps.MultipassBitmap")
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.BaseTime")
+    def test_start_render_does_not_reload_when_text_not_cached(
+        self, mock_base_time: Mock, mock_bitmap: Mock, mock_render_document: Mock
+    ):
+        """Tests that start_render does not reload the document when text was not cached"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.text_was_cached = False
+
+        # Set up mock document and render data
+        mock_doc = Mock()
+        mock_render_data = MagicMock()
+        mock_render_data.GetDataInstance = Mock()
+        mock_doc.GetActiveRenderData.return_value = mock_render_data
+        mock_doc.GetFps.return_value = 30
+        handler.doc = mock_doc
+
+        mock_render_document.return_value = c4d.RENDERRESULT_OK
+
+        with (
+            patch.object(handler, "_reload_document") as mock_reload,
+            patch.object(handler, "_cache_text_if_needed", return_value=False),
+        ):
+            handler.start_render({"frame": 1})
+
+        mock_reload.assert_not_called()
+
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.RenderDocument")
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.bitmaps.MultipassBitmap")
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.BaseTime")
+    def test_start_render_updates_text_was_cached_flag(
+        self, mock_base_time: Mock, mock_bitmap: Mock, mock_render_document: Mock
+    ):
+        """Tests that start_render updates the text_was_cached flag based on _cache_text_if_needed result"""
+        handler = Cinema4DHandler(mock_map_path)
+        handler.text_was_cached = False
+
+        # Set up mock document and render data
+        mock_doc = Mock()
+        mock_render_data = MagicMock()
+        mock_render_data.GetDataInstance = Mock()
+        mock_doc.GetActiveRenderData.return_value = mock_render_data
+        mock_doc.GetFps.return_value = 30
+        handler.doc = mock_doc
+
+        mock_render_document.return_value = c4d.RENDERRESULT_OK
+
+        # First call: _cache_text_if_needed returns True
+        with (
+            patch.object(handler, "_reload_document"),
+            patch.object(handler, "_cache_text_if_needed", return_value=True),
+        ):
+            handler.start_render({"frame": 1})
+
+        assert handler.text_was_cached is True
+
+        # Second call: _cache_text_if_needed returns False (no text to cache this time)
+        with (
+            patch.object(handler, "_reload_document"),
+            patch.object(handler, "_cache_text_if_needed", return_value=False),
+        ):
+            handler.start_render({"frame": 1})
+
+        assert handler.text_was_cached is False


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We currently support Cinema 4D text rendering on Windows but many customers want to use Linux due to lower cost. Unfortunately, there appears to be a bug in Cinema 4D where fonts are not loaded on Linux. Additionally, font rendering on Linux as a whole (including outside of Cinema 4D) is generally lower quality than on Windows. To work around the issue, we have added an option to use the cached text splines from the scene (which are generated on the submitting workstation) during the render. This also improves support for Mac -> Windows text rendering.

### What is the impact of this change?
Customers will now be able to render text on Linux!

### How was this change tested?

Updated my submitter locally and created an updated Conda package with this adaptor to use the new feature. Submitted a test job to my farm and viewed the output.

Updated submitter:

<img width="666" height="856" alt="image" src="https://github.com/user-attachments/assets/25473dd3-829a-40ad-a2a7-b85bcd521080" />

Output adaptor logs:
```
2025/11/19 12:42:13-06:00 ADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "start_render", "args": {"frame": 1}}
2025/11/19 12:42:13-06:00 ADAPTOR_OUTPUT: STDOUT: Text objects were found in the scene
2025/11/19 12:42:13-06:00 ADAPTOR_OUTPUT: STDOUT: Setting to the correct frame/time to calculate text location
2025/11/19 12:42:13-06:00 ADAPTOR_OUTPUT: STDOUT: Animating the text for frame 1
2025/11/19 12:42:14-06:00 ADAPTOR_OUTPUT: STDOUT: Searching for text objects
2025/11/19 12:42:14-06:00 ADAPTOR_OUTPUT: STDOUT: Text objects found in scene after animation: [<c4d.BaseObject object called Text Spline/Text Spline with ID 5178 at 1957584320>, <c4d.BaseObject object called Test/Text with ID 1019268 at 750642880>, <c4d.BaseObject object called Text.4/Text with ID 1019268 at 1931397760>, <c4d.BaseObject object called Text.2/Text with ID 1019268 at 1931424640>, <c4d.BaseObject object called Text.1/Text with ID 1019268 at 750642368>, <c4d.BaseObject object called Text/Text with ID 1019268 at 1919932032>]
2025/11/19 12:42:14-06:00 ADAPTOR_OUTPUT: STDOUT: Converting all parameterized text objects to polygons as Cinema 4D doesn't handle them correctly
2025/11/19 12:42:14-06:00 ADAPTOR_OUTPUT: STDOUT: Successfully converted all text objects to polygons
2025/11/19 12:42:14-06:00 ADAPTOR_OUTPUT: STDERR: Rendering frame 1 at <Wed Nov 19 18:42:13 2025>
2025/11/19 12:42:14-06:00 ADAPTOR_OUTPUT: STDOUT: Rendering frame 1 at <Wed Nov 19 18:42:13 2025>Progress update (before rendering): 0.0%
```

Output image:
<img width="1280" height="720" alt="purple_cube0039" src="https://github.com/user-attachments/assets/9ba21d1d-b394-4a34-8391-23185d8b3a00" />

I specifically tested the following scenarios:
* Physical or Redshift render
* Text objects with fields and effectors on a per character basis (the text and individual characters move as anticipated)
* Text objects and text splines with materials (this can only be applied on a per-object basis in Cinema 4D, and it works)

- Have you run the unit tests?
- Yes

- Have you run the integration tests? (Add your integration test report below)
Not yet

- Have you made changes to the submitter?
If yes, please include the results of both the automated tests and any manual tests that you ran.
Also, check if there is a change to the `integ_test_helpers.py` file within cinema4d_submitter as a result of your submitter change.
*delete text ending here* 

### Was this change documented?
Yes

### Is this a breaking change?
Yes, this is a breaking change - it changes the `init-data` adaptor contract. I've updated the adaptor version accordingly,

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*