### PR TITLE
fix(submitter): exclude Maxon DB assets from job bundle references

### DIFF
--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -11,9 +11,12 @@ from .platform_utils import is_windows
 from .scene import Scene
 from .font_utils import is_asset_a_font, copy_font_to_scene_folder, FONTS_DIR
 from .warning_collector import warning_collector
+from .warning_logging_handler import WarningCollectorHandler
 from .path_validator import validate_asset_paths
 
 logger = logging.getLogger(__name__)
+if not any(isinstance(h, WarningCollectorHandler) for h in logger.handlers):
+    logger.addHandler(WarningCollectorHandler())
 
 _FRAME_RE = re.compile("#+")
 
@@ -48,8 +51,6 @@ class AssetIntrospector:
             flags=c4d.ASSETDATA_FLAG_WITHFONTS,
         )
 
-        print(f"[Deadline Cloud] Total assets found: {len(asset_list)}")
-
         for asset in asset_list:
             # Only process fonts on Windows. Mac font functionality is not supported
             if is_windows() and is_asset_a_font(asset):
@@ -58,13 +59,9 @@ class AssetIntrospector:
             filename = asset.get("filename", None)
             exists = asset.get("exists", False)
 
-            # Debug: print all filenames to see what we're getting
-            if filename:
-                print(f"[Deadline Cloud] Asset: {filename} (exists={exists})")
-
             # Filter out Maxon DB assets (starting with "asset:" or "assetdb://") as they don't exist on local filesystem
             if filename is not None and filename.startswith(("asset:", "assetdb://")):
-                print(f"[Deadline Cloud] *** EXCLUDING Maxon DB asset: {filename}")
+                logger.warning(f"Excluding Maxon DB asset from job bundle: {filename}")
             elif exists is True and filename is not None:
                 assets.add(Path(filename))
 

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -62,7 +62,9 @@ class AssetIntrospector:
             # Filter out Maxon DB assets (starting with "asset:" or "assetdb://") as they don't exist on local filesystem
             if filename is not None and filename.startswith(("asset:", "assetdb://")):
                 logger.warning(f"Excluding Maxon DB asset from job bundle: {filename}")
-            elif exists is True and filename is not None:
+                continue
+
+            if exists is True and filename is not None:
                 assets.add(Path(filename))
 
         # Add all font files from the fonts directory to assets (Windows only)

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -61,7 +61,10 @@ class AssetIntrospector:
 
             # Filter out Maxon DB assets (starting with "asset:" or "assetdb://") as they don't exist on local filesystem
             if filename is not None and filename.startswith(("asset:", "assetdb://")):
-                logger.warning(f"Excluding Maxon DB asset from job bundle: {filename}")
+                logger.warning(
+                    f"Excluding Maxon DB asset from job bundle: {filename}\n"
+                    "To include assets with job submission, use 'File > Save Project with Assets' to localize them first."
+                )
                 continue
 
             if exists is True and filename is not None:

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -49,7 +49,7 @@ class AssetIntrospector:
         )
 
         print(f"[Deadline Cloud] Total assets found: {len(asset_list)}")
-        
+
         for asset in asset_list:
             # Only process fonts on Windows. Mac font functionality is not supported
             if is_windows() and is_asset_a_font(asset):
@@ -57,11 +57,11 @@ class AssetIntrospector:
 
             filename = asset.get("filename", None)
             exists = asset.get("exists", False)
-            
+
             # Debug: print all filenames to see what we're getting
             if filename:
                 print(f"[Deadline Cloud] Asset: {filename} (exists={exists})")
-            
+
             # Filter out Maxon DB assets (starting with "asset:" or "assetdb://") as they don't exist on local filesystem
             if filename is not None and filename.startswith(("asset:", "assetdb://")):
                 print(f"[Deadline Cloud] *** EXCLUDING Maxon DB asset: {filename}")

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -63,6 +63,7 @@ class AssetIntrospector:
             if filename is not None and filename.startswith(("asset:", "assetdb://")):
                 logger.warning(
                     f"Excluding Maxon DB asset from job bundle: {filename}\n"
+                    "These assets will be downloaded directly from Maxon during the render. "
                     "To include assets with job submission, use 'File > Save Project with Assets' to localize them first."
                 )
                 continue

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 
@@ -11,6 +12,8 @@ from .scene import Scene
 from .font_utils import is_asset_a_font, copy_font_to_scene_folder, FONTS_DIR
 from .warning_collector import warning_collector
 from .path_validator import validate_asset_paths
+
+logger = logging.getLogger(__name__)
 
 _FRAME_RE = re.compile("#+")
 
@@ -45,6 +48,8 @@ class AssetIntrospector:
             flags=c4d.ASSETDATA_FLAG_WITHFONTS,
         )
 
+        print(f"[Deadline Cloud] Total assets found: {len(asset_list)}")
+        
         for asset in asset_list:
             # Only process fonts on Windows. Mac font functionality is not supported
             if is_windows() and is_asset_a_font(asset):
@@ -52,7 +57,15 @@ class AssetIntrospector:
 
             filename = asset.get("filename", None)
             exists = asset.get("exists", False)
-            if exists is True and filename is not None:
+            
+            # Debug: print all filenames to see what we're getting
+            if filename:
+                print(f"[Deadline Cloud] Asset: {filename} (exists={exists})")
+            
+            # Filter out Maxon DB assets (starting with "asset:" or "assetdb://") as they don't exist on local filesystem
+            if filename is not None and filename.startswith(("asset:", "assetdb://")):
+                print(f"[Deadline Cloud] *** EXCLUDING Maxon DB asset: {filename}")
+            elif exists is True and filename is not None:
                 assets.add(Path(filename))
 
         # Add all font files from the fonts directory to assets (Windows only)

--- a/test/unit/deadline_submitter_for_cinema4d/test_assets.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_assets.py
@@ -215,3 +215,55 @@ class TestAssetIntrospectorFonts:
             assert {scene_file, Path("C:\\Users\\test-user\\texture.png"), font_file}.issubset(
                 assets
             )
+
+
+class TestMaxonDBAssets:
+    """Test Maxon DB asset filtering and warning messages"""
+
+    @pytest.mark.parametrize(
+        "asset_filename,should_exclude",
+        [
+            ("asset://some-asset-id", True),
+            ("assetdb://another-asset", True),
+            ("C:\\\\Users\\\\test-user\\\\texture.png", False),
+            ("/home/user/texture.png", False),
+        ],
+    )
+    def test_maxon_db_asset_exclusion(self, asset_filename, should_exclude, caplog):
+        """Test that Maxon DB assets are excluded from job bundle"""
+        with (
+            mock.patch.object(Scene, "name", return_value=TEST_SCENE_FILE_LOCATION),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [{"filename": asset_filename, "exists": True}], kwargs["assetList"]
+            )
+
+            assets = AssetIntrospector().parse_scene_assets()
+
+            if should_exclude:
+                assert Path(asset_filename) not in assets
+                assert "Excluding Maxon DB asset from job bundle" in caplog.text
+                assert "downloaded directly from Maxon during the render" in caplog.text
+            else:
+                assert Path(asset_filename) in assets
+
+    def test_maxon_db_warning_message_content(self, caplog):
+        """Test the complete warning message for Maxon DB assets"""
+        maxon_asset = "asset://test-asset-123"
+        with (
+            mock.patch.object(Scene, "name", return_value=TEST_SCENE_FILE_LOCATION),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [{"filename": maxon_asset, "exists": True}], kwargs["assetList"]
+            )
+
+            AssetIntrospector().parse_scene_assets()
+
+            assert maxon_asset in caplog.text
+            assert (
+                "These assets will be downloaded directly from Maxon during the render"
+                in caplog.text
+            )
+            assert "File > Save Project with Assets" in caplog.text


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/300

### What was the problem/requirement? (What/Why)
When I submit a job that references Maxon DB assets (e.g. the Showroom Template example), the Maxon DB assets are included in the asset_references.yaml file, even though they do not exist on the local filesystem, and still render correctly without them being included in the job submission (since they're downloaded from Maxon's asset DB).

### What was the solution? (How)
Added a prefix filter in AssetIntrospector.parse_scene_assets() to exclude Maxon Database assets from the collected asset list. The solution checks if asset filenames start with "asset:" or "assetdb://" prefixes and logs excluded assets to the Cinema 4D console for user visibility. These prefixes identify cloud-based assets that Cinema 4D automatically downloads from Maxon's servers at render time, so they don't need to be included in the job bundle's asset references.

<img width="541" height="726" alt="Screenshot 2025-11-24 at 2 02 00 PM" src="https://github.com/user-attachments/assets/307f0bb5-ecc7-4942-9830-d8c6906d7b38" />


<img width="495" height="427" alt="Screenshot 2025-11-25 at 12 17 18 PM" src="https://github.com/user-attachments/assets/7de41a9e-4ba6-464d-9420-223190fe2b33" />



### What is the impact of this change?
**User Experience:**
- Eliminates false "missing assets" warnings during job submission
- Removes misleading "Job submission confirmation" popups about S3 uploads for Maxon DB assets
- Prevents unnecessary "sync attachments" sessions in task logs
- Provides transparency via info logs showing which Maxon DB assets were excluded

**Technical:**
- Maxon DB assets (HDRIs, materials, models from Maxon's asset database) are no longer included in asset_references.yaml
- Job bundles are cleaner and only contain actual local filesystem assets
- No impact on rendering - Maxon DB assets still work correctly as Cinema 4D handles them automatically
- Console logging allows users to verify expected assets were excluded

**Backward Compatibility:**
- Fully backward compatible - only filters out non-existent cloud assets that were causing false warnings

### How was this change tested?

**Recommended testing:**
- Opened Cinema 4D 2024/2025 and loaded the Showroom Template scene (contains Maxon DB assets)
- Submitted job using AWS Deadline Cloud Submitter without "Bundled job submission" option
- Verified no "missing assets" warnings appear during submission
- Verified no S3 upload confirmation dialog appears
- Checked Cinema 4D console contains entries like: [Deadline Cloud] *** EXCLUDING Maxon DB asset: assetdb:///HDRIs/Studio/hdr-light-studio_17.exr
- Verified job renders successfully with Maxon DB assets
- Checked task logs confirm no unnecessary "sync attachments" sessions
- Tested with scenes containing both local assets and Maxon DB assets to ensure local assets are still properly included and only Maxon DB assets are logged as excluded

- Have you made changes to the submitter?
Yes, I have made changes to the submitter. Specifically:
File modified: src/deadline/cinema4d_submitter/assets.py

### Was this change documented?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*