### PR TITLE
feat: Add Cinema 4D detailed debug logs.

### DIFF
--- a/src/deadline/cinema4d_submitter/detailed_logging_scripts/print_logs.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_scripts/print_logs.py
@@ -3,6 +3,10 @@
 from dataclasses import dataclass, field
 import os
 import sys
+import tempfile
+
+# Cinema 4D detailed log filename constant
+C4D_DETAILED_LOG_FILENAME = "c4d_detailed_logs.txt"
 
 
 @dataclass
@@ -11,30 +15,102 @@ class FoundLogs:
 
     redshift: list[str] = field(default_factory=list)
     bugreport: list[str] = field(default_factory=list)
+    c4d_detailed: list[str] = field(default_factory=list)
 
 
-def _find_redshift_log(conda_prefix: str, path_components: list[str]) -> list[str]:
+def _find_redshift_log_in_path(base_path: str, path_components: list[str]) -> list[str]:
     """Search for Redshift log file in the specified path.
 
     Args:
-        conda_prefix: The CONDA_PREFIX environment variable value.
-        path_components: List of path components to join with conda_prefix.
+        base_path: The base directory to search in.
+        path_components: List of path components to join with base_path.
 
     Returns:
         List containing the Redshift log path if found, empty list otherwise.
     """
-    if not conda_prefix or not os.path.exists(conda_prefix):
-        print("CONDA_PREFIX not set or doesn't exist, skipping Redshift log search")
+    if not base_path or not os.path.exists(base_path):
         return []
 
-    redshift_log_path = os.path.join(conda_prefix, *path_components)
+    redshift_log_path = os.path.join(base_path, *path_components)
     print(f"Checking for Redshift log at: {redshift_log_path}")
 
     if os.path.exists(redshift_log_path):
         print(f"Found Redshift log: {redshift_log_path}")
         return [redshift_log_path]
+    return []
+
+
+def _get_redshift_local_data_paths() -> list[str]:
+    """Get potential Redshift local data paths to search for logs.
+
+    Returns paths in priority order:
+    1. CONDA_PREFIX-based paths (for conda environments)
+    2. REDSHIFT_LOCALDATAPATH environment variable (if set)
+    3. Platform-specific default paths
+
+    Returns:
+        List of paths to check for Redshift logs.
+    """
+    paths = []
+
+    # Add conda prefix path first if available (most likely in rendering environment)
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    if conda_prefix:
+        if sys.platform == "win32":
+            paths.append(os.path.join(conda_prefix, "cinema4d", "RedshiftData"))
+        else:
+            paths.append(os.path.join(conda_prefix, "redshiftlocaldata"))
+
+    # Check for custom path via environment variable
+    custom_path = os.environ.get("REDSHIFT_LOCALDATAPATH")
+    if custom_path:
+        print(f"Found REDSHIFT_LOCALDATAPATH environment variable: {custom_path}")
+        paths.append(custom_path)
+
+    # Add platform-specific default paths
+    if sys.platform == "win32":
+        # Windows default: C:\ProgramData\Redshift
+        paths.append(r"C:\ProgramData\Redshift")
     else:
-        print("Redshift log not found at expected location")
+        # Linux/macOS default: ~/redshift
+        home_dir = os.path.expanduser("~")
+        paths.append(os.path.join(home_dir, "redshift"))
+
+    return paths
+
+
+def _find_c4d_detailed_log(conda_prefix: str) -> list[str]:
+    """Search for Cinema 4D detailed log file.
+
+    Args:
+        conda_prefix: The CONDA_PREFIX environment variable value.
+
+    Returns:
+        List containing the Cinema 4D detailed log path if found, empty list otherwise.
+    """
+    # Try CONDA_PREFIX first if available
+    if conda_prefix and os.path.exists(conda_prefix):
+        c4d_log_path = os.path.join(conda_prefix, C4D_DETAILED_LOG_FILENAME)
+        print(f"Checking for Cinema 4D detailed log at: {c4d_log_path}")
+
+        if os.path.exists(c4d_log_path):
+            print(f"Found Cinema 4D detailed log: {c4d_log_path}")
+            return [c4d_log_path]
+        else:
+            print("Cinema 4D detailed log not found in CONDA_PREFIX")
+    else:
+        print("CONDA_PREFIX not set or doesn't exist")
+
+    # Fallback to temp directory
+    temp_dir = tempfile.gettempdir()
+    temp_log_path = os.path.join(temp_dir, C4D_DETAILED_LOG_FILENAME)
+    print(f"Checking for Cinema 4D detailed log in temp directory: {temp_log_path}")
+
+    if os.path.exists(temp_log_path):
+        print(f"Found Cinema 4D detailed log in temp directory: {temp_log_path}")
+        return [temp_log_path]
+    else:
+        print("Cinema 4D detailed log not found in temp directory either")
         return []
 
 
@@ -98,10 +174,19 @@ def find_log_files_linux() -> FoundLogs:
 
     print("Searching for log files...")
 
-    # Check for Redshift log.html: $CONDA_PREFIX/redshiftlocaldata/log/log.latest.0/log.html
-    found_logs.redshift = _find_redshift_log(
-        conda_prefix, ["redshiftlocaldata", "log", "log.latest.0", "log.html"]
-    )
+    # Check for Redshift log.html in multiple possible locations
+    redshift_paths = _get_redshift_local_data_paths()
+    for base_path in redshift_paths:
+        result = _find_redshift_log_in_path(base_path, ["log", "log.latest.0", "log.html"])
+        if result:
+            found_logs.redshift = result
+            break
+
+    if not found_logs.redshift:
+        print("Redshift log not found in any expected location")
+
+    # Check for Cinema 4D detailed log: $CONDA_PREFIX/c4d_detailed_logs.txt
+    found_logs.c4d_detailed = _find_c4d_detailed_log(conda_prefix)
 
     # Check for bug reports: ~/Maxon/bin_*/_bugreports/*_BugReport.txt
     maxon_path = os.path.join(home_dir, "Maxon")
@@ -122,10 +207,20 @@ def find_log_files_windows() -> FoundLogs:
 
     print("Searching for log files...")
 
-    # Check for Redshift log.html: $CONDA_PREFIX\cinema4d\RedshiftData\Log\Log.Latest.0\log.html
-    found_logs.redshift = _find_redshift_log(
-        conda_prefix, ["cinema4d", "RedshiftData", "Log", "Log.Latest.0", "log.html"]
-    )
+    # Check for Redshift log.html in multiple possible locations
+    redshift_paths = _get_redshift_local_data_paths()
+    for base_path in redshift_paths:
+        result = _find_redshift_log_in_path(base_path, ["Log", "Log.Latest.0", "log.html"])
+        if result:
+            found_logs.redshift = result
+            break
+
+    if not found_logs.redshift:
+        print("Redshift log not found in any expected location")
+
+    # Check for Cinema 4D detailed log: $CONDA_PREFIX\c4d_detailed_logs.txt
+    found_logs.c4d_detailed = _find_c4d_detailed_log(conda_prefix)
+
     # Check for bug reports: %APPDATA%\Maxon\cinema4d_*\_bugreports\*_BugReport.txt
     if appdata and os.path.exists(appdata):
         maxon_path = os.path.join(appdata, "Maxon")
@@ -147,6 +242,8 @@ def find_log_files() -> FoundLogs:
     print(f"  CONDA_PREFIX: {os.environ.get('CONDA_PREFIX', 'NOT SET')}")
     print(f"  HOME: {os.environ.get('HOME', 'NOT SET')}")
     print(f"  USER: {os.environ.get('USER', 'NOT SET')}")
+    print(f"  REDSHIFT_LOCALDATAPATH: {os.environ.get('REDSHIFT_LOCALDATAPATH', 'NOT SET')}")
+    print(f"  REDSHIFT_COREDATAPATH: {os.environ.get('REDSHIFT_COREDATAPATH', 'NOT SET')}")
 
     # Use platform-specific search
     if sys.platform == "win32":
@@ -170,7 +267,7 @@ def print_log_file(log_file, log_type="LOG"):
         with open(log_file, "r", encoding="utf-8", errors="replace") as f:
             print(f.read())
     except Exception as e:
-        print(f"Error reading log file {log_file}: {e}")
+        print(f"Error reading log file {log_file}: {type(e).__name__}: {e}")
         return
 
     print(f"\n{'='*80}")
@@ -178,28 +275,63 @@ def print_log_file(log_file, log_type="LOG"):
     print(f"{'='*80}\n")
 
 
+def _print_logs_by_type(
+    log_files: list[str], log_type: str, description: str, not_found_message: str
+) -> None:
+    """Print log files of a specific type with appropriate messaging.
+
+    Args:
+        log_files: List of log file paths to print.
+        log_type: Type identifier for the log (e.g., "REDSHIFT DEBUG LOG").
+        description: Human-readable description of the log type.
+        not_found_message: Message to display when no logs are found.
+    """
+    if log_files:
+        print(f"\nFound {len(log_files)} {description}")
+        for log_file in log_files:
+            print_log_file(log_file, log_type)
+    else:
+        print(f"\n{not_found_message}")
+
+
+def print_detailed_logs(enabled: str):
+    """Print detailed logs if enabled."""
+    if enabled != "1":
+        print("Detailed logging is deactivated, skipping log output.")
+        return
+
+    found_logs = find_log_files()
+
+    _print_logs_by_type(
+        found_logs.redshift,
+        "REDSHIFT DEBUG LOG",
+        "Redshift log file(s)",
+        "No Redshift debug logs (log.html) found.\n"
+        "This may be normal if Redshift was not used for rendering.",
+    )
+
+    _print_logs_by_type(
+        found_logs.c4d_detailed,
+        "CINEMA 4D DETAILED LOG",
+        "Cinema 4D detailed log file(s)",
+        f"No Cinema 4D detailed log ({C4D_DETAILED_LOG_FILENAME}) found.\n"
+        "This is unexpected - the log file should have been created by Cinema 4D.",
+    )
+
+    _print_logs_by_type(
+        found_logs.bugreport,
+        "CINEMA 4D BUG REPORT",
+        "Cinema 4D bug report(s)",
+        "No Cinema 4D bug reports (*_BugReport.txt) found.\n"
+        "This may be normal if no crashes occurred.",
+    )
+
+    # Clean up environment variables set during setup
+    print("openjd_unset_env: g_alloc")
+    print("openjd_unset_env: g_logfile")
+    print("Environment variables cleaned up")
+
+
 if __name__ == "__main__":
     enabled = sys.argv[1] if len(sys.argv) > 1 else "0"
-
-    if enabled != "1":
-        print("Detailed logging is disabled, skipping log output.")
-    else:
-        found_logs = find_log_files()
-
-        # Print all Redshift logs
-        if found_logs.redshift:
-            print(f"\nFound {len(found_logs.redshift)} Redshift log file(s)")
-            for log_file in found_logs.redshift:
-                print_log_file(log_file, "REDSHIFT DEBUG LOG")
-        else:
-            print("\nNo Redshift debug logs (log.html) found.")
-            print("This may be normal if Redshift was not used for rendering.")
-
-        # Print all bug report logs
-        if found_logs.bugreport:
-            print(f"\nFound {len(found_logs.bugreport)} Cinema 4D bug report(s)")
-            for log_file in found_logs.bugreport:
-                print_log_file(log_file, "CINEMA 4D BUG REPORT")
-        else:
-            print("\nNo Cinema 4D bug reports (*_BugReport.txt) found.")
-            print("This may be normal if no crashes occurred.")
+    print_detailed_logs(enabled)

--- a/src/deadline/cinema4d_submitter/detailed_logging_scripts/print_logs.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_scripts/print_logs.py
@@ -1,258 +1,271 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """Find and print Cinema 4D and Redshift log files after rendering."""
-from dataclasses import dataclass, field
 import os
+import shutil
 import sys
-import tempfile
+from pathlib import Path
 
-# Cinema 4D detailed log filename constant
+# Constants
 C4D_DETAILED_LOG_FILENAME = "c4d_detailed_logs.txt"
+C4D_SECURE_TEMP_DIR_ENV_VAR = "C4D_DETAILED_LOG_DIR"
+CONDA_PREFIX_ENV_VAR = "CONDA_PREFIX"
+REDSHIFT_LOCALDATAPATH_ENV_VAR = "REDSHIFT_LOCALDATAPATH"
+REDSHIFT_COREDATAPATH_ENV_VAR = "REDSHIFT_COREDATAPATH"
 
 
-@dataclass
-class FoundLogs:
-    """Container for discovered log files."""
-
-    redshift: list[str] = field(default_factory=list)
-    bugreport: list[str] = field(default_factory=list)
-    c4d_detailed: list[str] = field(default_factory=list)
+def get_conda_prefix() -> str:
+    """Get the CONDA_PREFIX environment variable value."""
+    return os.environ.get(CONDA_PREFIX_ENV_VAR, "")
 
 
-def _find_redshift_log_in_path(base_path: str, path_components: list[str]) -> list[str]:
-    """Search for Redshift log file in the specified path.
+def _get_redshift_log_paths_windows() -> list[str]:
+    """Get potential Redshift log file paths for Windows.
 
-    Args:
-        base_path: The base directory to search in.
-        path_components: List of path components to join with base_path.
+    Returns:
+        List of unique complete log file paths to check on Windows.
+    """
+    paths = set()
+    conda_prefix = get_conda_prefix()
+    log_subpath = os.path.join("Log", "Log.Latest.0", "log.html")
+
+    # CONDA_PREFIX location
+    if conda_prefix:
+        paths.add(os.path.join(conda_prefix, "cinema4d", "RedshiftData", log_subpath))
+
+    # Custom REDSHIFT_LOCALDATAPATH location
+    custom_path = os.environ.get(REDSHIFT_LOCALDATAPATH_ENV_VAR)
+    if custom_path:
+        print(f"Found {REDSHIFT_LOCALDATAPATH_ENV_VAR} environment variable: {custom_path}")
+        paths.add(os.path.join(custom_path, log_subpath))
+
+    # Windows default location
+    paths.add(os.path.join(r"C:\ProgramData\Redshift", log_subpath))
+
+    return list(paths)
+
+
+def _get_redshift_log_paths_linux() -> list[str]:
+    """Get potential Redshift log file paths for Linux/macOS.
+
+    Returns:
+        List of unique complete log file paths to check on Linux/macOS.
+    """
+    paths = set()
+    conda_prefix = get_conda_prefix()
+    log_subpath = os.path.join("log", "log.latest.0", "log.html")
+
+    # CONDA_PREFIX location
+    if conda_prefix:
+        paths.add(os.path.join(conda_prefix, "redshiftlocaldata", log_subpath))
+
+    # Custom REDSHIFT_LOCALDATAPATH location
+    custom_path = os.environ.get(REDSHIFT_LOCALDATAPATH_ENV_VAR)
+    if custom_path:
+        print(f"Found {REDSHIFT_LOCALDATAPATH_ENV_VAR} environment variable: {custom_path}")
+        paths.add(os.path.join(custom_path, log_subpath))
+
+    # Linux/macOS default location
+    home_dir = os.path.expanduser("~")
+    paths.add(os.path.join(home_dir, "redshift", log_subpath))
+
+    return list(paths)
+
+
+def _get_redshift_log_paths() -> list[str]:
+    """Get potential Redshift log file paths.
+
+    Returns:
+        List of potential paths to check for Redshift log.html files.
+    """
+    if sys.platform == "win32":
+        return _get_redshift_log_paths_windows()
+    else:
+        return _get_redshift_log_paths_linux()
+
+
+def _find_redshift_log() -> list[str]:
+    """Search for Redshift log file.
 
     Returns:
         List containing the Redshift log path if found, empty list otherwise.
     """
-    if not base_path or not os.path.exists(base_path):
-        return []
+    paths = _get_redshift_log_paths()
+    return _find_log_file(paths, "Redshift log")
 
-    redshift_log_path = os.path.join(base_path, *path_components)
-    print(f"Checking for Redshift log at: {redshift_log_path}")
 
-    if os.path.exists(redshift_log_path):
-        print(f"Found Redshift log: {redshift_log_path}")
-        return [redshift_log_path]
+def _get_c4d_detailed_log_paths() -> list[str]:
+    """Get potential Cinema 4D detailed log file paths.
+
+    Checks locations in priority order (matching setup_logging.py logic):
+    1. CONDA_PREFIX location (preferred)
+    2. C4D_DETAILED_LOG_DIR environment variable (secure temp directory fallback)
+
+    Returns:
+        List containing the log file path to check.
+    """
+    # Check CONDA_PREFIX location first (preferred)
+    conda_prefix = get_conda_prefix()
+    if conda_prefix:
+        return [os.path.join(conda_prefix, C4D_DETAILED_LOG_FILENAME)]
+
+    # Fallback to secure temp directory
+    secure_temp_dir = os.environ.get(C4D_SECURE_TEMP_DIR_ENV_VAR)
+    if secure_temp_dir:
+        return [os.path.join(secure_temp_dir, C4D_DETAILED_LOG_FILENAME)]
+
+    # Neither location is available
+    print(f"Neither {CONDA_PREFIX_ENV_VAR} nor {C4D_SECURE_TEMP_DIR_ENV_VAR} is set")
     return []
 
 
-def _get_redshift_local_data_paths() -> list[str]:
-    """Get potential Redshift local data paths to search for logs.
-
-    Returns paths in priority order:
-    1. CONDA_PREFIX-based paths (for conda environments)
-    2. REDSHIFT_LOCALDATAPATH environment variable (if set)
-    3. Platform-specific default paths
-
-    Returns:
-        List of paths to check for Redshift logs.
-    """
-    paths = []
-
-    # Add conda prefix path first if available (most likely in rendering environment)
-    conda_prefix = os.environ.get("CONDA_PREFIX")
-    if conda_prefix:
-        if sys.platform == "win32":
-            paths.append(os.path.join(conda_prefix, "cinema4d", "RedshiftData"))
-        else:
-            paths.append(os.path.join(conda_prefix, "redshiftlocaldata"))
-
-    # Check for custom path via environment variable
-    custom_path = os.environ.get("REDSHIFT_LOCALDATAPATH")
-    if custom_path:
-        print(f"Found REDSHIFT_LOCALDATAPATH environment variable: {custom_path}")
-        paths.append(custom_path)
-
-    # Add platform-specific default paths
-    if sys.platform == "win32":
-        # Windows default: C:\ProgramData\Redshift
-        paths.append(r"C:\ProgramData\Redshift")
-    else:
-        # Linux/macOS default: ~/redshift
-        home_dir = os.path.expanduser("~")
-        paths.append(os.path.join(home_dir, "redshift"))
-
-    return paths
-
-
-def _find_c4d_detailed_log(conda_prefix: str) -> list[str]:
-    """Search for Cinema 4D detailed log file.
+def _find_log_file(paths: list[str], log_description: str) -> list[str]:
+    """Search for a log file in a list of potential paths.
 
     Args:
-        conda_prefix: The CONDA_PREFIX environment variable value.
+        paths: List of paths to check for the log file.
+        log_description: Description of the log type for debug messages.
+
+    Returns:
+        List containing the first found log file path, or empty list if not found.
+    """
+    # Guard clause: handle empty paths early
+    if not paths:
+        print(f"{log_description} not found - no paths to check")
+        return []
+
+    for path in paths:
+        print(f"Checking for {log_description} at: {path}")
+        if os.path.exists(path):
+            print(f"Found {log_description}: {path}")
+            return [path]
+
+    print(f"{log_description} not found in any expected location")
+    return []
+
+
+def _find_c4d_detailed_log() -> list[str]:
+    """Search for Cinema 4D detailed log file.
 
     Returns:
         List containing the Cinema 4D detailed log path if found, empty list otherwise.
     """
-    # Try CONDA_PREFIX first if available
-    if conda_prefix and os.path.exists(conda_prefix):
-        c4d_log_path = os.path.join(conda_prefix, C4D_DETAILED_LOG_FILENAME)
-        print(f"Checking for Cinema 4D detailed log at: {c4d_log_path}")
+    paths = _get_c4d_detailed_log_paths()
+    return _find_log_file(paths, "Cinema 4D detailed log")
 
-        if os.path.exists(c4d_log_path):
-            print(f"Found Cinema 4D detailed log: {c4d_log_path}")
-            return [c4d_log_path]
-        else:
-            print("Cinema 4D detailed log not found in CONDA_PREFIX")
+
+def _get_bug_report_search_path() -> tuple[str, str]:
+    """Get platform-specific bug report search parameters.
+
+    Returns:
+        Tuple of (base_path, directory_prefix) for searching bug reports.
+    """
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", "")
+        base_path = os.path.join(appdata, "Maxon") if appdata else ""
+        dir_prefix = "cinema4d_"
     else:
-        print("CONDA_PREFIX not set or doesn't exist")
+        home_dir = os.path.expanduser("~")
+        base_path = os.path.join(home_dir, "Maxon")
+        dir_prefix = "bin_"
 
-    # Fallback to temp directory
-    temp_dir = tempfile.gettempdir()
-    temp_log_path = os.path.join(temp_dir, C4D_DETAILED_LOG_FILENAME)
-    print(f"Checking for Cinema 4D detailed log in temp directory: {temp_log_path}")
-
-    if os.path.exists(temp_log_path):
-        print(f"Found Cinema 4D detailed log in temp directory: {temp_log_path}")
-        return [temp_log_path]
-    else:
-        print("Cinema 4D detailed log not found in temp directory either")
-        return []
+    return base_path, dir_prefix
 
 
-def _find_bug_reports(base_path: str, dir_prefix: str) -> list[str]:
-    """Search for Cinema 4D bug report files.
+def _scan_for_bug_reports(base_path: str, dir_prefix: str) -> list[str]:
+    """Scan directory for Cinema 4D bug report files.
 
     Args:
-        base_path: Base directory to search in (e.g., ~/Maxon or %APPDATA%/Maxon).
-        dir_prefix: Prefix of directories to search (e.g., "bin_" or "cinema4d_").
+        base_path: Base directory to search in.
+        dir_prefix: Prefix of Cinema 4D directories to search.
 
     Returns:
         List of bug report file paths found.
     """
-    bug_reports: list[str] = []
-
-    if not os.path.exists(base_path):
-        print(f"{base_path} doesn't exist, skipping bug report search")
+    try:
+        base = Path(base_path)
+        bug_reports = [
+            str(bugreports_dir / "_BugReport.txt")
+            for item in base.iterdir()
+            if item.is_dir() and item.name.startswith(dir_prefix)
+            for bugreports_dir in [item / "_bugreports"]
+            if bugreports_dir.exists() and (bugreports_dir / "_BugReport.txt").exists()
+        ]
         return bug_reports
+    except Exception as e:
+        print(f"Error scanning for bug reports: {e}")
+        return []
+
+
+def _find_bug_reports() -> list[str]:
+    """Search for Cinema 4D bug report files.
+
+    Returns:
+        List of bug report file paths found.
+    """
+    base_path, dir_prefix = _get_bug_report_search_path()
+
+    # Guard clause: check if base path exists
+    if not base_path or not os.path.exists(base_path):
+        return []
 
     print(f"Checking for bug reports in: {base_path}")
-    bugreports_dirs_found = []
-
-    try:
-        for item in os.listdir(base_path):
-            if item.startswith(dir_prefix):
-                bugreports_dir = os.path.join(base_path, item, "_bugreports")
-                if os.path.exists(bugreports_dir):
-                    bugreports_dirs_found.append(bugreports_dir)
-                    print(f"Found _bugreports directory: {bugreports_dir}")
-
-                    bug_reports_in_dir = []
-                    for file in os.listdir(bugreports_dir):
-                        if file.endswith("_BugReport.txt"):
-                            bug_report_path = os.path.join(bugreports_dir, file)
-                            bug_reports.append(bug_report_path)
-                            bug_reports_in_dir.append(bug_report_path)
-                            print(f"Found bug report: {bug_report_path}")
-
-                    if not bug_reports_in_dir:
-                        print(
-                            f"_bugreports directory exists but no bug report files found inside: {bugreports_dir}"
-                        )
-
-        if not bugreports_dirs_found:
-            print("No _bugreports directories found")
-    except Exception as e:
-        print(f"Error searching for bug reports: {e}")
-
-    return bug_reports
+    return _scan_for_bug_reports(base_path, dir_prefix)
 
 
-def find_log_files_linux() -> FoundLogs:
-    """Search for log files on Linux/Mac using known paths.
-
-    Returns:
-        FoundLogs: Container with redshift and bugreport log file paths.
-    """
-    found_logs = FoundLogs()
-    conda_prefix = os.environ.get("CONDA_PREFIX", "")
-    home_dir = os.path.expanduser("~")
-
-    print("Searching for log files...")
-
-    # Check for Redshift log.html in multiple possible locations
-    redshift_paths = _get_redshift_local_data_paths()
-    for base_path in redshift_paths:
-        result = _find_redshift_log_in_path(base_path, ["log", "log.latest.0", "log.html"])
-        if result:
-            found_logs.redshift = result
-            break
-
-    if not found_logs.redshift:
-        print("Redshift log not found in any expected location")
-
-    # Check for Cinema 4D detailed log: $CONDA_PREFIX/c4d_detailed_logs.txt
-    found_logs.c4d_detailed = _find_c4d_detailed_log(conda_prefix)
-
-    # Check for bug reports: ~/Maxon/bin_*/_bugreports/*_BugReport.txt
-    maxon_path = os.path.join(home_dir, "Maxon")
-    found_logs.bugreport = _find_bug_reports(maxon_path, "bin_")
-
-    return found_logs
-
-
-def find_log_files_windows() -> FoundLogs:
-    """Search for log files on Windows using known paths.
-
-    Returns:
-        FoundLogs: Container with redshift and bugreport log file paths.
-    """
-    found_logs = FoundLogs()
-    conda_prefix = os.environ.get("CONDA_PREFIX", "")
-    appdata = os.environ.get("APPDATA", "")
-
-    print("Searching for log files...")
-
-    # Check for Redshift log.html in multiple possible locations
-    redshift_paths = _get_redshift_local_data_paths()
-    for base_path in redshift_paths:
-        result = _find_redshift_log_in_path(base_path, ["Log", "Log.Latest.0", "log.html"])
-        if result:
-            found_logs.redshift = result
-            break
-
-    if not found_logs.redshift:
-        print("Redshift log not found in any expected location")
-
-    # Check for Cinema 4D detailed log: $CONDA_PREFIX\c4d_detailed_logs.txt
-    found_logs.c4d_detailed = _find_c4d_detailed_log(conda_prefix)
-
-    # Check for bug reports: %APPDATA%\Maxon\cinema4d_*\_bugreports\*_BugReport.txt
-    if appdata and os.path.exists(appdata):
-        maxon_path = os.path.join(appdata, "Maxon")
-        found_logs.bugreport = _find_bug_reports(maxon_path, "cinema4d_")
-    else:
-        print("APPDATA not set or doesn't exist, skipping bug report search")
-
-    return found_logs
-
-
-def find_log_files() -> FoundLogs:
-    """Search for Cinema 4D and Redshift log files.
-
-    Returns:
-        FoundLogs: Container with redshift and bugreport log file paths.
-    """
-    # Print environment variables for debugging
+def _print_environment_info() -> None:
+    """Print relevant environment variables for debugging."""
     print("Environment variables:")
-    print(f"  CONDA_PREFIX: {os.environ.get('CONDA_PREFIX', 'NOT SET')}")
+    print(f"  {CONDA_PREFIX_ENV_VAR}: {get_conda_prefix() or 'NOT SET'}")
+    print(
+        f"  {C4D_SECURE_TEMP_DIR_ENV_VAR}: {os.environ.get(C4D_SECURE_TEMP_DIR_ENV_VAR, 'NOT SET')}"
+    )
     print(f"  HOME: {os.environ.get('HOME', 'NOT SET')}")
     print(f"  USER: {os.environ.get('USER', 'NOT SET')}")
-    print(f"  REDSHIFT_LOCALDATAPATH: {os.environ.get('REDSHIFT_LOCALDATAPATH', 'NOT SET')}")
-    print(f"  REDSHIFT_COREDATAPATH: {os.environ.get('REDSHIFT_COREDATAPATH', 'NOT SET')}")
-
-    # Use platform-specific search
-    if sys.platform == "win32":
-        return find_log_files_windows()
-    else:
-        return find_log_files_linux()
+    print(
+        f"  {REDSHIFT_LOCALDATAPATH_ENV_VAR}: {os.environ.get(REDSHIFT_LOCALDATAPATH_ENV_VAR, 'NOT SET')}"
+    )
+    print(
+        f"  {REDSHIFT_COREDATAPATH_ENV_VAR}: {os.environ.get(REDSHIFT_COREDATAPATH_ENV_VAR, 'NOT SET')}"
+    )
 
 
-def print_log_file(log_file, log_type="LOG"):
+def _find_and_print_redshift_logs() -> None:
+    """Find and print Redshift debug logs."""
+    log_files = _find_redshift_log()
+    _print_logs_by_type(
+        log_files,
+        "REDSHIFT DEBUG LOG",
+        "Redshift log file(s)",
+        "No Redshift debug logs (log.html) found.\n"
+        "This may be normal if Redshift was not used for rendering.",
+    )
+
+
+def _find_and_print_c4d_detailed_logs() -> None:
+    """Find and print Cinema 4D detailed logs."""
+    log_files = _find_c4d_detailed_log()
+    _print_logs_by_type(
+        log_files,
+        "CINEMA 4D DETAILED LOG",
+        "Cinema 4D detailed log file(s)",
+        f"No Cinema 4D detailed log ({C4D_DETAILED_LOG_FILENAME}) found.\n"
+        "This is unexpected - the log file should have been created by Cinema 4D.",
+    )
+
+
+def _find_and_print_bug_reports() -> None:
+    """Find and print Cinema 4D bug reports."""
+    log_files = _find_bug_reports()
+    _print_logs_by_type(
+        log_files,
+        "CINEMA 4D BUG REPORT",
+        "Cinema 4D bug report(s)",
+        "No Cinema 4D bug reports (*_BugReport.txt) found.\n"
+        "This may be normal if no crashes occurred.",
+    )
+
+
+def print_log_file(log_file, log_type="LOG") -> None:
     """Print the contents of a log file.
 
     Args:
@@ -286,50 +299,50 @@ def _print_logs_by_type(
         description: Human-readable description of the log type.
         not_found_message: Message to display when no logs are found.
     """
-    if log_files:
-        print(f"\nFound {len(log_files)} {description}")
-        for log_file in log_files:
-            print_log_file(log_file, log_type)
-    else:
+    # Guard clause: handle empty log files list early
+    if not log_files:
         print(f"\n{not_found_message}")
+        return
+
+    print(f"\nFound {len(log_files)} {description}")
+    for log_file in log_files:
+        print_log_file(log_file, log_type)
 
 
-def print_detailed_logs(enabled: str):
+def _cleanup_temporary_directory() -> None:
+    """Clean up temporary directory if it was created during setup."""
+    temp_dir = os.environ.get(C4D_SECURE_TEMP_DIR_ENV_VAR)
+    if temp_dir and os.path.exists(temp_dir):
+        try:
+            shutil.rmtree(temp_dir)
+            print(f"Cleaned up temporary directory: {temp_dir}")
+        except Exception as e:
+            print(f"Note: Could not clean up temporary directory {temp_dir}: {e}")
+
+
+def _cleanup_environment_variables() -> None:
+    """Clean up Cinema 4D environment variables set during setup."""
+    print("openjd_unset_env: g_alloc")
+    print("openjd_unset_env: g_logfile")
+    print("Environment variables cleaned up")
+
+
+def print_detailed_logs(enabled: str) -> None:
     """Print detailed logs if enabled."""
     if enabled != "1":
         print("Detailed logging is deactivated, skipping log output.")
         return
 
-    found_logs = find_log_files()
+    _print_environment_info()
 
-    _print_logs_by_type(
-        found_logs.redshift,
-        "REDSHIFT DEBUG LOG",
-        "Redshift log file(s)",
-        "No Redshift debug logs (log.html) found.\n"
-        "This may be normal if Redshift was not used for rendering.",
-    )
+    print("Searching for log files...")
 
-    _print_logs_by_type(
-        found_logs.c4d_detailed,
-        "CINEMA 4D DETAILED LOG",
-        "Cinema 4D detailed log file(s)",
-        f"No Cinema 4D detailed log ({C4D_DETAILED_LOG_FILENAME}) found.\n"
-        "This is unexpected - the log file should have been created by Cinema 4D.",
-    )
+    _find_and_print_redshift_logs()
+    _find_and_print_c4d_detailed_logs()
+    _find_and_print_bug_reports()
 
-    _print_logs_by_type(
-        found_logs.bugreport,
-        "CINEMA 4D BUG REPORT",
-        "Cinema 4D bug report(s)",
-        "No Cinema 4D bug reports (*_BugReport.txt) found.\n"
-        "This may be normal if no crashes occurred.",
-    )
-
-    # Clean up environment variables set during setup
-    print("openjd_unset_env: g_alloc")
-    print("openjd_unset_env: g_logfile")
-    print("Environment variables cleaned up")
+    _cleanup_temporary_directory()
+    _cleanup_environment_variables()
 
 
 if __name__ == "__main__":

--- a/src/deadline/cinema4d_submitter/detailed_logging_scripts/setup_logging.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_scripts/setup_logging.py
@@ -1,25 +1,45 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-"""Verify Redshift debug logging environment variable is enabled."""
+"""Verify Redshift debug logging environment variable is enabled and set Cinema 4D environment variables."""
 import os
 import sys
+import tempfile
+
+# Cinema 4D detailed log filename constant
+C4D_DETAILED_LOG_FILENAME = "c4d_detailed_logs.txt"
 
 
-def verify_debug_environment_variables(enabled: str):
-    """Verify that debug logging is enabled and environment variable is set."""
+def setup_debug_environment_variables(enabled: str):
+    """Set up debug environment variables when detailed logging is enabled."""
     if enabled != "1":
-        print("Detailed logging is disabled, skipping setup.")
+        print("Detailed logging is deactivated, skipping setup.")
         return
 
+    # Verify REDSHIFT_DEBUGCAPTURE is set correctly
     redshift_debug = os.environ.get("REDSHIFT_DEBUGCAPTURE")
     if redshift_debug == "1":
         print("Redshift debug logging is enabled (REDSHIFT_DEBUGCAPTURE=1)")
     else:
         print("Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'")
 
+    # Set Cinema 4D environment variables using OpenJD protocol
+    print("openjd_env: g_alloc=debug")
+    print("Cinema 4D memory debugging enabled (g_alloc=debug)")
+
+    # Set g_logfile with cross-platform path construction
+    conda_prefix = os.environ.get("CONDA_PREFIX", "")
+    if conda_prefix:
+        log_file_path = os.path.join(conda_prefix, C4D_DETAILED_LOG_FILENAME)
+        print(f"openjd_env: g_logfile={log_file_path}")
+        print(f"Cinema 4D detailed logging enabled (g_logfile={log_file_path})")
+    else:
+        # Fallback to temp directory if CONDA_PREFIX is not set
+        temp_dir = tempfile.gettempdir()
+        log_file_path = os.path.join(temp_dir, C4D_DETAILED_LOG_FILENAME)
+        print("Warning: CONDA_PREFIX not set, using temp directory for g_logfile")
+        print(f"openjd_env: g_logfile={log_file_path}")
+        print(f"Cinema 4D detailed logging enabled (g_logfile={log_file_path})")
+
 
 if __name__ == "__main__":
     enabled = sys.argv[1] if len(sys.argv) > 1 else "0"
-    # Currently, this EnvEnter is not particularly useful
-    # But is a required field.
-    # Although, we can add more logic if necessary in the future
-    verify_debug_environment_variables(enabled)
+    setup_debug_environment_variables(enabled)

--- a/src/deadline/cinema4d_submitter/detailed_logging_scripts/setup_logging.py
+++ b/src/deadline/cinema4d_submitter/detailed_logging_scripts/setup_logging.py
@@ -1,43 +1,86 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-"""Verify Redshift debug logging environment variable is enabled and set Cinema 4D environment variables."""
+"""Configure environment variables for Cinema 4D detailed logging."""
 import os
 import sys
 import tempfile
 
-# Cinema 4D detailed log filename constant
+# Constants
 C4D_DETAILED_LOG_FILENAME = "c4d_detailed_logs.txt"
+C4D_SECURE_TEMP_DIR_ENV_VAR = "C4D_DETAILED_LOG_DIR"
+CONDA_PREFIX_ENV_VAR = "CONDA_PREFIX"
+REDSHIFT_DEBUG_ENV_VAR = "REDSHIFT_DEBUGCAPTURE"
 
 
-def setup_debug_environment_variables(enabled: str):
-    """Set up debug environment variables when detailed logging is enabled."""
+def get_conda_prefix() -> str:
+    """Get the CONDA_PREFIX environment variable value."""
+    return os.environ.get(CONDA_PREFIX_ENV_VAR, "")
+
+
+def _verify_redshift_debug_enabled() -> None:
+    """Verify that Redshift debug logging is properly configured."""
+    redshift_debug = os.environ.get(REDSHIFT_DEBUG_ENV_VAR)
+    if redshift_debug == "1":
+        print(f"Redshift debug logging is enabled ({REDSHIFT_DEBUG_ENV_VAR}=1)")
+    else:
+        print(f"Warning: Detailed logging requested but {REDSHIFT_DEBUG_ENV_VAR} is not set to '1'")
+
+
+def _set_cinema4d_debug_mode() -> None:
+    """Enable Cinema 4D debug allocation mode for detailed logging."""
+    print("openjd_env: g_alloc=debug")
+    print("Cinema 4D debug mode enabled (g_alloc=debug)")
+
+
+def _create_secure_temp_directory() -> str:
+    """Create a secure temporary directory with restricted permissions."""
+    secure_temp_dir = tempfile.mkdtemp(prefix="c4d_logs_")
+    return secure_temp_dir
+
+
+def _get_log_directory() -> str:
+    """
+    Determine the directory for Cinema 4D log files.
+
+    Returns:
+        Path to the log directory (CONDA_PREFIX or secure temp directory)
+    """
+    conda_prefix = get_conda_prefix()
+    if conda_prefix:
+        return conda_prefix
+
+    # Fallback to secure temp directory when CONDA_PREFIX is not available
+    secure_temp_dir = _create_secure_temp_directory()
+    print(
+        f"Warning: {CONDA_PREFIX_ENV_VAR} not set, using secure temp directory: {secure_temp_dir}"
+    )
+    print(f"openjd_env: {C4D_SECURE_TEMP_DIR_ENV_VAR}={secure_temp_dir}")
+    return secure_temp_dir
+
+
+def _set_cinema4d_log_file() -> None:
+    """Configure Cinema 4D detailed log file location."""
+    log_directory = _get_log_directory()
+    log_file_path = os.path.join(log_directory, C4D_DETAILED_LOG_FILENAME)
+
+    print(f"openjd_env: g_logfile={log_file_path}")
+    print(f"Cinema 4D detailed logging enabled (g_logfile={log_file_path})")
+
+
+def setup_debug_environment_variables(enabled: str) -> None:
+    """
+    Configure debug environment variables for Cinema 4D detailed logging.
+
+    Args:
+        enabled: "1" to enable detailed logging, any other value to skip setup
+    """
+    # Guard clause: exit early if logging is disabled
     if enabled != "1":
         print("Detailed logging is deactivated, skipping setup.")
         return
 
-    # Verify REDSHIFT_DEBUGCAPTURE is set correctly
-    redshift_debug = os.environ.get("REDSHIFT_DEBUGCAPTURE")
-    if redshift_debug == "1":
-        print("Redshift debug logging is enabled (REDSHIFT_DEBUGCAPTURE=1)")
-    else:
-        print("Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'")
-
-    # Set Cinema 4D environment variables using OpenJD protocol
-    print("openjd_env: g_alloc=debug")
-    print("Cinema 4D memory debugging enabled (g_alloc=debug)")
-
-    # Set g_logfile with cross-platform path construction
-    conda_prefix = os.environ.get("CONDA_PREFIX", "")
-    if conda_prefix:
-        log_file_path = os.path.join(conda_prefix, C4D_DETAILED_LOG_FILENAME)
-        print(f"openjd_env: g_logfile={log_file_path}")
-        print(f"Cinema 4D detailed logging enabled (g_logfile={log_file_path})")
-    else:
-        # Fallback to temp directory if CONDA_PREFIX is not set
-        temp_dir = tempfile.gettempdir()
-        log_file_path = os.path.join(temp_dir, C4D_DETAILED_LOG_FILENAME)
-        print("Warning: CONDA_PREFIX not set, using temp directory for g_logfile")
-        print(f"openjd_env: g_logfile={log_file_path}")
-        print(f"Cinema 4D detailed logging enabled (g_logfile={log_file_path})")
+    _verify_redshift_debug_enabled()
+    _set_cinema4d_debug_mode()
+    _set_cinema4d_log_file()
 
 
 if __name__ == "__main__":

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -472,7 +472,7 @@ class TestCacheTextIfNeeded:
 
         assert result is False
 
-    def test_cache_text_returns_false_when_disabled(self):
+    def test_cache_text_returns_false_when_deactivated(self):
         """Tests that _cache_text_if_needed returns False when use_cached_text is False"""
         handler = Cinema4DHandler(mock_map_path)
         handler.render_kwargs = {USE_CACHED_TEXT_KEY: False}

--- a/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_print_logs.py
+++ b/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_print_logs.py
@@ -11,311 +11,459 @@ from unittest import mock
 import pytest
 
 from deadline.cinema4d_submitter.detailed_logging_scripts.print_logs import (
-    FoundLogs,
-    _find_redshift_log_in_path,
-    _get_redshift_local_data_paths,
+    get_conda_prefix,
+    _get_redshift_log_paths_windows,
+    _get_redshift_log_paths_linux,
+    _get_redshift_log_paths,
+    _find_log_file,
+    _find_redshift_log,
+    _get_c4d_detailed_log_paths,
     _find_c4d_detailed_log,
+    _get_bug_report_search_path,
+    _scan_for_bug_reports,
     _find_bug_reports,
-    find_log_files_linux,
-    find_log_files_windows,
-    find_log_files,
+    _print_environment_info,
+    _print_logs_by_type,
+    _cleanup_temporary_directory,
+    _cleanup_environment_variables,
     print_log_file,
     print_detailed_logs,
 )
 
 
-class TestFoundLogs:
-    """Test the FoundLogs dataclass"""
+class TestGetCondaPrefix:
+    """Test the get_conda_prefix() helper function.
 
-    def test_default_initialization(self):
-        """Test that FoundLogs initializes with empty lists"""
-        # WHEN
-        found_logs = FoundLogs()
+    This function retrieves the CONDA_PREFIX environment variable,
+    which is used to determine the primary log file location.
+    """
 
-        # THEN
-        assert found_logs.redshift == []
-        assert found_logs.bugreport == []
-        assert found_logs.c4d_detailed == []
-
-    def test_initialization_with_values(self):
-        """Test that FoundLogs can be initialized with values"""
+    def test_returns_conda_prefix_when_set(self):
+        """Test that correct value is returned when CONDA_PREFIX is set"""
         # GIVEN
-        redshift_logs = ["/path/to/redshift.log"]
-        bug_reports = ["/path/to/bugreport.txt"]
-        c4d_detailed_logs = ["/path/to/c4d_detailed_logs.txt"]
-
-        # WHEN
-        found_logs = FoundLogs(
-            redshift=redshift_logs, bugreport=bug_reports, c4d_detailed=c4d_detailed_logs
-        )
-
-        # THEN
-        assert found_logs.redshift == redshift_logs
-        assert found_logs.bugreport == bug_reports
-        assert found_logs.c4d_detailed == c4d_detailed_logs
-
-
-class TestFindRedshiftLogInPath:
-    """Test the _find_redshift_log_in_path function"""
-
-    def test_returns_empty_list_when_base_path_not_set(self, capsys):
-        """Test that empty list is returned when base_path is not set"""
-        # WHEN
-        result = _find_redshift_log_in_path("", ["log", "log.html"])
-        captured = capsys.readouterr()
-
-        # THEN
-        assert result == []
-        assert captured.out == ""
-
-    def test_returns_empty_list_when_base_path_does_not_exist(self, capsys):
-        """Test that empty list is returned when base_path doesn't exist"""
-        # WHEN
-        result = _find_redshift_log_in_path("/nonexistent/path", ["log", "log.html"])
-        captured = capsys.readouterr()
-
-        # THEN
-        assert result == []
-        assert captured.out == ""
-
-    def test_returns_empty_list_when_log_file_not_found(self, capsys):
-        """Test that empty list is returned when log file doesn't exist"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
+        test_prefix = "/opt/conda/env"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": test_prefix}):
             # WHEN
-            result = _find_redshift_log_in_path(tmpdir, ["log", "log.latest.0", "log.html"])
+            result = get_conda_prefix()
+
+            # THEN
+            assert result == test_prefix
+
+    def test_returns_empty_string_when_not_set(self):
+        """Test that empty string is returned when CONDA_PREFIX is not set"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            result = get_conda_prefix()
+
+            # THEN
+            assert result == ""
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
+class TestGetRedshiftLogPathsWindows:
+    """Test the _get_redshift_log_paths_windows() function."""
+
+    @pytest.mark.parametrize(
+        "env_vars,expected_path_parts,check_output",
+        [
+            # CONDA_PREFIX path
+            (
+                {"CONDA_PREFIX": r"C:\conda\env"},
+                [r"C:\conda\env", "cinema4d", "RedshiftData", "Log", "Log.Latest.0", "log.html"],
+                None,
+            ),
+            # Custom REDSHIFT_LOCALDATAPATH
+            (
+                {"REDSHIFT_LOCALDATAPATH": r"C:\custom\redshift"},
+                [r"C:\custom\redshift", "Log", "Log.Latest.0", "log.html"],
+                "Found REDSHIFT_LOCALDATAPATH environment variable",
+            ),
+            # Windows default path (no env vars)
+            (
+                {},
+                [r"C:\ProgramData\Redshift", "Log", "Log.Latest.0", "log.html"],
+                None,
+            ),
+        ],
+        ids=["conda_prefix", "custom_localdatapath", "windows_default"],
+    )
+    def test_includes_expected_paths(self, capsys, env_vars, expected_path_parts, check_output):
+        """Test that expected paths are included based on environment variables"""
+        # GIVEN
+        with mock.patch.dict(os.environ, env_vars, clear=True):
+            # WHEN
+            result = _get_redshift_log_paths_windows()
             captured = capsys.readouterr()
 
             # THEN
-            assert result == []
-            assert "Checking for Redshift log at:" in captured.out
+            expected_path = os.path.join(*expected_path_parts)
+            assert expected_path in result
+            if check_output:
+                assert check_output in captured.out
 
-    def test_returns_log_path_when_file_exists(self, capsys):
-        """Test that log path is returned when file exists"""
+    def test_returns_unique_paths(self):
+        """Test that duplicate paths are removed"""
+        # GIVEN
+        conda_prefix = r"C:\ProgramData\Redshift"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}, clear=True):
+            # WHEN
+            result = _get_redshift_log_paths_windows()
+
+            # THEN
+            # Should not have duplicates even though conda prefix matches default
+            assert len(result) == len(set(result))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Linux/macOS-specific test")
+class TestGetRedshiftLogPathsLinux:
+    """Test the _get_redshift_log_paths_linux() function."""
+
+    @pytest.mark.parametrize(
+        "env_vars,expected_path_parts,check_output,mock_expanduser",
+        [
+            # CONDA_PREFIX path
+            (
+                {"CONDA_PREFIX": "/opt/conda/env"},
+                ["/opt/conda/env", "redshiftlocaldata", "log", "log.latest.0", "log.html"],
+                None,
+                None,
+            ),
+            # Custom REDSHIFT_LOCALDATAPATH
+            (
+                {"REDSHIFT_LOCALDATAPATH": "/custom/redshift"},
+                ["/custom/redshift", "log", "log.latest.0", "log.html"],
+                "Found REDSHIFT_LOCALDATAPATH environment variable",
+                None,
+            ),
+            # Linux default path (no env vars, uses expanduser)
+            (
+                {},
+                ["/home/user", "redshift", "log", "log.latest.0", "log.html"],
+                None,
+                "/home/user",
+            ),
+        ],
+        ids=["conda_prefix", "custom_localdatapath", "linux_default"],
+    )
+    def test_includes_expected_paths(
+        self, capsys, env_vars, expected_path_parts, check_output, mock_expanduser
+    ):
+        """Test that expected paths are included based on environment variables"""
+        # GIVEN
+        with mock.patch.dict(os.environ, env_vars, clear=True):
+            if mock_expanduser:
+                with mock.patch("os.path.expanduser", return_value=mock_expanduser):
+                    # WHEN
+                    result = _get_redshift_log_paths_linux()
+                    captured = capsys.readouterr()
+            else:
+                # WHEN
+                result = _get_redshift_log_paths_linux()
+                captured = capsys.readouterr()
+
+            # THEN
+            expected_path = os.path.join(*expected_path_parts)
+            assert expected_path in result
+            if check_output:
+                assert check_output in captured.out
+
+    def test_returns_unique_paths(self):
+        """Test that duplicate paths are removed"""
+        # GIVEN
+        home_dir = "/home/user"
+        conda_prefix = os.path.join(home_dir, "redshift")
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}, clear=True):
+            with mock.patch("os.path.expanduser", return_value=home_dir):
+                # WHEN
+                result = _get_redshift_log_paths_linux()
+
+                # THEN
+                # Should not have duplicates
+                assert len(result) == len(set(result))
+
+
+class TestGetRedshiftLogPaths:
+    """Test the _get_redshift_log_paths() platform dispatcher function."""
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
+    def test_calls_windows_function_on_win32(self):
+        """Test that _get_redshift_log_paths_windows() is called on win32 platform"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            result = _get_redshift_log_paths()
+
+            # THEN
+            # Should include Windows default path
+            assert any(r"C:\ProgramData\Redshift" in path for path in result)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux/macOS-specific test")
+    def test_calls_linux_function_on_linux(self):
+        """Test that _get_redshift_log_paths_linux() is called on non-win32 platforms"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("os.path.expanduser", return_value="/home/user"):
+                # WHEN
+                result = _get_redshift_log_paths()
+
+                # THEN
+                # Should include Linux default path
+                assert any("/home/user/redshift" in path for path in result)
+
+
+class TestFindLogFile:
+    """Test the _find_log_file() generic log finding function."""
+
+    def test_returns_first_found_log(self, capsys):
+        """Test that first existing log path is returned"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
-            log_dir = Path(tmpdir) / "log" / "log.latest.0"
-            log_dir.mkdir(parents=True)
-            log_file = log_dir / "log.html"
-            log_file.write_text("test log content")
+            log_file = Path(tmpdir) / "test.log"
+            log_file.write_text("test log")
+            paths = ["/nonexistent/log1.log", str(log_file), "/nonexistent/log2.log"]
 
             # WHEN
-            result = _find_redshift_log_in_path(tmpdir, ["log", "log.latest.0", "log.html"])
+            result = _find_log_file(paths, "test log")
             captured = capsys.readouterr()
 
             # THEN
             assert len(result) == 1
             assert result[0] == str(log_file)
-            assert "Found Redshift log:" in captured.out
+            assert "Found test log:" in captured.out
 
-
-class TestGetRedshiftLocalDataPaths:
-    """Test the _get_redshift_local_data_paths function"""
-
-    def test_returns_custom_path_when_env_var_set(self, capsys):
-        """Test that REDSHIFT_LOCALDATAPATH is prioritized when set"""
+    def test_returns_empty_list_when_not_found(self, capsys):
+        """Test that empty list is returned when no logs exist"""
         # GIVEN
-        custom_path = "/custom/redshift/path"
-        with mock.patch.dict(os.environ, {"REDSHIFT_LOCALDATAPATH": custom_path}, clear=True):
-            # WHEN
-            result = _get_redshift_local_data_paths()
-            captured = capsys.readouterr()
+        paths = ["/nonexistent/log1.log", "/nonexistent/log2.log"]
 
-            # THEN
-            assert custom_path in result
-            assert result[0] == custom_path
-            assert "Found REDSHIFT_LOCALDATAPATH environment variable" in captured.out
-
-    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
-    def test_returns_windows_default_paths(self):
-        """Test that Windows default paths are returned"""
-        # GIVEN
-        with mock.patch.dict(os.environ, {}, clear=True):
-            # WHEN
-            result = _get_redshift_local_data_paths()
-
-            # THEN
-            assert r"C:\ProgramData\Redshift" in result
-
-    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific test")
-    def test_returns_linux_default_paths(self):
-        """Test that Linux default paths are returned"""
-        # GIVEN
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with mock.patch("os.path.expanduser", return_value="/home/user"):
-                # WHEN
-                result = _get_redshift_local_data_paths()
-
-                # THEN
-                assert "/home/user/redshift" in result
-
-    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
-    def test_includes_conda_prefix_path_windows(self):
-        """Test that CONDA_PREFIX path is included on Windows"""
-        # GIVEN
-        conda_prefix = r"C:\conda\env"
-        with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}):
-            # WHEN
-            result = _get_redshift_local_data_paths()
-
-            # THEN
-            expected_path = os.path.join(conda_prefix, "cinema4d", "RedshiftData")
-            assert expected_path in result
-
-    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific test")
-    def test_includes_conda_prefix_path_linux(self):
-        """Test that CONDA_PREFIX path is included on Linux"""
-        # GIVEN
-        conda_prefix = "/opt/conda/env"
-        with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}):
-            with mock.patch("os.path.expanduser", return_value="/home/user"):
-                # WHEN
-                result = _get_redshift_local_data_paths()
-
-                # THEN
-                expected_path = os.path.join(conda_prefix, "redshiftlocaldata")
-                assert expected_path in result
-
-
-class TestFindC4DDetailedLog:
-    """Test the _find_c4d_detailed_log function"""
-
-    def test_checks_temp_directory_when_conda_prefix_not_set(self, capsys):
-        """Test that temp directory is checked when CONDA_PREFIX is not set"""
         # WHEN
-        result = _find_c4d_detailed_log("")
+        result = _find_log_file(paths, "test log")
         captured = capsys.readouterr()
 
         # THEN
         assert result == []
-        assert "CONDA_PREFIX not set or doesn't exist" in captured.out
-        assert "Checking for Cinema 4D detailed log in temp directory:" in captured.out
-        assert "Cinema 4D detailed log not found in temp directory either" in captured.out
+        assert "test log not found in any expected location" in captured.out
 
-    def test_checks_temp_directory_when_conda_prefix_does_not_exist(self, capsys):
-        """Test that temp directory is checked when CONDA_PREFIX path doesn't exist"""
-        # GIVEN - ensure temp directory is clean
-        temp_dir = tempfile.gettempdir()
-        temp_log_file = Path(temp_dir) / "c4d_detailed_logs.txt"
-        if temp_log_file.exists():
-            temp_log_file.unlink()
+    @pytest.mark.parametrize(
+        "setup_paths,expected_messages",
+        [
+            # Checking messages for multiple paths
+            (
+                "nonexistent_paths",
+                [
+                    "Checking for test log at: /path1/log.log",
+                    "Checking for test log at: /path2/log.log",
+                ],
+            ),
+            # Found message when log exists
+            ("existing_log", ["Found test log:"]),
+            # Not found message when no logs exist
+            ("nonexistent_single", ["test log not found in any expected location"]),
+        ],
+        ids=["checking_messages", "found_message", "not_found_message"],
+    )
+    def test_prints_expected_messages(self, capsys, setup_paths, expected_messages):
+        """Test that appropriate messages are printed based on log file existence"""
+        # GIVEN
+        if setup_paths == "nonexistent_paths":
+            paths = ["/path1/log.log", "/path2/log.log"]
+        elif setup_paths == "existing_log":
+            with tempfile.TemporaryDirectory() as tmpdir:
+                log_file = Path(tmpdir) / "test.log"
+                log_file.write_text("test log")
+                paths = [str(log_file)]
+
+                # WHEN
+                _find_log_file(paths, "test log")
+                captured = capsys.readouterr()
+
+                # THEN
+                for message in expected_messages:
+                    assert message in captured.out
+                return
+        else:  # nonexistent_single
+            paths = ["/nonexistent/log.log"]
 
         # WHEN
-        result = _find_c4d_detailed_log("/nonexistent/path")
+        _find_log_file(paths, "test log")
         captured = capsys.readouterr()
 
         # THEN
-        assert result == []
-        assert "CONDA_PREFIX not set or doesn't exist" in captured.out
-        assert "Checking for Cinema 4D detailed log in temp directory:" in captured.out
+        for message in expected_messages:
+            assert message in captured.out
 
-    def test_checks_temp_directory_when_log_not_in_conda_prefix(self, capsys):
-        """Test that temp directory is checked when log file doesn't exist in CONDA_PREFIX"""
-        # GIVEN - ensure temp directory is clean
-        temp_dir = tempfile.gettempdir()
-        temp_log_file = Path(temp_dir) / "c4d_detailed_logs.txt"
-        if temp_log_file.exists():
-            temp_log_file.unlink()
 
+class TestFindRedshiftLog:
+    """Test the _find_redshift_log() function."""
+
+    def test_returns_log_when_found(self, capsys):
+        """Test that log path is returned when found"""
+        # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
+            log_dir = Path(tmpdir) / "redshiftlocaldata" / "log" / "log.latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("redshift log")
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("sys.platform", "linux"):
+                    with mock.patch("os.path.expanduser", return_value=tmpdir):
+                        # WHEN
+                        result = _find_redshift_log()
+
+                        # THEN
+                        assert len(result) == 1
+                        assert result[0] == str(log_file)
+
+    def test_returns_empty_list_when_not_found(self, capsys):
+        """Test that empty list is returned when not found"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("sys.platform", "linux"):
+                with mock.patch("os.path.expanduser", return_value="/home/user"):
+                    # WHEN
+                    result = _find_redshift_log()
+                    captured = capsys.readouterr()
+
+                    # THEN
+                    assert result == []
+                    assert "Redshift log not found in any expected location" in captured.out
+
+
+class TestGetC4dDetailedLogPaths:
+    """Test the _get_c4d_detailed_log_paths() function."""
+
+    @pytest.mark.parametrize(
+        "env_vars,expected_result_count,expected_path_base,expected_message",
+        [
+            # CONDA_PREFIX available
+            (
+                {"CONDA_PREFIX": "/opt/conda/env"},
+                1,
+                "/opt/conda/env",
+                None,
+            ),
+            # C4D_DETAILED_LOG_DIR as fallback
+            (
+                {"C4D_DETAILED_LOG_DIR": "/home/user/c4d_logs_12345"},
+                1,
+                "/home/user/c4d_logs_12345",
+                None,
+            ),
+            # Neither available
+            (
+                {},
+                0,
+                None,
+                "Neither CONDA_PREFIX nor C4D_DETAILED_LOG_DIR is set",
+            ),
+        ],
+        ids=["conda_prefix", "secure_temp_fallback", "neither_available"],
+    )
+    def test_returns_expected_paths(
+        self, capsys, env_vars, expected_result_count, expected_path_base, expected_message
+    ):
+        """Test that correct paths are returned based on environment variables"""
+        # GIVEN
+        with mock.patch.dict(os.environ, env_vars, clear=True):
             # WHEN
-            result = _find_c4d_detailed_log(tmpdir)
+            result = _get_c4d_detailed_log_paths()
             captured = capsys.readouterr()
 
             # THEN
-            assert result == []
-            assert "Checking for Cinema 4D detailed log at:" in captured.out
-            assert "Cinema 4D detailed log not found in CONDA_PREFIX" in captured.out
-            assert "Checking for Cinema 4D detailed log in temp directory:" in captured.out
-            assert "Cinema 4D detailed log not found in temp directory either" in captured.out
+            assert len(result) == expected_result_count
+            if expected_path_base:
+                expected_path = os.path.join(expected_path_base, "c4d_detailed_logs.txt")
+                assert result[0] == expected_path
+            if expected_message:
+                assert expected_message in captured.out
 
-    def test_returns_log_path_when_file_exists_in_conda_prefix(self, capsys):
-        """Test that log path is returned when file exists in CONDA_PREFIX"""
+
+class TestFindC4dDetailedLog:
+    """Test the _find_c4d_detailed_log() function."""
+
+    def test_finds_log_in_conda_prefix(self, capsys):
+        """Test that log is found in CONDA_PREFIX location"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = Path(tmpdir) / "c4d_detailed_logs.txt"
             log_file.write_text("Cinema 4D detailed log content")
 
-            # WHEN
-            result = _find_c4d_detailed_log(tmpdir)
-            captured = capsys.readouterr()
-
-            # THEN
-            assert len(result) == 1
-            assert result[0] == str(log_file)
-            assert "Found Cinema 4D detailed log:" in captured.out
-
-    def test_returns_log_path_from_temp_directory_when_not_in_conda_prefix(self, capsys):
-        """Test that log path from temp directory is returned when not found in CONDA_PREFIX"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create log in temp directory
-            temp_dir = tempfile.gettempdir()
-            temp_log_file = Path(temp_dir) / "c4d_detailed_logs.txt"
-            temp_log_file.write_text("Cinema 4D detailed log in temp")
-
-            try:
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
                 # WHEN
-                result = _find_c4d_detailed_log(tmpdir)
+                result = _find_c4d_detailed_log()
                 captured = capsys.readouterr()
 
                 # THEN
                 assert len(result) == 1
-                assert result[0] == str(temp_log_file)
-                assert "Cinema 4D detailed log not found in CONDA_PREFIX" in captured.out
-                assert "Found Cinema 4D detailed log in temp directory:" in captured.out
-            finally:
-                # Clean up
-                if temp_log_file.exists():
-                    temp_log_file.unlink()
+                assert result[0] == str(log_file)
+                assert "Found Cinema 4D detailed log:" in captured.out
 
-
-class TestFindBugReports:
-    """Test the _find_bug_reports function"""
-
-    def test_returns_empty_list_when_base_path_does_not_exist(self, capsys):
-        """Test that empty list is returned when base path doesn't exist"""
-        # WHEN
-        result = _find_bug_reports("/nonexistent/path", "bin_")
-        captured = capsys.readouterr()
-
-        # THEN
-        assert result == []
-        assert "doesn't exist, skipping bug report search" in captured.out
-
-    def test_returns_empty_list_when_no_matching_directories(self, capsys):
-        """Test that empty list is returned when no directories match prefix"""
+    def test_finds_log_in_secure_temp(self, capsys):
+        """Test that log is found in secure temp directory (C4D_DETAILED_LOG_DIR)"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Create a directory that doesn't match the prefix
-            (Path(tmpdir) / "other_dir").mkdir()
+            log_file = Path(tmpdir) / "c4d_detailed_logs.txt"
+            log_file.write_text("Cinema 4D detailed log in temp")
 
+            with mock.patch.dict(os.environ, {"C4D_DETAILED_LOG_DIR": tmpdir}, clear=True):
+                # WHEN
+                result = _find_c4d_detailed_log()
+                captured = capsys.readouterr()
+
+                # THEN
+                assert len(result) == 1
+                assert result[0] == str(log_file)
+                assert "Found Cinema 4D detailed log:" in captured.out
+
+    def test_returns_empty_when_not_found(self, capsys):
+        """Test that empty list is returned when log doesn't exist"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
             # WHEN
-            result = _find_bug_reports(tmpdir, "bin_")
+            result = _find_c4d_detailed_log()
             captured = capsys.readouterr()
 
             # THEN
             assert result == []
-            assert "No _bugreports directories found" in captured.out
+            assert "Neither CONDA_PREFIX nor C4D_DETAILED_LOG_DIR is set" in captured.out
 
-    def test_returns_empty_list_when_bugreports_dir_exists_but_no_files(self, capsys):
-        """Test that empty list is returned when _bugreports dir exists but has no bug report files"""
+
+class TestGetBugReportSearchPath:
+    """Test the _get_bug_report_search_path() function."""
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
+    def test_returns_windows_paths(self):
+        """Test that Windows APPDATA/Maxon path with cinema4d_ prefix is returned"""
         # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            bugreports_dir = Path(tmpdir) / "bin_12345" / "_bugreports"
-            bugreports_dir.mkdir(parents=True)
-
+        appdata = r"C:\Users\TestUser\AppData\Roaming"
+        with mock.patch.dict(os.environ, {"APPDATA": appdata}):
             # WHEN
-            result = _find_bug_reports(tmpdir, "bin_")
-            captured = capsys.readouterr()
+            base_path, dir_prefix = _get_bug_report_search_path()
 
             # THEN
-            assert result == []
-            assert "Found _bugreports directory:" in captured.out
-            assert "no bug report files found inside" in captured.out
+            assert base_path == os.path.join(appdata, "Maxon")
+            assert dir_prefix == "cinema4d_"
 
-    def test_finds_bug_report_files(self, capsys):
-        """Test that bug report files are found correctly"""
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux/macOS-specific test")
+    def test_returns_linux_paths(self):
+        """Test that Linux ~/Maxon path with bin_ prefix is returned"""
+        # GIVEN
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            # WHEN
+            base_path, dir_prefix = _get_bug_report_search_path()
+
+            # THEN
+            assert base_path == "/home/user/Maxon"
+            assert dir_prefix == "bin_"
+
+
+class TestScanForBugReports:
+    """Test the _scan_for_bug_reports() function."""
+
+    def test_finds_bug_reports_in_matching_directories(self):
+        """Test that bug reports are found in directories matching prefix"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
             bugreports_dir = Path(tmpdir) / "bin_12345" / "_bugreports"
@@ -324,15 +472,48 @@ class TestFindBugReports:
             bug_report.write_text("bug report")
 
             # WHEN
-            result = _find_bug_reports(tmpdir, "bin_")
-            captured = capsys.readouterr()
+            result = _scan_for_bug_reports(tmpdir, "bin_")
 
             # THEN
             assert len(result) == 1
             assert str(bug_report) in result
-            assert "Found bug report:" in captured.out
 
-    def test_finds_bug_reports_in_multiple_directories(self, capsys):
+    def test_ignores_non_matching_directories(self):
+        """Test that directories not matching prefix are ignored"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create directory that doesn't match prefix
+            other_dir = Path(tmpdir) / "other_12345" / "_bugreports"
+            other_dir.mkdir(parents=True)
+            bug_report = other_dir / "_BugReport.txt"
+            bug_report.write_text("bug report")
+
+            # WHEN
+            result = _scan_for_bug_reports(tmpdir, "bin_")
+
+            # THEN
+            assert result == []
+
+    def test_ignores_non_bug_report_files(self):
+        """Test that only *_BugReport.txt files are included"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bugreports_dir = Path(tmpdir) / "bin_12345" / "_bugreports"
+            bugreports_dir.mkdir(parents=True)
+            bug_report = bugreports_dir / "_BugReport.txt"
+            other_file = bugreports_dir / "other_file.txt"
+            bug_report.write_text("bug report")
+            other_file.write_text("other content")
+
+            # WHEN
+            result = _scan_for_bug_reports(tmpdir, "bin_")
+
+            # THEN
+            assert len(result) == 1
+            assert str(bug_report) in result
+            assert str(other_file) not in result
+
+    def test_finds_bug_reports_in_multiple_directories(self):
         """Test that bug reports are found in multiple matching directories"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -349,455 +530,254 @@ class TestFindBugReports:
             bug_report2.write_text("bug report 2")
 
             # WHEN
-            result = _find_bug_reports(tmpdir, "bin_")
+            result = _scan_for_bug_reports(tmpdir, "bin_")
 
             # THEN
             assert len(result) == 2
             assert str(bug_report1) in result
             assert str(bug_report2) in result
 
-    def test_ignores_non_bug_report_files(self, capsys):
-        """Test that non-bug report files are ignored"""
+
+class TestFindBugReports:
+    """Test the _find_bug_reports() function."""
+
+    def test_returns_empty_when_base_path_not_exists(self):
+        """Test that empty list is returned when base_path doesn't exist (guard clause)"""
+        # WHEN
+        with mock.patch(
+            "deadline.cinema4d_submitter.detailed_logging_scripts.print_logs._get_bug_report_search_path",
+            return_value=("/nonexistent/path", "bin_"),
+        ):
+            result = _find_bug_reports()
+
+            # THEN
+            assert result == []
+
+    def test_delegates_to_scan_function(self, capsys):
+        """Test that _scan_for_bug_reports() is called when path exists"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
             bugreports_dir = Path(tmpdir) / "bin_12345" / "_bugreports"
             bugreports_dir.mkdir(parents=True)
             bug_report = bugreports_dir / "_BugReport.txt"
-            other_file = bugreports_dir / "other_file.txt"
             bug_report.write_text("bug report")
-            other_file.write_text("other content")
 
+            with mock.patch(
+                "deadline.cinema4d_submitter.detailed_logging_scripts.print_logs._get_bug_report_search_path",
+                return_value=(tmpdir, "bin_"),
+            ):
+                # WHEN
+                result = _find_bug_reports()
+                captured = capsys.readouterr()
+
+                # THEN
+                assert len(result) == 1
+                assert str(bug_report) in result
+                assert "Checking for bug reports in:" in captured.out
+
+
+class TestPrintEnvironmentInfo:
+    """Test the _print_environment_info() function."""
+
+    @pytest.mark.parametrize(
+        "env_vars,expected_outputs",
+        [
+            # All variables set
+            (
+                {
+                    "CONDA_PREFIX": "/opt/conda",
+                    "C4D_DETAILED_LOG_DIR": "/home/user/c4d_logs",
+                    "HOME": "/home/user",
+                    "USER": "testuser",
+                    "REDSHIFT_LOCALDATAPATH": "/custom/redshift",
+                    "REDSHIFT_COREDATAPATH": "/custom/core",
+                },
+                [
+                    "Environment variables:",
+                    "CONDA_PREFIX: /opt/conda",
+                    "C4D_DETAILED_LOG_DIR: /home/user/c4d_logs",
+                    "HOME: /home/user",
+                    "USER: testuser",
+                    "REDSHIFT_LOCALDATAPATH: /custom/redshift",
+                    "REDSHIFT_COREDATAPATH: /custom/core",
+                ],
+            ),
+            # No variables set
+            (
+                {},
+                [
+                    "CONDA_PREFIX: NOT SET",
+                    "C4D_DETAILED_LOG_DIR: NOT SET",
+                    "HOME: NOT SET",
+                    "USER: NOT SET",
+                    "REDSHIFT_LOCALDATAPATH: NOT SET",
+                    "REDSHIFT_COREDATAPATH: NOT SET",
+                ],
+            ),
+            # Only CONDA_PREFIX set
+            (
+                {"CONDA_PREFIX": "/test/path"},
+                ["CONDA_PREFIX: /test/path"],
+            ),
+            # Only Redshift variables set
+            (
+                {
+                    "REDSHIFT_LOCALDATAPATH": "/local/data",
+                    "REDSHIFT_COREDATAPATH": "/core/data",
+                },
+                [
+                    "REDSHIFT_LOCALDATAPATH: /local/data",
+                    "REDSHIFT_COREDATAPATH: /core/data",
+                ],
+            ),
+        ],
+        ids=["all_variables", "no_variables", "conda_prefix_only", "redshift_variables_only"],
+    )
+    def test_prints_environment_variables(self, capsys, env_vars, expected_outputs):
+        """Test that environment variables are printed correctly"""
+        # GIVEN
+        with mock.patch.dict(os.environ, env_vars, clear=True):
             # WHEN
-            result = _find_bug_reports(tmpdir, "bin_")
+            _print_environment_info()
+            captured = capsys.readouterr()
 
             # THEN
-            assert len(result) == 1
-            assert str(bug_report) in result
-            assert str(other_file) not in result
+            for expected_output in expected_outputs:
+                assert expected_output in captured.out
 
-    def test_handles_exception_gracefully(self, capsys):
-        """Test that exceptions during search are handled gracefully"""
+
+class TestPrintLogsByType:
+    """Test the _print_logs_by_type() function."""
+
+    def test_prints_not_found_message_for_empty_list(self, capsys):
+        """Test that not_found_message is printed for empty log list (guard clause)"""
+        # WHEN
+        _print_logs_by_type([], "TEST LOG", "test logs", "No test logs found")
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "No test logs found" in captured.out
+
+    def test_prints_count_and_description(self, capsys):
+        """Test that count and description are printed when logs are found"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch("os.listdir", side_effect=PermissionError("Access denied")):
+            log_file = Path(tmpdir) / "test.log"
+            log_file.write_text("test content")
+
+            # WHEN
+            _print_logs_by_type([str(log_file)], "TEST LOG", "test log(s)", "Not found")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "Found 1 test log(s)" in captured.out
+
+    def test_calls_print_log_file_for_each_log(self, capsys):
+        """Test that print_log_file() is called for each log file"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log1 = Path(tmpdir) / "test1.log"
+            log2 = Path(tmpdir) / "test2.log"
+            log1.write_text("content 1")
+            log2.write_text("content 2")
+
+            # WHEN
+            _print_logs_by_type([str(log1), str(log2)], "TEST LOG", "test logs", "Not found")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "TEST LOG:" in captured.out
+            assert "content 1" in captured.out
+            assert "content 2" in captured.out
+
+
+class TestCleanupEnvironmentVariables:
+    """Test the _cleanup_environment_variables() function."""
+
+    def test_prints_unset_commands(self, capsys):
+        """Test that openjd_unset_env commands are printed"""
+        # WHEN
+        _cleanup_environment_variables()
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "openjd_unset_env: g_alloc" in captured.out
+        assert "openjd_unset_env: g_logfile" in captured.out
+
+    def test_prints_confirmation_message(self, capsys):
+        """Test that cleanup confirmation message is printed"""
+        # WHEN
+        _cleanup_environment_variables()
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "Environment variables cleaned up" in captured.out
+
+
+class TestCleanupTemporaryDirectory:
+    """Test the _cleanup_temporary_directory() function."""
+
+    def test_cleans_up_temp_directory_when_set(self, capsys):
+        """Test that temporary directory is removed when C4D_DETAILED_LOG_DIR is set"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_log_dir = os.path.join(tmpdir, "c4d_logs_test")
+            os.makedirs(temp_log_dir)
+
+            with mock.patch.dict(os.environ, {"C4D_DETAILED_LOG_DIR": temp_log_dir}):
                 # WHEN
-                result = _find_bug_reports(tmpdir, "bin_")
+                _cleanup_temporary_directory()
                 captured = capsys.readouterr()
 
                 # THEN
-                assert result == []
-                assert "Error searching for bug reports:" in captured.out
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific tests")
-class TestFindLogFilesLinux:
-    """Test the find_log_files_linux function"""
-
-    def test_finds_redshift_log_in_custom_path(self, capsys):
-        """Test that Redshift log is found in REDSHIFT_LOCALDATAPATH"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create Redshift log in custom path
-            log_dir = Path(tmpdir) / "log" / "log.latest.0"
-            log_dir.mkdir(parents=True)
-            log_file = log_dir / "log.html"
-            log_file.write_text("redshift log")
-
-            home_dir = Path(tmpdir) / "home"
-            home_dir.mkdir()
-
-            with mock.patch.dict(os.environ, {"REDSHIFT_LOCALDATAPATH": tmpdir}):
-                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
-                    # WHEN
-                    result = find_log_files_linux()
-
-                    # THEN
-                    assert len(result.redshift) == 1
-                    assert result.redshift[0] == str(log_file)
-
-    def test_finds_redshift_log_in_home_directory(self, capsys):
-        """Test that Redshift log is found in ~/redshift (default location)"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home_dir = Path(tmpdir) / "home"
-            redshift_dir = home_dir / "redshift" / "log" / "log.latest.0"
-            redshift_dir.mkdir(parents=True)
-            log_file = redshift_dir / "log.html"
-            log_file.write_text("redshift log")
-
-            with mock.patch.dict(os.environ, {}, clear=True):
-                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
-                    with mock.patch("sys.platform", "linux"):
-                        # WHEN
-                        result = find_log_files_linux()
-
-                        # THEN
-                        assert len(result.redshift) == 1
-                        assert result.redshift[0] == str(log_file)
-
-    def test_finds_redshift_log_in_conda_prefix(self, capsys):
-        """Test that Redshift log is found in CONDA_PREFIX"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create Redshift log in conda prefix
-            log_dir = Path(tmpdir) / "redshiftlocaldata" / "log" / "log.latest.0"
-            log_dir.mkdir(parents=True)
-            log_file = log_dir / "log.html"
-            log_file.write_text("redshift log")
-
-            home_dir = Path(tmpdir) / "home"
-            home_dir.mkdir()
-
-            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
-                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
-                    with mock.patch("sys.platform", "linux"):
-                        # WHEN
-                        result = find_log_files_linux()
-
-                        # THEN
-                        assert len(result.redshift) == 1
-                        assert result.redshift[0] == str(log_file)
-
-    def test_prioritizes_custom_path_over_defaults(self, capsys):
-        """Test that REDSHIFT_LOCALDATAPATH is checked after conda prefix but before default paths"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create log in custom path
-            custom_dir = Path(tmpdir) / "custom"
-            custom_log_dir = custom_dir / "log" / "log.latest.0"
-            custom_log_dir.mkdir(parents=True)
-            custom_log_file = custom_log_dir / "log.html"
-            custom_log_file.write_text("custom redshift log")
-
-            # Create log in default path (should be ignored)
-            home_dir = Path(tmpdir) / "home"
-            default_log_dir = home_dir / "redshift" / "log" / "log.latest.0"
-            default_log_dir.mkdir(parents=True)
-            default_log_file = default_log_dir / "log.html"
-            default_log_file.write_text("default redshift log")
-
-            with mock.patch.dict(os.environ, {"REDSHIFT_LOCALDATAPATH": str(custom_dir)}):
-                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
-                    with mock.patch("sys.platform", "linux"):
-                        # WHEN
-                        result = find_log_files_linux()
-
-                        # THEN
-                        assert len(result.redshift) == 1
-                        assert result.redshift[0] == str(custom_log_file)
-
-    def test_prints_message_when_no_redshift_log_found(self, capsys):
-        """Test that appropriate message is printed when no Redshift log is found"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home_dir = Path(tmpdir) / "home"
-            home_dir.mkdir()
-
-            with mock.patch.dict(os.environ, {}, clear=True):
-                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
-                    # WHEN
-                    result = find_log_files_linux()
-                    captured = capsys.readouterr()
-
-                    # THEN
-                    assert result.redshift == []
-                    assert "Redshift log not found in any expected location" in captured.out
-
-    def test_finds_c4d_detailed_log_on_linux(self, capsys):
-        """Test that Cinema 4D detailed log is found on Linux"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create Cinema 4D detailed log
-            c4d_log = Path(tmpdir) / "c4d_detailed_logs.txt"
-            c4d_log.write_text("Cinema 4D detailed log")
-
-            home_dir = Path(tmpdir) / "home"
-            home_dir.mkdir()
-
-            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
-                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
-                    # WHEN
-                    result = find_log_files_linux()
-
-                    # THEN
-                    assert len(result.c4d_detailed) == 1
-                    assert result.c4d_detailed[0] == str(c4d_log)
-
-    def test_finds_bug_reports_on_linux(self, capsys):
-        """Test that bug reports are found on Linux"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home_dir = Path(tmpdir) / "home"
-            maxon_dir = home_dir / "Maxon" / "bin_12345" / "_bugreports"
-            maxon_dir.mkdir(parents=True)
-            bug_report = maxon_dir / "_BugReport.txt"
-            bug_report.write_text("bug report")
-
-            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
-                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
-                    # WHEN
-                    result = find_log_files_linux()
-
-                    # THEN
-                    assert len(result.bugreport) == 1
-                    assert result.bugreport[0] == str(bug_report)
-
-
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific tests")
-class TestFindLogFilesWindows:
-    """Test the find_log_files_windows function"""
-
-    def test_searches_for_redshift_and_bug_reports(self, capsys):
-        """Test that both Redshift logs and bug reports are searched"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            appdata_dir = Path(tmpdir) / "appdata"
-            appdata_dir.mkdir()
-
-            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir, "APPDATA": str(appdata_dir)}):
-                # WHEN
-                result = find_log_files_windows()
-                captured = capsys.readouterr()
-
-                # THEN
-                assert isinstance(result, FoundLogs)
-                assert "Searching for log files..." in captured.out
-
-    def test_finds_redshift_log_in_custom_path(self, capsys):
-        """Test that Redshift log is found in REDSHIFT_LOCALDATAPATH"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create Redshift log in custom path
-            log_dir = Path(tmpdir) / "Log" / "Log.Latest.0"
-            log_dir.mkdir(parents=True)
-            log_file = log_dir / "log.html"
-            log_file.write_text("redshift log")
-
-            appdata_dir = Path(tmpdir) / "appdata"
-            appdata_dir.mkdir()
-
-            with mock.patch.dict(
-                os.environ, {"REDSHIFT_LOCALDATAPATH": tmpdir, "APPDATA": str(appdata_dir)}
-            ):
-                # WHEN
-                result = find_log_files_windows()
-
-                # THEN
-                assert len(result.redshift) == 1
-                assert result.redshift[0] == str(log_file)
-
-    def test_finds_redshift_log_in_programdata(self, capsys):
-        """Test that Redshift log is found in C:\\ProgramData\\Redshift (default location)"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Mock the default Windows path
-            programdata_dir = Path(tmpdir) / "ProgramData" / "Redshift"
-            log_dir = programdata_dir / "Log" / "Log.Latest.0"
-            log_dir.mkdir(parents=True)
-            log_file = log_dir / "log.html"
-            log_file.write_text("redshift log")
-
-            appdata_dir = Path(tmpdir) / "appdata"
-            appdata_dir.mkdir()
-
-            with mock.patch.dict(os.environ, {"APPDATA": str(appdata_dir)}, clear=True):
-                with mock.patch(
-                    "deadline.cinema4d_submitter.detailed_logging_scripts.print_logs._get_redshift_local_data_paths",
-                    return_value=[str(programdata_dir)],
-                ):
-                    # WHEN
-                    result = find_log_files_windows()
-
-                    # THEN
-                    assert len(result.redshift) == 1
-                    assert result.redshift[0] == str(log_file)
-
-    def test_finds_redshift_log_in_conda_prefix(self, capsys):
-        """Test that Redshift log is found in CONDA_PREFIX"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create Redshift log in conda prefix
-            log_dir = Path(tmpdir) / "cinema4d" / "RedshiftData" / "Log" / "Log.Latest.0"
-            log_dir.mkdir(parents=True)
-            log_file = log_dir / "log.html"
-            log_file.write_text("redshift log")
-
-            appdata_dir = Path(tmpdir) / "appdata"
-            appdata_dir.mkdir()
-
-            # Mock _get_redshift_local_data_paths to only return conda prefix path
-            conda_path = os.path.join(tmpdir, "cinema4d", "RedshiftData")
-            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir, "APPDATA": str(appdata_dir)}):
-                with mock.patch(
-                    "deadline.cinema4d_submitter.detailed_logging_scripts.print_logs._get_redshift_local_data_paths",
-                    return_value=[conda_path],
-                ):
-                    # WHEN
-                    result = find_log_files_windows()
-
-                    # THEN
-                    assert len(result.redshift) == 1
-                    assert result.redshift[0] == str(log_file)
-
-    def test_prioritizes_custom_path_over_defaults(self, capsys):
-        """Test that conda prefix is checked before REDSHIFT_LOCALDATAPATH"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create log in custom path (should be ignored since conda prefix is checked first)
-            custom_dir = Path(tmpdir) / "custom"
-            custom_log_dir = custom_dir / "Log" / "Log.Latest.0"
-            custom_log_dir.mkdir(parents=True)
-            custom_log_file = custom_log_dir / "log.html"
-            custom_log_file.write_text("custom redshift log")
-
-            # Create log in conda prefix (should be found first)
-            conda_dir = Path(tmpdir) / "conda"
-            conda_log_dir = conda_dir / "cinema4d" / "RedshiftData" / "Log" / "Log.Latest.0"
-            conda_log_dir.mkdir(parents=True)
-            conda_log_file = conda_log_dir / "log.html"
-            conda_log_file.write_text("conda redshift log")
-
-            appdata_dir = Path(tmpdir) / "appdata"
-            appdata_dir.mkdir()
-
-            with mock.patch.dict(
-                os.environ,
-                {
-                    "REDSHIFT_LOCALDATAPATH": str(custom_dir),
-                    "CONDA_PREFIX": str(conda_dir),
-                    "APPDATA": str(appdata_dir),
-                },
-            ):
-                # WHEN
-                result = find_log_files_windows()
-
-                # THEN
-                assert len(result.redshift) == 1
-                # Conda prefix is checked first, so it should find the conda log
-                assert result.redshift[0] == str(conda_log_file)
-
-    def test_prints_message_when_no_redshift_log_found(self, capsys):
-        """Test that appropriate message is printed when no Redshift log is found"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            appdata_dir = Path(tmpdir) / "appdata"
-            appdata_dir.mkdir()
-
-            # Mock _get_redshift_local_data_paths to return non-existent paths
-            with mock.patch.dict(os.environ, {"APPDATA": str(appdata_dir)}, clear=True):
-                with mock.patch(
-                    "deadline.cinema4d_submitter.detailed_logging_scripts.print_logs._get_redshift_local_data_paths",
-                    return_value=["/nonexistent/path1", "/nonexistent/path2"],
-                ):
-                    # WHEN
-                    result = find_log_files_windows()
-                    captured = capsys.readouterr()
-
-                    # THEN
-                    assert result.redshift == []
-                    assert "Redshift log not found in any expected location" in captured.out
-
-    def test_finds_c4d_detailed_log_on_windows(self, capsys):
-        """Test that Cinema 4D detailed log is found on Windows"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create Cinema 4D detailed log
-            c4d_log = Path(tmpdir) / "c4d_detailed_logs.txt"
-            c4d_log.write_text("Cinema 4D detailed log")
-
-            appdata_dir = Path(tmpdir) / "appdata"
-            appdata_dir.mkdir()
-
-            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir, "APPDATA": str(appdata_dir)}):
-                # WHEN
-                result = find_log_files_windows()
-
-                # THEN
-                assert len(result.c4d_detailed) == 1
-                assert result.c4d_detailed[0] == str(c4d_log)
-
-    def test_finds_bug_reports_on_windows(self, capsys):
-        """Test that bug reports are found on Windows"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            appdata_dir = Path(tmpdir) / "appdata"
-            maxon_dir = appdata_dir / "Maxon" / "cinema4d_12345" / "_bugreports"
-            maxon_dir.mkdir(parents=True)
-            bug_report = maxon_dir / "_BugReport.txt"
-            bug_report.write_text("bug report")
-
-            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir, "APPDATA": str(appdata_dir)}):
-                # WHEN
-                result = find_log_files_windows()
-
-                # THEN
-                assert len(result.bugreport) == 1
-                assert result.bugreport[0] == str(bug_report)
-
-    def test_handles_missing_appdata(self, capsys):
-        """Test that missing APPDATA is handled gracefully"""
-        # GIVEN
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}, clear=True):
-                # WHEN
-                result = find_log_files_windows()
-                captured = capsys.readouterr()
-
-                # THEN
-                assert result.bugreport == []
-                assert "APPDATA not set or doesn't exist" in captured.out
-
-
-class TestFindLogFiles:
-    """Test the find_log_files function"""
-
-    def test_prints_environment_variables(self, capsys):
-        """Test that environment variables are printed for debugging"""
-        # GIVEN
-        with mock.patch.dict(
-            os.environ,
-            {
-                "CONDA_PREFIX": "/test/path",
-                "HOME": "/home/user",
-                "USER": "testuser",
-                "REDSHIFT_LOCALDATAPATH": "/custom/redshift",
-                "REDSHIFT_COREDATAPATH": "/custom/core",
-            },
-        ):
-            with mock.patch("sys.platform", "linux"):
-                with mock.patch("os.path.expanduser", return_value="/home/user"):
-                    # WHEN
-                    find_log_files()
-                    captured = capsys.readouterr()
-
-                    # THEN
-                    assert "Environment variables:" in captured.out
-                    assert "CONDA_PREFIX: /test/path" in captured.out
-                    assert "HOME: /home/user" in captured.out
-                    assert "USER: testuser" in captured.out
-                    assert "REDSHIFT_LOCALDATAPATH: /custom/redshift" in captured.out
-                    assert "REDSHIFT_COREDATAPATH: /custom/core" in captured.out
-
-    def test_prints_not_set_for_missing_environment_variables(self, capsys):
-        """Test that 'NOT SET' is printed for missing environment variables"""
+                assert not os.path.exists(temp_log_dir)
+                assert f"Cleaned up temporary directory: {temp_log_dir}" in captured.out
+
+    def test_does_not_fail_when_temp_dir_not_set(self, capsys):
+        """Test that cleanup succeeds when C4D_DETAILED_LOG_DIR is not set"""
         # GIVEN
         with mock.patch.dict(os.environ, {}, clear=True):
-            with mock.patch("sys.platform", "linux"):
-                with mock.patch("os.path.expanduser", return_value="/home/user"):
+            # WHEN
+            _cleanup_temporary_directory()
+            captured = capsys.readouterr()
+
+            # THEN
+            # Should not print anything or fail
+            assert captured.out == ""
+
+    def test_does_not_fail_when_temp_dir_already_removed(self, capsys):
+        """Test that cleanup succeeds when temp directory doesn't exist"""
+        # GIVEN
+        nonexistent_dir = "/nonexistent/temp/dir"
+        with mock.patch.dict(os.environ, {"C4D_DETAILED_LOG_DIR": nonexistent_dir}):
+            # WHEN
+            _cleanup_temporary_directory()
+            captured = capsys.readouterr()
+
+            # THEN
+            # Should not print cleanup message for non-existent directory
+            assert "Cleaned up temporary directory" not in captured.out
+
+    def test_handles_cleanup_errors_gracefully(self, capsys):
+        """Test that cleanup errors are handled gracefully"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_log_dir = os.path.join(tmpdir, "c4d_logs_test")
+            os.makedirs(temp_log_dir)
+
+            with mock.patch.dict(os.environ, {"C4D_DETAILED_LOG_DIR": temp_log_dir}):
+                with mock.patch("shutil.rmtree", side_effect=PermissionError("Access denied")):
                     # WHEN
-                    find_log_files()
+                    _cleanup_temporary_directory()
                     captured = capsys.readouterr()
 
                     # THEN
-                    assert "CONDA_PREFIX: NOT SET" in captured.out
-                    assert "HOME: NOT SET" in captured.out
-                    assert "USER: NOT SET" in captured.out
-                    assert "REDSHIFT_LOCALDATAPATH: NOT SET" in captured.out
-                    assert "REDSHIFT_COREDATAPATH: NOT SET" in captured.out
+                    assert "Note: Could not clean up temporary directory" in captured.out
+                    assert "Access denied" in captured.out
 
 
 class TestPrintLogFile:
-    """Test the print_log_file function"""
+    """Test the print_log_file() function."""
 
     def test_prints_log_file_content(self, capsys):
         """Test that log file content is printed correctly"""
@@ -839,9 +819,9 @@ class TestPrintLogFile:
         """Test that unicode errors are handled with replace strategy"""
         # GIVEN
         with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".log") as tmp:
-            # Write some valid UTF-8 and some non_valid bytes
+            # Write some valid UTF-8 and some invalid bytes
             tmp.write(b"Valid text\n")
-            tmp.write(b"\xff\xfe non_valid bytes\n")
+            tmp.write(b"\xff\xfe invalid bytes\n")
             tmp.write(b"More valid text")
             tmp_path = tmp.name
 
@@ -854,7 +834,6 @@ class TestPrintLogFile:
             assert "UNICODE LOG:" in captured.out
             assert "Valid text" in captured.out
             assert "More valid text" in captured.out
-            # The non valid bytes should be replaced with replacement character
         finally:
             os.unlink(tmp_path)
 
@@ -878,7 +857,46 @@ class TestPrintLogFile:
 
 
 class TestPrintDetailedLogs:
-    """Test the print_detailed_logs function"""
+    """Test the print_detailed_logs() function."""
+
+    def test_guard_clause_for_disabled(self, capsys):
+        """Test that guard clause skips execution when enabled != "1" """
+        # WHEN
+        print_detailed_logs("0")
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "Detailed logging is deactivated, skipping log output." in captured.out
+        assert "openjd_unset_env" not in captured.out
+
+    def test_complete_workflow_when_enabled(self, capsys):
+        """Test that complete workflow executes when enabled == "1" """
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a Redshift log
+            log_dir = Path(tmpdir) / "redshiftlocaldata" / "log" / "log.latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("Redshift log content")
+
+            # Create a Cinema 4D detailed log
+            c4d_log = Path(tmpdir) / "c4d_detailed_logs.txt"
+            c4d_log.write_text("Cinema 4D detailed log content")
+
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    with mock.patch("sys.platform", "linux"):
+                        # WHEN
+                        print_detailed_logs("1")
+                        captured = capsys.readouterr()
+
+                        # THEN
+                        assert "Searching for log files..." in captured.out
+                        assert "REDSHIFT DEBUG LOG" in captured.out
+                        assert "CINEMA 4D DETAILED LOG" in captured.out
 
     def test_skips_when_deactivated(self, capsys):
         """Test that logging is skipped when deactivated"""

--- a/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_print_logs.py
+++ b/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_print_logs.py
@@ -3,18 +3,24 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from deadline.cinema4d_submitter.detailed_logging_scripts.print_logs import (
     FoundLogs,
-    _find_redshift_log,
+    _find_redshift_log_in_path,
+    _get_redshift_local_data_paths,
+    _find_c4d_detailed_log,
     _find_bug_reports,
     find_log_files_linux,
     find_log_files_windows,
     find_log_files,
     print_log_file,
+    print_detailed_logs,
 )
 
 
@@ -29,76 +35,239 @@ class TestFoundLogs:
         # THEN
         assert found_logs.redshift == []
         assert found_logs.bugreport == []
+        assert found_logs.c4d_detailed == []
 
     def test_initialization_with_values(self):
         """Test that FoundLogs can be initialized with values"""
         # GIVEN
         redshift_logs = ["/path/to/redshift.log"]
         bug_reports = ["/path/to/bugreport.txt"]
+        c4d_detailed_logs = ["/path/to/c4d_detailed_logs.txt"]
 
         # WHEN
-        found_logs = FoundLogs(redshift=redshift_logs, bugreport=bug_reports)
+        found_logs = FoundLogs(
+            redshift=redshift_logs, bugreport=bug_reports, c4d_detailed=c4d_detailed_logs
+        )
 
         # THEN
         assert found_logs.redshift == redshift_logs
         assert found_logs.bugreport == bug_reports
+        assert found_logs.c4d_detailed == c4d_detailed_logs
 
 
-class TestFindRedshiftLog:
-    """Test the _find_redshift_log function"""
+class TestFindRedshiftLogInPath:
+    """Test the _find_redshift_log_in_path function"""
 
-    def test_returns_empty_list_when_conda_prefix_not_set(self, capsys):
-        """Test that empty list is returned when CONDA_PREFIX is not set"""
+    def test_returns_empty_list_when_base_path_not_set(self, capsys):
+        """Test that empty list is returned when base_path is not set"""
         # WHEN
-        result = _find_redshift_log("", ["redshiftlocaldata", "log", "log.html"])
+        result = _find_redshift_log_in_path("", ["log", "log.html"])
         captured = capsys.readouterr()
 
         # THEN
         assert result == []
-        assert "CONDA_PREFIX not set or doesn't exist" in captured.out
+        assert captured.out == ""
 
-    def test_returns_empty_list_when_conda_prefix_does_not_exist(self, capsys):
-        """Test that empty list is returned when CONDA_PREFIX path doesn't exist"""
+    def test_returns_empty_list_when_base_path_does_not_exist(self, capsys):
+        """Test that empty list is returned when base_path doesn't exist"""
         # WHEN
-        result = _find_redshift_log("/nonexistent/path", ["redshiftlocaldata", "log"])
+        result = _find_redshift_log_in_path("/nonexistent/path", ["log", "log.html"])
         captured = capsys.readouterr()
 
         # THEN
         assert result == []
-        assert "CONDA_PREFIX not set or doesn't exist" in captured.out
+        assert captured.out == ""
 
     def test_returns_empty_list_when_log_file_not_found(self, capsys):
         """Test that empty list is returned when log file doesn't exist"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
             # WHEN
-            result = _find_redshift_log(tmpdir, ["redshiftlocaldata", "log", "log.html"])
+            result = _find_redshift_log_in_path(tmpdir, ["log", "log.latest.0", "log.html"])
             captured = capsys.readouterr()
 
             # THEN
             assert result == []
             assert "Checking for Redshift log at:" in captured.out
-            assert "Redshift log not found at expected location" in captured.out
 
     def test_returns_log_path_when_file_exists(self, capsys):
         """Test that log path is returned when file exists"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
-            log_dir = Path(tmpdir) / "redshiftlocaldata" / "log" / "log.latest.0"
+            log_dir = Path(tmpdir) / "log" / "log.latest.0"
             log_dir.mkdir(parents=True)
             log_file = log_dir / "log.html"
             log_file.write_text("test log content")
 
             # WHEN
-            result = _find_redshift_log(
-                tmpdir, ["redshiftlocaldata", "log", "log.latest.0", "log.html"]
-            )
+            result = _find_redshift_log_in_path(tmpdir, ["log", "log.latest.0", "log.html"])
             captured = capsys.readouterr()
 
             # THEN
             assert len(result) == 1
             assert result[0] == str(log_file)
             assert "Found Redshift log:" in captured.out
+
+
+class TestGetRedshiftLocalDataPaths:
+    """Test the _get_redshift_local_data_paths function"""
+
+    def test_returns_custom_path_when_env_var_set(self, capsys):
+        """Test that REDSHIFT_LOCALDATAPATH is prioritized when set"""
+        # GIVEN
+        custom_path = "/custom/redshift/path"
+        with mock.patch.dict(os.environ, {"REDSHIFT_LOCALDATAPATH": custom_path}, clear=True):
+            # WHEN
+            result = _get_redshift_local_data_paths()
+            captured = capsys.readouterr()
+
+            # THEN
+            assert custom_path in result
+            assert result[0] == custom_path
+            assert "Found REDSHIFT_LOCALDATAPATH environment variable" in captured.out
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
+    def test_returns_windows_default_paths(self):
+        """Test that Windows default paths are returned"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            result = _get_redshift_local_data_paths()
+
+            # THEN
+            assert r"C:\ProgramData\Redshift" in result
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific test")
+    def test_returns_linux_default_paths(self):
+        """Test that Linux default paths are returned"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("os.path.expanduser", return_value="/home/user"):
+                # WHEN
+                result = _get_redshift_local_data_paths()
+
+                # THEN
+                assert "/home/user/redshift" in result
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
+    def test_includes_conda_prefix_path_windows(self):
+        """Test that CONDA_PREFIX path is included on Windows"""
+        # GIVEN
+        conda_prefix = r"C:\conda\env"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}):
+            # WHEN
+            result = _get_redshift_local_data_paths()
+
+            # THEN
+            expected_path = os.path.join(conda_prefix, "cinema4d", "RedshiftData")
+            assert expected_path in result
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific test")
+    def test_includes_conda_prefix_path_linux(self):
+        """Test that CONDA_PREFIX path is included on Linux"""
+        # GIVEN
+        conda_prefix = "/opt/conda/env"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}):
+            with mock.patch("os.path.expanduser", return_value="/home/user"):
+                # WHEN
+                result = _get_redshift_local_data_paths()
+
+                # THEN
+                expected_path = os.path.join(conda_prefix, "redshiftlocaldata")
+                assert expected_path in result
+
+
+class TestFindC4DDetailedLog:
+    """Test the _find_c4d_detailed_log function"""
+
+    def test_checks_temp_directory_when_conda_prefix_not_set(self, capsys):
+        """Test that temp directory is checked when CONDA_PREFIX is not set"""
+        # WHEN
+        result = _find_c4d_detailed_log("")
+        captured = capsys.readouterr()
+
+        # THEN
+        assert result == []
+        assert "CONDA_PREFIX not set or doesn't exist" in captured.out
+        assert "Checking for Cinema 4D detailed log in temp directory:" in captured.out
+        assert "Cinema 4D detailed log not found in temp directory either" in captured.out
+
+    def test_checks_temp_directory_when_conda_prefix_does_not_exist(self, capsys):
+        """Test that temp directory is checked when CONDA_PREFIX path doesn't exist"""
+        # GIVEN - ensure temp directory is clean
+        temp_dir = tempfile.gettempdir()
+        temp_log_file = Path(temp_dir) / "c4d_detailed_logs.txt"
+        if temp_log_file.exists():
+            temp_log_file.unlink()
+
+        # WHEN
+        result = _find_c4d_detailed_log("/nonexistent/path")
+        captured = capsys.readouterr()
+
+        # THEN
+        assert result == []
+        assert "CONDA_PREFIX not set or doesn't exist" in captured.out
+        assert "Checking for Cinema 4D detailed log in temp directory:" in captured.out
+
+    def test_checks_temp_directory_when_log_not_in_conda_prefix(self, capsys):
+        """Test that temp directory is checked when log file doesn't exist in CONDA_PREFIX"""
+        # GIVEN - ensure temp directory is clean
+        temp_dir = tempfile.gettempdir()
+        temp_log_file = Path(temp_dir) / "c4d_detailed_logs.txt"
+        if temp_log_file.exists():
+            temp_log_file.unlink()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # WHEN
+            result = _find_c4d_detailed_log(tmpdir)
+            captured = capsys.readouterr()
+
+            # THEN
+            assert result == []
+            assert "Checking for Cinema 4D detailed log at:" in captured.out
+            assert "Cinema 4D detailed log not found in CONDA_PREFIX" in captured.out
+            assert "Checking for Cinema 4D detailed log in temp directory:" in captured.out
+            assert "Cinema 4D detailed log not found in temp directory either" in captured.out
+
+    def test_returns_log_path_when_file_exists_in_conda_prefix(self, capsys):
+        """Test that log path is returned when file exists in CONDA_PREFIX"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "c4d_detailed_logs.txt"
+            log_file.write_text("Cinema 4D detailed log content")
+
+            # WHEN
+            result = _find_c4d_detailed_log(tmpdir)
+            captured = capsys.readouterr()
+
+            # THEN
+            assert len(result) == 1
+            assert result[0] == str(log_file)
+            assert "Found Cinema 4D detailed log:" in captured.out
+
+    def test_returns_log_path_from_temp_directory_when_not_in_conda_prefix(self, capsys):
+        """Test that log path from temp directory is returned when not found in CONDA_PREFIX"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create log in temp directory
+            temp_dir = tempfile.gettempdir()
+            temp_log_file = Path(temp_dir) / "c4d_detailed_logs.txt"
+            temp_log_file.write_text("Cinema 4D detailed log in temp")
+
+            try:
+                # WHEN
+                result = _find_c4d_detailed_log(tmpdir)
+                captured = capsys.readouterr()
+
+                # THEN
+                assert len(result) == 1
+                assert result[0] == str(temp_log_file)
+                assert "Cinema 4D detailed log not found in CONDA_PREFIX" in captured.out
+                assert "Found Cinema 4D detailed log in temp directory:" in captured.out
+            finally:
+                # Clean up
+                if temp_log_file.exists():
+                    temp_log_file.unlink()
 
 
 class TestFindBugReports:
@@ -220,14 +389,57 @@ class TestFindBugReports:
                 assert "Error searching for bug reports:" in captured.out
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific tests")
 class TestFindLogFilesLinux:
     """Test the find_log_files_linux function"""
 
-    def test_finds_redshift_log_on_linux(self, capsys):
-        """Test that Redshift log is found on Linux"""
+    def test_finds_redshift_log_in_custom_path(self, capsys):
+        """Test that Redshift log is found in REDSHIFT_LOCALDATAPATH"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Create Redshift log
+            # Create Redshift log in custom path
+            log_dir = Path(tmpdir) / "log" / "log.latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("redshift log")
+
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"REDSHIFT_LOCALDATAPATH": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    # WHEN
+                    result = find_log_files_linux()
+
+                    # THEN
+                    assert len(result.redshift) == 1
+                    assert result.redshift[0] == str(log_file)
+
+    def test_finds_redshift_log_in_home_directory(self, capsys):
+        """Test that Redshift log is found in ~/redshift (default location)"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home_dir = Path(tmpdir) / "home"
+            redshift_dir = home_dir / "redshift" / "log" / "log.latest.0"
+            redshift_dir.mkdir(parents=True)
+            log_file = redshift_dir / "log.html"
+            log_file.write_text("redshift log")
+
+            with mock.patch.dict(os.environ, {}, clear=True):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    with mock.patch("sys.platform", "linux"):
+                        # WHEN
+                        result = find_log_files_linux()
+
+                        # THEN
+                        assert len(result.redshift) == 1
+                        assert result.redshift[0] == str(log_file)
+
+    def test_finds_redshift_log_in_conda_prefix(self, capsys):
+        """Test that Redshift log is found in CONDA_PREFIX"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create Redshift log in conda prefix
             log_dir = Path(tmpdir) / "redshiftlocaldata" / "log" / "log.latest.0"
             log_dir.mkdir(parents=True)
             log_file = log_dir / "log.html"
@@ -238,12 +450,78 @@ class TestFindLogFilesLinux:
 
             with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
                 with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    with mock.patch("sys.platform", "linux"):
+                        # WHEN
+                        result = find_log_files_linux()
+
+                        # THEN
+                        assert len(result.redshift) == 1
+                        assert result.redshift[0] == str(log_file)
+
+    def test_prioritizes_custom_path_over_defaults(self, capsys):
+        """Test that REDSHIFT_LOCALDATAPATH is checked after conda prefix but before default paths"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create log in custom path
+            custom_dir = Path(tmpdir) / "custom"
+            custom_log_dir = custom_dir / "log" / "log.latest.0"
+            custom_log_dir.mkdir(parents=True)
+            custom_log_file = custom_log_dir / "log.html"
+            custom_log_file.write_text("custom redshift log")
+
+            # Create log in default path (should be ignored)
+            home_dir = Path(tmpdir) / "home"
+            default_log_dir = home_dir / "redshift" / "log" / "log.latest.0"
+            default_log_dir.mkdir(parents=True)
+            default_log_file = default_log_dir / "log.html"
+            default_log_file.write_text("default redshift log")
+
+            with mock.patch.dict(os.environ, {"REDSHIFT_LOCALDATAPATH": str(custom_dir)}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    with mock.patch("sys.platform", "linux"):
+                        # WHEN
+                        result = find_log_files_linux()
+
+                        # THEN
+                        assert len(result.redshift) == 1
+                        assert result.redshift[0] == str(custom_log_file)
+
+    def test_prints_message_when_no_redshift_log_found(self, capsys):
+        """Test that appropriate message is printed when no Redshift log is found"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {}, clear=True):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    # WHEN
+                    result = find_log_files_linux()
+                    captured = capsys.readouterr()
+
+                    # THEN
+                    assert result.redshift == []
+                    assert "Redshift log not found in any expected location" in captured.out
+
+    def test_finds_c4d_detailed_log_on_linux(self, capsys):
+        """Test that Cinema 4D detailed log is found on Linux"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create Cinema 4D detailed log
+            c4d_log = Path(tmpdir) / "c4d_detailed_logs.txt"
+            c4d_log.write_text("Cinema 4D detailed log")
+
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
                     # WHEN
                     result = find_log_files_linux()
 
                     # THEN
-                    assert len(result.redshift) == 1
-                    assert result.redshift[0] == str(log_file)
+                    assert len(result.c4d_detailed) == 1
+                    assert result.c4d_detailed[0] == str(c4d_log)
 
     def test_finds_bug_reports_on_linux(self, capsys):
         """Test that bug reports are found on Linux"""
@@ -265,6 +543,7 @@ class TestFindLogFilesLinux:
                     assert result.bugreport[0] == str(bug_report)
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific tests")
 class TestFindLogFilesWindows:
     """Test the find_log_files_windows function"""
 
@@ -284,15 +563,147 @@ class TestFindLogFilesWindows:
                 assert isinstance(result, FoundLogs)
                 assert "Searching for log files..." in captured.out
 
-    def test_finds_redshift_log_on_windows(self, capsys):
-        """Test that Redshift log is found on Windows"""
+    def test_finds_redshift_log_in_custom_path(self, capsys):
+        """Test that Redshift log is found in REDSHIFT_LOCALDATAPATH"""
         # GIVEN
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Create Redshift log
+            # Create Redshift log in custom path
+            log_dir = Path(tmpdir) / "Log" / "Log.Latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("redshift log")
+
+            appdata_dir = Path(tmpdir) / "appdata"
+            appdata_dir.mkdir()
+
+            with mock.patch.dict(
+                os.environ, {"REDSHIFT_LOCALDATAPATH": tmpdir, "APPDATA": str(appdata_dir)}
+            ):
+                # WHEN
+                result = find_log_files_windows()
+
+                # THEN
+                assert len(result.redshift) == 1
+                assert result.redshift[0] == str(log_file)
+
+    def test_finds_redshift_log_in_programdata(self, capsys):
+        """Test that Redshift log is found in C:\\ProgramData\\Redshift (default location)"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Mock the default Windows path
+            programdata_dir = Path(tmpdir) / "ProgramData" / "Redshift"
+            log_dir = programdata_dir / "Log" / "Log.Latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("redshift log")
+
+            appdata_dir = Path(tmpdir) / "appdata"
+            appdata_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"APPDATA": str(appdata_dir)}, clear=True):
+                with mock.patch(
+                    "deadline.cinema4d_submitter.detailed_logging_scripts.print_logs._get_redshift_local_data_paths",
+                    return_value=[str(programdata_dir)],
+                ):
+                    # WHEN
+                    result = find_log_files_windows()
+
+                    # THEN
+                    assert len(result.redshift) == 1
+                    assert result.redshift[0] == str(log_file)
+
+    def test_finds_redshift_log_in_conda_prefix(self, capsys):
+        """Test that Redshift log is found in CONDA_PREFIX"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create Redshift log in conda prefix
             log_dir = Path(tmpdir) / "cinema4d" / "RedshiftData" / "Log" / "Log.Latest.0"
             log_dir.mkdir(parents=True)
             log_file = log_dir / "log.html"
             log_file.write_text("redshift log")
+
+            appdata_dir = Path(tmpdir) / "appdata"
+            appdata_dir.mkdir()
+
+            # Mock _get_redshift_local_data_paths to only return conda prefix path
+            conda_path = os.path.join(tmpdir, "cinema4d", "RedshiftData")
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir, "APPDATA": str(appdata_dir)}):
+                with mock.patch(
+                    "deadline.cinema4d_submitter.detailed_logging_scripts.print_logs._get_redshift_local_data_paths",
+                    return_value=[conda_path],
+                ):
+                    # WHEN
+                    result = find_log_files_windows()
+
+                    # THEN
+                    assert len(result.redshift) == 1
+                    assert result.redshift[0] == str(log_file)
+
+    def test_prioritizes_custom_path_over_defaults(self, capsys):
+        """Test that conda prefix is checked before REDSHIFT_LOCALDATAPATH"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create log in custom path (should be ignored since conda prefix is checked first)
+            custom_dir = Path(tmpdir) / "custom"
+            custom_log_dir = custom_dir / "Log" / "Log.Latest.0"
+            custom_log_dir.mkdir(parents=True)
+            custom_log_file = custom_log_dir / "log.html"
+            custom_log_file.write_text("custom redshift log")
+
+            # Create log in conda prefix (should be found first)
+            conda_dir = Path(tmpdir) / "conda"
+            conda_log_dir = conda_dir / "cinema4d" / "RedshiftData" / "Log" / "Log.Latest.0"
+            conda_log_dir.mkdir(parents=True)
+            conda_log_file = conda_log_dir / "log.html"
+            conda_log_file.write_text("conda redshift log")
+
+            appdata_dir = Path(tmpdir) / "appdata"
+            appdata_dir.mkdir()
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "REDSHIFT_LOCALDATAPATH": str(custom_dir),
+                    "CONDA_PREFIX": str(conda_dir),
+                    "APPDATA": str(appdata_dir),
+                },
+            ):
+                # WHEN
+                result = find_log_files_windows()
+
+                # THEN
+                assert len(result.redshift) == 1
+                # Conda prefix is checked first, so it should find the conda log
+                assert result.redshift[0] == str(conda_log_file)
+
+    def test_prints_message_when_no_redshift_log_found(self, capsys):
+        """Test that appropriate message is printed when no Redshift log is found"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            appdata_dir = Path(tmpdir) / "appdata"
+            appdata_dir.mkdir()
+
+            # Mock _get_redshift_local_data_paths to return non-existent paths
+            with mock.patch.dict(os.environ, {"APPDATA": str(appdata_dir)}, clear=True):
+                with mock.patch(
+                    "deadline.cinema4d_submitter.detailed_logging_scripts.print_logs._get_redshift_local_data_paths",
+                    return_value=["/nonexistent/path1", "/nonexistent/path2"],
+                ):
+                    # WHEN
+                    result = find_log_files_windows()
+                    captured = capsys.readouterr()
+
+                    # THEN
+                    assert result.redshift == []
+                    assert "Redshift log not found in any expected location" in captured.out
+
+    def test_finds_c4d_detailed_log_on_windows(self, capsys):
+        """Test that Cinema 4D detailed log is found on Windows"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create Cinema 4D detailed log
+            c4d_log = Path(tmpdir) / "c4d_detailed_logs.txt"
+            c4d_log.write_text("Cinema 4D detailed log")
 
             appdata_dir = Path(tmpdir) / "appdata"
             appdata_dir.mkdir()
@@ -302,8 +713,8 @@ class TestFindLogFilesWindows:
                 result = find_log_files_windows()
 
                 # THEN
-                assert len(result.redshift) == 1
-                assert result.redshift[0] == str(log_file)
+                assert len(result.c4d_detailed) == 1
+                assert result.c4d_detailed[0] == str(c4d_log)
 
     def test_finds_bug_reports_on_windows(self, capsys):
         """Test that bug reports are found on Windows"""
@@ -344,7 +755,14 @@ class TestFindLogFiles:
         """Test that environment variables are printed for debugging"""
         # GIVEN
         with mock.patch.dict(
-            os.environ, {"CONDA_PREFIX": "/test/path", "HOME": "/home/user", "USER": "testuser"}
+            os.environ,
+            {
+                "CONDA_PREFIX": "/test/path",
+                "HOME": "/home/user",
+                "USER": "testuser",
+                "REDSHIFT_LOCALDATAPATH": "/custom/redshift",
+                "REDSHIFT_COREDATAPATH": "/custom/core",
+            },
         ):
             with mock.patch("sys.platform", "linux"):
                 with mock.patch("os.path.expanduser", return_value="/home/user"):
@@ -357,6 +775,25 @@ class TestFindLogFiles:
                     assert "CONDA_PREFIX: /test/path" in captured.out
                     assert "HOME: /home/user" in captured.out
                     assert "USER: testuser" in captured.out
+                    assert "REDSHIFT_LOCALDATAPATH: /custom/redshift" in captured.out
+                    assert "REDSHIFT_COREDATAPATH: /custom/core" in captured.out
+
+    def test_prints_not_set_for_missing_environment_variables(self, capsys):
+        """Test that 'NOT SET' is printed for missing environment variables"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("sys.platform", "linux"):
+                with mock.patch("os.path.expanduser", return_value="/home/user"):
+                    # WHEN
+                    find_log_files()
+                    captured = capsys.readouterr()
+
+                    # THEN
+                    assert "CONDA_PREFIX: NOT SET" in captured.out
+                    assert "HOME: NOT SET" in captured.out
+                    assert "USER: NOT SET" in captured.out
+                    assert "REDSHIFT_LOCALDATAPATH: NOT SET" in captured.out
+                    assert "REDSHIFT_COREDATAPATH: NOT SET" in captured.out
 
 
 class TestPrintLogFile:
@@ -402,9 +839,9 @@ class TestPrintLogFile:
         """Test that unicode errors are handled with replace strategy"""
         # GIVEN
         with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".log") as tmp:
-            # Write some valid UTF-8 and some invalid bytes
+            # Write some valid UTF-8 and some non_valid bytes
             tmp.write(b"Valid text\n")
-            tmp.write(b"\xff\xfe Invalid bytes\n")
+            tmp.write(b"\xff\xfe non_valid bytes\n")
             tmp.write(b"More valid text")
             tmp_path = tmp.name
 
@@ -417,7 +854,7 @@ class TestPrintLogFile:
             assert "UNICODE LOG:" in captured.out
             assert "Valid text" in captured.out
             assert "More valid text" in captured.out
-            # The invalid bytes should be replaced with replacement character
+            # The non valid bytes should be replaced with replacement character
         finally:
             os.unlink(tmp_path)
 
@@ -438,3 +875,125 @@ class TestPrintLogFile:
             assert "END OF LOG" in captured.out
         finally:
             os.unlink(tmp_path)
+
+
+class TestPrintDetailedLogs:
+    """Test the print_detailed_logs function"""
+
+    def test_skips_when_deactivated(self, capsys):
+        """Test that logging is skipped when deactivated"""
+        # WHEN
+        print_detailed_logs("0")
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "Detailed logging is deactivated, skipping log output." in captured.out
+        assert "openjd_unset_env" not in captured.out
+
+    def test_prints_logs_when_enabled(self, capsys):
+        """Test that logs are printed when enabled"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a Redshift log
+            log_dir = Path(tmpdir) / "redshiftlocaldata" / "log" / "log.latest.0"
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "log.html"
+            log_file.write_text("Redshift log content")
+
+            # Create a Cinema 4D detailed log
+            c4d_log = Path(tmpdir) / "c4d_detailed_logs.txt"
+            c4d_log.write_text("Cinema 4D detailed log content")
+
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    with mock.patch("sys.platform", "linux"):
+                        # WHEN
+                        print_detailed_logs("1")
+                        captured = capsys.readouterr()
+
+                        # THEN
+                        assert "REDSHIFT DEBUG LOG" in captured.out
+                        assert "Redshift log content" in captured.out
+                        assert "CINEMA 4D DETAILED LOG" in captured.out
+                        assert "Cinema 4D detailed log content" in captured.out
+
+    def test_cleans_up_environment_variables_when_enabled(self, capsys):
+        """Test that environment variables are cleaned up after printing logs"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    with mock.patch("sys.platform", "linux"):
+                        # WHEN
+                        print_detailed_logs("1")
+                        captured = capsys.readouterr()
+
+                        # THEN
+                        assert "openjd_unset_env: g_alloc" in captured.out
+                        assert "openjd_unset_env: g_logfile" in captured.out
+                        assert "Environment variables cleaned up" in captured.out
+
+    def test_does_not_clean_up_when_deactivated(self, capsys):
+        """Test that environment variables are not cleaned up when logging is deactivated"""
+        # WHEN
+        print_detailed_logs("0")
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "openjd_unset_env" not in captured.out
+        assert "Environment variables cleaned up" not in captured.out
+
+    def test_prints_no_logs_found_messages(self, capsys):
+        """Test that appropriate messages are printed when no logs are found"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    with mock.patch("sys.platform", "linux"):
+                        # WHEN
+                        print_detailed_logs("1")
+                        captured = capsys.readouterr()
+
+                        # THEN
+                        assert "No Redshift debug logs (log.html) found." in captured.out
+                        assert (
+                            "No Cinema 4D detailed log (c4d_detailed_logs.txt) found."
+                            in captured.out
+                        )
+                        assert "No Cinema 4D bug reports (*_BugReport.txt) found." in captured.out
+                        # Still cleans up environment variables
+                        assert "openjd_unset_env: g_alloc" in captured.out
+                        assert "openjd_unset_env: g_logfile" in captured.out
+
+    def test_prints_bug_reports_when_found(self, capsys):
+        """Test that bug reports are printed when found"""
+        # GIVEN
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home_dir = Path(tmpdir) / "home"
+            maxon_dir = home_dir / "Maxon" / "bin_12345" / "_bugreports"
+            maxon_dir.mkdir(parents=True)
+            bug_report = maxon_dir / "_BugReport.txt"
+            bug_report.write_text("Bug report content")
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": tmpdir}):
+                with mock.patch("os.path.expanduser", return_value=str(home_dir)):
+                    with mock.patch("sys.platform", "linux"):
+                        # WHEN
+                        print_detailed_logs("1")
+                        captured = capsys.readouterr()
+
+                        # THEN
+                        assert "CINEMA 4D BUG REPORT" in captured.out
+                        assert "Bug report content" in captured.out
+                        # Still cleans up environment variables
+                        assert "openjd_unset_env: g_alloc" in captured.out
+                        assert "openjd_unset_env: g_logfile" in captured.out

--- a/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_setup_logging.py
+++ b/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_setup_logging.py
@@ -6,8 +6,236 @@ import os
 from unittest import mock
 
 from deadline.cinema4d_submitter.detailed_logging_scripts.setup_logging import (
+    get_conda_prefix,
     setup_debug_environment_variables,
+    _verify_redshift_debug_enabled,
+    _set_cinema4d_debug_mode,
+    _create_secure_temp_directory,
+    _get_log_directory,
+    _set_cinema4d_log_file,
 )
+
+
+class TestGetCondaPrefix:
+    """Test the get_conda_prefix() helper function."""
+
+    def test_returns_conda_prefix_when_set(self):
+        """Test that get_conda_prefix returns correct value when CONDA_PREFIX is set"""
+        # GIVEN
+        test_prefix = "/test/conda/prefix"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": test_prefix}, clear=True):
+            # WHEN
+            result = get_conda_prefix()
+
+            # THEN
+            assert result == test_prefix
+
+    def test_returns_empty_string_when_not_set(self):
+        """Test that get_conda_prefix returns empty string when CONDA_PREFIX is not set"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            result = get_conda_prefix()
+
+            # THEN
+            assert result == ""
+
+
+class TestVerifyRedshiftDebugEnabled:
+    """Test the _verify_redshift_debug_enabled() function."""
+
+    def test_prints_confirmation_when_enabled(self, capsys):
+        """Test that confirmation message is printed when REDSHIFT_DEBUGCAPTURE=1"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "1"}, clear=True):
+            # WHEN
+            _verify_redshift_debug_enabled()
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "Redshift debug logging is enabled (REDSHIFT_DEBUGCAPTURE=1)" in captured.out
+
+    def test_prints_warning_when_not_set(self, capsys):
+        """Test that warning is printed when REDSHIFT_DEBUGCAPTURE is not set"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            _verify_redshift_debug_enabled()
+            captured = capsys.readouterr()
+
+            # THEN
+            assert (
+                "Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'"
+                in captured.out
+            )
+
+    def test_prints_warning_when_wrong_value(self, capsys):
+        """Test that warning is printed when REDSHIFT_DEBUGCAPTURE has wrong value"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "0"}, clear=True):
+            # WHEN
+            _verify_redshift_debug_enabled()
+            captured = capsys.readouterr()
+
+            # THEN
+            assert (
+                "Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'"
+                in captured.out
+            )
+
+
+class TestSetCinema4dDebugMode:
+    """Test the _set_cinema4d_debug_mode() function."""
+
+    def test_prints_openjd_env_command(self, capsys):
+        """Test that correct openjd_env command is printed for g_alloc=debug"""
+        # WHEN
+        _set_cinema4d_debug_mode()
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "openjd_env: g_alloc=debug" in captured.out
+
+    def test_prints_confirmation_message(self, capsys):
+        """Test that confirmation message is printed"""
+        # WHEN
+        _set_cinema4d_debug_mode()
+        captured = capsys.readouterr()
+
+        # THEN
+        assert "Cinema 4D debug mode enabled (g_alloc=debug)" in captured.out
+
+
+class TestCreateSecureTempDirectory:
+    """Test the _create_secure_temp_directory() function."""
+
+    def test_creates_directory_with_prefix(self):
+        """Test that directory is created with c4d_logs_ prefix"""
+        # WHEN
+        result = _create_secure_temp_directory()
+
+        # THEN
+        assert os.path.exists(result)
+        assert os.path.isdir(result)
+        assert "c4d_logs_" in os.path.basename(result)
+
+        # Cleanup
+        os.rmdir(result)
+
+
+class TestGetLogDirectory:
+    """Test the _get_log_directory() function."""
+
+    def test_returns_conda_prefix_when_available(self):
+        """Test that CONDA_PREFIX is returned when available"""
+        # GIVEN
+        test_prefix = "/test/conda/prefix"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": test_prefix}, clear=True):
+            # WHEN
+            result = _get_log_directory()
+
+            # THEN
+            assert result == test_prefix
+
+    def test_creates_secure_temp_as_fallback(self, capsys):
+        """Test that secure temp directory is created as fallback"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            result = _get_log_directory()
+
+            # THEN
+            assert os.path.exists(result)
+            assert os.path.isdir(result)
+            assert "c4d_logs_" in os.path.basename(result)
+
+            # Cleanup
+            os.rmdir(result)
+
+    def test_prints_warning_for_fallback(self, capsys):
+        """Test that warning message is printed when using fallback"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            result = _get_log_directory()
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "Warning: CONDA_PREFIX not set, using secure temp directory:" in captured.out
+            assert result in captured.out
+
+            # Cleanup
+            os.rmdir(result)
+
+    def test_prints_openjd_env_for_temp_directory(self, capsys):
+        """Test that openjd_env command is printed for C4D_DETAILED_LOG_DIR"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            result = _get_log_directory()
+            captured = capsys.readouterr()
+
+            # THEN
+            assert f"openjd_env: C4D_DETAILED_LOG_DIR={result}" in captured.out
+
+            # Cleanup
+            os.rmdir(result)
+
+
+class TestSetCinema4dLogFile:
+    """Test the _set_cinema4d_log_file() function."""
+
+    def test_uses_conda_prefix_when_available(self, capsys):
+        """Test that log file path uses CONDA_PREFIX when available"""
+        # GIVEN
+        test_prefix = "/test/conda/prefix"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": test_prefix}, clear=True):
+            # WHEN
+            _set_cinema4d_log_file()
+            captured = capsys.readouterr()
+
+            # THEN
+            expected_path = os.path.join(test_prefix, "c4d_detailed_logs.txt")
+            assert f"openjd_env: g_logfile={expected_path}" in captured.out
+
+    def test_uses_secure_temp_as_fallback(self, capsys):
+        """Test that log file path uses secure temp directory as fallback"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # WHEN
+            _set_cinema4d_log_file()
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "openjd_env: g_logfile=" in captured.out
+            assert "c4d_logs_" in captured.out
+            assert "c4d_detailed_logs.txt" in captured.out
+
+    def test_prints_openjd_env_command(self, capsys):
+        """Test that correct openjd_env command is printed for g_logfile"""
+        # GIVEN
+        test_prefix = "/test/conda/prefix"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": test_prefix}, clear=True):
+            # WHEN
+            _set_cinema4d_log_file()
+            captured = capsys.readouterr()
+
+            # THEN
+            expected_path = os.path.join(test_prefix, "c4d_detailed_logs.txt")
+            assert f"openjd_env: g_logfile={expected_path}" in captured.out
+
+    def test_prints_confirmation_message(self, capsys):
+        """Test that confirmation message is printed"""
+        # GIVEN
+        test_prefix = "/test/conda/prefix"
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": test_prefix}, clear=True):
+            # WHEN
+            _set_cinema4d_log_file()
+            captured = capsys.readouterr()
+
+            # THEN
+            expected_path = os.path.join(test_prefix, "c4d_detailed_logs.txt")
+            assert f"Cinema 4D detailed logging enabled (g_logfile={expected_path})" in captured.out
 
 
 class TestSetupDebugEnvironmentVariables:
@@ -26,7 +254,7 @@ class TestSetupDebugEnvironmentVariables:
             # THEN
             assert "Redshift debug logging is enabled (REDSHIFT_DEBUGCAPTURE=1)" in captured.out
             assert "openjd_env: g_alloc=debug" in captured.out
-            assert "Cinema 4D memory debugging enabled (g_alloc=debug)" in captured.out
+            assert "Cinema 4D debug mode enabled (g_alloc=debug)" in captured.out
             assert "openjd_env: g_logfile=" in captured.out
             assert "c4d_detailed_logs.txt" in captured.out
             assert "Cinema 4D detailed logging enabled (g_logfile=" in captured.out
@@ -99,10 +327,8 @@ class TestSetupDebugEnvironmentVariables:
 
             # THEN
             assert "openjd_env: g_alloc=debug" in captured.out
-            assert "Cinema 4D memory debugging enabled (g_alloc=debug)" in captured.out
-            assert (
-                "Warning: CONDA_PREFIX not set, using temp directory for g_logfile" in captured.out
-            )
+            assert "Cinema 4D debug mode enabled (g_alloc=debug)" in captured.out
+            assert "Warning: CONDA_PREFIX not set, using secure temp directory:" in captured.out
             # g_logfile SHOULD be set to temp directory when CONDA_PREFIX is missing
             assert "openjd_env: g_logfile=" in captured.out
             assert "c4d_detailed_logs.txt" in captured.out
@@ -128,18 +354,17 @@ class TestSetupDebugEnvironmentVariables:
             assert f"openjd_env: g_logfile={expected_path}" in captured.out
             assert f"Cinema 4D detailed logging enabled (g_logfile={expected_path})" in captured.out
 
-    def test_temp_directory_fallback_uses_correct_path(self, capsys):
-        """Test that temp directory fallback uses the correct system temp path"""
+    def test_temp_directory_fallback_creates_secure_directory(self, capsys):
+        """Test that temp directory fallback creates a secure directory with proper prefix"""
         # GIVEN
-        import tempfile
-
         with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "1"}, clear=True):
             # WHEN
             setup_debug_environment_variables("1")
             captured = capsys.readouterr()
 
             # THEN
-            temp_dir = tempfile.gettempdir()
-            expected_path = os.path.join(temp_dir, "c4d_detailed_logs.txt")
-            assert f"openjd_env: g_logfile={expected_path}" in captured.out
-            assert f"Cinema 4D detailed logging enabled (g_logfile={expected_path})" in captured.out
+            # Should create a secure temp directory with c4d_logs_ prefix
+            assert "c4d_logs_" in captured.out
+            assert "openjd_env: g_logfile=" in captured.out
+            assert "c4d_detailed_logs.txt" in captured.out
+            assert "Cinema 4D detailed logging enabled (g_logfile=" in captured.out

--- a/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_setup_logging.py
+++ b/test/unit/deadline_submitter_for_cinema4d/detailed_logging_scripts/test_setup_logging.py
@@ -6,30 +6,37 @@ import os
 from unittest import mock
 
 from deadline.cinema4d_submitter.detailed_logging_scripts.setup_logging import (
-    verify_debug_environment_variables,
+    setup_debug_environment_variables,
 )
 
 
-class TestVerifyDebugEnvironmentVariables:
-    """Test the verify_debug_environment_variables function"""
+class TestSetupDebugEnvironmentVariables:
+    """Test the setup_debug_environment_variables function"""
 
     def test_prints_confirmation_when_environment_variable_is_set(self, capsys):
         """Test that confirmation message is printed when REDSHIFT_DEBUGCAPTURE is set"""
         # GIVEN
-        with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "1"}, clear=True):
+        with mock.patch.dict(
+            os.environ, {"REDSHIFT_DEBUGCAPTURE": "1", "CONDA_PREFIX": "/test/conda"}, clear=True
+        ):
             # WHEN
-            verify_debug_environment_variables("1")
+            setup_debug_environment_variables("1")
             captured = capsys.readouterr()
 
             # THEN
             assert "Redshift debug logging is enabled (REDSHIFT_DEBUGCAPTURE=1)" in captured.out
+            assert "openjd_env: g_alloc=debug" in captured.out
+            assert "Cinema 4D memory debugging enabled (g_alloc=debug)" in captured.out
+            assert "openjd_env: g_logfile=" in captured.out
+            assert "c4d_detailed_logs.txt" in captured.out
+            assert "Cinema 4D detailed logging enabled (g_logfile=" in captured.out
 
     def test_prints_warning_when_environment_variable_not_set(self, capsys):
         """Test that warning is printed when REDSHIFT_DEBUGCAPTURE is not set"""
         # GIVEN
-        with mock.patch.dict(os.environ, {}, clear=True):
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": "/test/conda"}, clear=True):
             # WHEN
-            verify_debug_environment_variables("1")
+            setup_debug_environment_variables("1")
             captured = capsys.readouterr()
 
             # THEN
@@ -37,13 +44,18 @@ class TestVerifyDebugEnvironmentVariables:
                 "Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'"
                 in captured.out
             )
+            # Cinema 4D environment variables should still be set
+            assert "openjd_env: g_alloc=debug" in captured.out
+            assert "openjd_env: g_logfile=" in captured.out
 
     def test_prints_warning_when_environment_variable_has_wrong_value(self, capsys):
         """Test that warning is printed when REDSHIFT_DEBUGCAPTURE has wrong value"""
         # GIVEN
-        with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "0"}, clear=True):
+        with mock.patch.dict(
+            os.environ, {"REDSHIFT_DEBUGCAPTURE": "0", "CONDA_PREFIX": "/test/conda"}, clear=True
+        ):
             # WHEN
-            verify_debug_environment_variables("1")
+            setup_debug_environment_variables("1")
             captured = capsys.readouterr()
 
             # THEN
@@ -51,25 +63,83 @@ class TestVerifyDebugEnvironmentVariables:
                 "Warning: Detailed logging requested but REDSHIFT_DEBUGCAPTURE is not set to '1'"
                 in captured.out
             )
+            # Cinema 4D environment variables should still be set
+            assert "openjd_env: g_alloc=debug" in captured.out
+            assert "openjd_env: g_logfile=" in captured.out
 
-    def test_skips_verification_when_disabled(self, capsys):
-        """Test that verification is skipped when disabled"""
+    def test_skips_verification_when_deactivated(self, capsys):
+        """Test that verification is skipped when deactivated"""
         # GIVEN
         with mock.patch.dict(os.environ, {}, clear=True):
             # WHEN
-            verify_debug_environment_variables("0")
+            setup_debug_environment_variables("0")
             captured = capsys.readouterr()
 
             # THEN
-            assert "Detailed logging is disabled, skipping setup." in captured.out
+            assert "Detailed logging is deactivated, skipping setup." in captured.out
 
-    def test_skips_verification_with_invalid_value(self, capsys):
-        """Test that verification is skipped with invalid value"""
+    def test_skips_verification_with_non_valid_value(self, capsys):
+        """Test that verification is skipped with non_valid value"""
         # GIVEN
         with mock.patch.dict(os.environ, {}, clear=True):
             # WHEN
-            verify_debug_environment_variables("invalid")
+            setup_debug_environment_variables("non_valid")
             captured = capsys.readouterr()
 
             # THEN
-            assert "Detailed logging is disabled, skipping setup." in captured.out
+            assert "Detailed logging is deactivated, skipping setup." in captured.out
+
+    def test_uses_temp_directory_when_conda_prefix_not_set(self, capsys):
+        """Test that temp directory is used as fallback when CONDA_PREFIX is not set"""
+        # GIVEN
+        with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "1"}, clear=True):
+            # WHEN
+            setup_debug_environment_variables("1")
+            captured = capsys.readouterr()
+
+            # THEN
+            assert "openjd_env: g_alloc=debug" in captured.out
+            assert "Cinema 4D memory debugging enabled (g_alloc=debug)" in captured.out
+            assert (
+                "Warning: CONDA_PREFIX not set, using temp directory for g_logfile" in captured.out
+            )
+            # g_logfile SHOULD be set to temp directory when CONDA_PREFIX is missing
+            assert "openjd_env: g_logfile=" in captured.out
+            assert "c4d_detailed_logs.txt" in captured.out
+            assert "Cinema 4D detailed logging enabled (g_logfile=" in captured.out
+
+    def test_sets_cinema4d_variables_with_cross_platform_path(self, capsys):
+        """Test that Cinema 4D variables are set with cross-platform path construction"""
+        # GIVEN
+        test_conda_prefix = "/test/conda/prefix"
+        with mock.patch.dict(
+            os.environ,
+            {"REDSHIFT_DEBUGCAPTURE": "1", "CONDA_PREFIX": test_conda_prefix},
+            clear=True,
+        ):
+            # WHEN
+            setup_debug_environment_variables("1")
+            captured = capsys.readouterr()
+
+            # THEN
+            # Verify the log file path uses the constant
+            assert "c4d_detailed_logs.txt" in captured.out
+            expected_path = os.path.join(test_conda_prefix, "c4d_detailed_logs.txt")
+            assert f"openjd_env: g_logfile={expected_path}" in captured.out
+            assert f"Cinema 4D detailed logging enabled (g_logfile={expected_path})" in captured.out
+
+    def test_temp_directory_fallback_uses_correct_path(self, capsys):
+        """Test that temp directory fallback uses the correct system temp path"""
+        # GIVEN
+        import tempfile
+
+        with mock.patch.dict(os.environ, {"REDSHIFT_DEBUGCAPTURE": "1"}, clear=True):
+            # WHEN
+            setup_debug_environment_variables("1")
+            captured = capsys.readouterr()
+
+            # THEN
+            temp_dir = tempfile.gettempdir()
+            expected_path = os.path.join(temp_dir, "c4d_detailed_logs.txt")
+            assert f"openjd_env: g_logfile={expected_path}" in captured.out
+            assert f"Cinema 4D detailed logging enabled (g_logfile={expected_path})" in captured.out


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

This is a follow up to https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/342 and adds Cinema 4D debug logging (we only added Redshift and Cinema 4D crash reports earlier)

### What was the solution? (How)

Add Cinema 4D debug logging. 
There was also a comment in my previous PR to use the different Redshift env variables for CMF. So updated that. 

### What is the impact of this change?

We will now even log the Cinema 4D debug logging. 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Currently running it. 

- Have you made changes to the submitter?
Yes but doesn't require any changes to helper. 

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*