### PR TITLE
fix: add validation to detect pipe characters in asset paths

### DIFF
--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -10,6 +10,7 @@ from .platform_utils import is_windows
 from .scene import Scene
 from .font_utils import is_asset_a_font, copy_font_to_scene_folder, FONTS_DIR
 from .warning_collector import warning_collector
+from .path_validator import validate_asset_paths
 
 _FRAME_RE = re.compile("#+")
 
@@ -61,5 +62,8 @@ class AssetIntrospector:
                 for font_file in fonts_dir.iterdir():
                     if font_file.is_file():
                         assets.add(font_file)
+
+        # Validate asset paths for Windows-incompatible characters
+        validate_asset_paths(assets)
 
         return assets

--- a/src/deadline/cinema4d_submitter/path_validator.py
+++ b/src/deadline/cinema4d_submitter/path_validator.py
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import logging
+from pathlib import Path
+from typing import Set
+
+from .warning_logging_handler import WarningCollectorHandler
+
+logger = logging.getLogger(__name__)
+if not any(isinstance(h, WarningCollectorHandler) for h in logger.handlers):
+    logger.addHandler(WarningCollectorHandler())
+
+
+def validate_asset_paths(asset_paths: Set[Path]) -> None:
+    """
+    Validate asset paths for pipe character which causes sync failures on Windows.
+    Logs warnings for any paths containing pipe character.
+
+    Args:
+        asset_paths: Set of asset file paths to validate
+    """
+    for asset_path in asset_paths:
+        path_str = str(asset_path)
+
+        if "|" in path_str:
+            logger.warning(
+                f"Asset path contains pipe character '|': '{path_str}'. "
+                f"This will cause sync failures on Windows workers."
+            )

--- a/test/unit/deadline_submitter_for_cinema4d/test_path_validator.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_path_validator.py
@@ -1,0 +1,64 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from pathlib import Path
+from unittest import mock
+
+from deadline.cinema4d_submitter.path_validator import validate_asset_paths
+
+
+class TestPathValidator:
+    def test_validate_asset_paths_with_pipe_in_filename(self):
+        """Test validation detects pipe character in filename."""
+        assets = {Path("C:/test/file|name.jpg")}
+
+        with mock.patch("deadline.cinema4d_submitter.path_validator.logger") as mock_logger:
+            validate_asset_paths(assets)
+
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0][0]
+            assert "file|name.jpg" in call_args
+            assert "pipe character" in call_args
+
+    def test_validate_asset_paths_with_pipe_in_directory(self):
+        """Test validation detects pipe character in directory name."""
+        assets = {Path("C:/test|dir/file.jpg")}
+
+        with mock.patch("deadline.cinema4d_submitter.path_validator.logger") as mock_logger:
+            validate_asset_paths(assets)
+
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0][0]
+            assert "test|dir" in call_args
+
+    def test_validate_asset_paths_with_multiple_pipes(self):
+        """Test validation detects multiple pipe characters."""
+        assets = {
+            Path("C:/test|dir/file|name.jpg"),
+            Path("C:/another|path/file.txt"),
+        }
+
+        with mock.patch("deadline.cinema4d_submitter.path_validator.logger") as mock_logger:
+            validate_asset_paths(assets)
+
+            assert mock_logger.warning.call_count == 2
+
+    def test_validate_asset_paths_valid_paths(self):
+        """Test validation passes for valid paths."""
+        assets = {
+            Path("C:/test/valid_file.jpg"),
+            Path("C:/another/path/file.txt"),
+        }
+
+        with mock.patch("deadline.cinema4d_submitter.path_validator.logger") as mock_logger:
+            validate_asset_paths(assets)
+
+            mock_logger.warning.assert_not_called()
+
+    def test_validate_asset_paths_empty_set(self):
+        """Test validation handles empty asset set."""
+        assets: set[Path] = set()
+
+        with mock.patch("deadline.cinema4d_submitter.path_validator.logger") as mock_logger:
+            validate_asset_paths(assets)
+
+            mock_logger.warning.assert_not_called()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/338

### What was the problem/requirement? (What/Why)
Currently, if there is "|" in the path or file name we fail to sync the asset on Windows workers with the following error.

If there is "|" in asset file name.

2025/11/08 16:57:20-08:00 [Errno 22] Invalid argument: 'C:\\Sessions\\session-abc\\assetroot-abc\\tex\\Map-COL-with"|".jpg.af4d5BFa'
If there is "|" in path name.

OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'C:\\Sessions\\session-abc\\assetroot-abc\\tex with | '


### What was the solution? (How)
Created a path_validator module with a validate_asset_paths() function that iterates through all asset paths and checks for the pipe character "|". When detected, it logs a warning through the WarningCollectorHandler which displays the message in the submitter UI, alerting users before job submission that these paths will cause sync failures on Windows workers.

<img width="501" height="429" alt="Screenshot 2025-11-20 at 2 50 43 PM" src="https://github.com/user-attachments/assets/b61f6063-fd82-4d3a-8fb0-3f75493018d3" />


### What is the impact of this change?
Users will now receive clear warnings in the submitter UI when their asset paths contain pipe characters, allowing them to fix the issue before submitting jobs. This prevents job failures on Windows workers and saves time by catching the problem early rather than discovering it after submission when assets fail to sync.

### How was this change tested?
Added comprehensive unit tests in test_path_validator.py covering:
- Detection of pipe characters in filenames
- Detection of pipe characters in directory names
- Handling multiple paths with pipe characters
- Validation that clean paths don't trigger warnings
- Edge case of empty asset sets
All tests pass along with linting (ruff, black, mypy) validation.

- Have you made changes to the submitter?
No

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*