### PR TITLE
fix: resolve  token per-take for marked takes submissions

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -236,7 +236,7 @@ class Cinema4DHandler:
             # Reloading the document will allow the next frame to have correct data.
             self._reload_document()
 
-        self.render_data = self.doc.GetActiveRenderData()
+        self.render_data = self._get_take_render_data(self.doc)
         self.render_data[c4d.RDATA_FRAMESEQUENCE] = c4d.RDATA_FRAMESEQUENCE_MANUAL
         self.render_kwargs[FRAME_KEY] = int(self.render_kwargs.get(FRAME_KEY, data[FRAME_KEY]))
         frame = self.render_kwargs[FRAME_KEY]
@@ -246,9 +246,21 @@ class Cinema4DHandler:
         self.render_data[c4d.RDATA_FRAMETO] = frame_time
         self.render_data[c4d.RDATA_FRAMESTEP] = 1
 
-        if self.render_data[c4d.RDATA_PATH]:
+        # Resolve and set output paths with tokens like $take, $prj
+        if OUTPUT_PATH_KEY in self.render_kwargs and self.render_kwargs[OUTPUT_PATH_KEY]:
+            resolved_path = self._resolve_render_tokens(
+                self.render_kwargs[OUTPUT_PATH_KEY], self.doc, self.render_data
+            )
+            self.render_data[c4d.RDATA_PATH] = self.map_path(resolved_path)
+        elif self.render_data[c4d.RDATA_PATH]:
             self.render_data[c4d.RDATA_PATH] = self.map_path(self.render_data[c4d.RDATA_PATH])
-        if (
+
+        if MULTIPASS_PATH_KEY in self.render_kwargs and self.render_kwargs[MULTIPASS_PATH_KEY]:
+            resolved_path = self._resolve_render_tokens(
+                self.render_kwargs[MULTIPASS_PATH_KEY], self.doc, self.render_data
+            )
+            self.render_data[c4d.RDATA_MULTIPASS_FILENAME] = self.map_path(resolved_path)
+        elif (
             self.render_data[c4d.RDATA_MULTIPASS_SAVEIMAGE]
             and self.render_data[c4d.RDATA_MULTIPASS_FILENAME]
         ):
@@ -283,18 +295,38 @@ class Cinema4DHandler:
     def output_path(self, data: dict) -> None:
         output_path = data.get(OUTPUT_PATH_KEY, "")
         self.render_kwargs[OUTPUT_PATH_KEY] = output_path
-        if output_path:
-            doc = c4d.documents.GetActiveDocument()
-            render_data = doc.GetActiveRenderData()
-            render_data[c4d.RDATA_PATH] = self.map_path(output_path)
 
     def multi_pass_path(self, data: dict) -> None:
         multi_pass_path = data.get(MULTIPASS_PATH_KEY, "")
         self.render_kwargs[MULTIPASS_PATH_KEY] = multi_pass_path
-        if multi_pass_path:
-            doc = c4d.documents.GetActiveDocument()
-            render_data = doc.GetActiveRenderData()
-            render_data[c4d.RDATA_MULTIPASS_FILENAME] = self.map_path(multi_pass_path)
+
+    def _get_take_render_data(self, doc):
+        """Get the render data for the current take."""
+        take_data = doc.GetTakeData()
+        if take_data:
+            current_take = take_data.GetCurrentTake()
+            take_erd = current_take.GetEffectiveRenderData(take_data)
+            if take_erd:
+                return take_erd[0]
+        return doc.GetActiveRenderData()
+
+    def _resolve_render_tokens(self, path, doc, render_data):
+        """Resolve Cinema 4D render tokens like $take, $prj, etc."""
+        take_data = doc.GetTakeData()
+        current_take = take_data.GetCurrentTake() if take_data else None
+        
+        render_path_data = {
+            "_doc": doc,
+            "_rData": render_data,
+            "_rBc": render_data.GetDataInstance(),
+            "_frame": doc.GetTime().GetFrame(doc.GetFps()),
+        }
+        if current_take:
+            render_path_data["_take"] = current_take
+        
+        resolved = c4d.modules.tokensystem.FilenameConvertTokens(path, render_path_data)
+        print(f"Token resolution: '{path}' -> '{resolved}' (take: {current_take.GetName() if current_take else 'None'})")
+        return resolved
 
     def set_take(self, data: dict) -> None:
         """

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -314,7 +314,7 @@ class Cinema4DHandler:
         """Resolve Cinema 4D render tokens like $take, $prj, etc."""
         take_data = doc.GetTakeData()
         current_take = take_data.GetCurrentTake() if take_data else None
-        
+
         render_path_data = {
             "_doc": doc,
             "_rData": render_data,
@@ -323,9 +323,11 @@ class Cinema4DHandler:
         }
         if current_take:
             render_path_data["_take"] = current_take
-        
+
         resolved = c4d.modules.tokensystem.FilenameConvertTokens(path, render_path_data)
-        print(f"Token resolution: '{path}' -> '{resolved}' (take: {current_take.GetName() if current_take else 'None'})")
+        print(
+            f"Token resolution: '{path}' -> '{resolved}' (take: {current_take.GetName() if current_take else 'None'})"
+        )
         return resolved
 
     def set_take(self, data: dict) -> None:

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -478,24 +478,60 @@ def create_job_bundle(
     elif settings.take_selection == TakeSelection.CURRENT:
         submit_takes = takes["current_data_list"]
 
-    # Add overrides to asset references and update the paths with C4D render path tokens.
+    # Resolve output paths per-take to properly handle $take tokens
+    doc = c4d.documents.GetActiveDocument()
+    take_data_obj = doc.GetTakeData()
+    
+    def find_take_by_name(take_data_obj, name):
+        """Find a take by name in the take hierarchy."""
+        main_take = take_data_obj.GetMainTake()
+        
+        def search_take(take, target_name):
+            if take.GetName() == target_name:
+                return take
+            for child in take.GetChildren():
+                result = search_take(child, target_name)
+                if result:
+                    return result
+            return None
+        
+        return search_take(main_take, name)
+    
+    for take_data in submit_takes:
+        take_obj = find_take_by_name(take_data_obj, take_data.name)
+        
+        if settings.override_output_path:
+            if settings.output_path:
+                resolved_path = Scene.replace_render_path_tokens(settings.output_path, doc=doc, take=take_obj)
+                asset_references.output_directories.add(os.path.dirname(resolved_path))
+        else:
+            if scene_output_path:
+                resolved_path = Scene.replace_render_path_tokens(scene_output_path, doc=doc, take=take_obj)
+                asset_references.output_directories.add(os.path.dirname(resolved_path))
+        
+        if settings.override_multi_pass_path:
+            if settings.multi_pass_path:
+                resolved_path = Scene.replace_render_path_tokens(settings.multi_pass_path, doc=doc, take=take_obj)
+                asset_references.output_directories.add(os.path.dirname(resolved_path))
+        else:
+            if scene_multi_pass_path:
+                resolved_path = Scene.replace_render_path_tokens(scene_multi_pass_path, doc=doc, take=take_obj)
+                asset_references.output_directories.add(os.path.dirname(resolved_path))
+    
+    # Set the global output paths (these will be used as fallback in parameter values)
     if settings.override_output_path:
         if settings.output_path:
             settings.output_path = Scene.replace_render_path_tokens(settings.output_path)
-            asset_references.output_directories.add(os.path.dirname(settings.output_path))
     else:
         if scene_output_path:
             settings.output_path = Scene.replace_render_path_tokens(scene_output_path)
-            asset_references.output_directories.add(os.path.dirname(scene_output_path))
-
+    
     if settings.override_multi_pass_path:
         if settings.multi_pass_path:
             settings.multi_pass_path = Scene.replace_render_path_tokens(settings.multi_pass_path)
-            asset_references.output_directories.add(os.path.dirname(settings.multi_pass_path))
     else:
         if scene_multi_pass_path:
             settings.multi_pass_path = Scene.replace_render_path_tokens(scene_multi_pass_path)
-            asset_references.output_directories.add(os.path.dirname(scene_multi_pass_path))
 
     # # Check if there are multiple frame ranges across the takes
     first_frame_range = submit_takes[0].frame_range

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -481,11 +481,11 @@ def create_job_bundle(
     # Resolve output paths per-take to properly handle $take tokens
     doc = c4d.documents.GetActiveDocument()
     take_data_obj = doc.GetTakeData()
-    
+
     def find_take_by_name(take_data_obj, name):
         """Find a take by name in the take hierarchy."""
         main_take = take_data_obj.GetMainTake()
-        
+
         def search_take(take, target_name):
             if take.GetName() == target_name:
                 return take
@@ -494,30 +494,38 @@ def create_job_bundle(
                 if result:
                     return result
             return None
-        
+
         return search_take(main_take, name)
-    
+
     for take_data in submit_takes:
         take_obj = find_take_by_name(take_data_obj, take_data.name)
-        
+
         if settings.override_output_path:
             if settings.output_path:
-                resolved_path = Scene.replace_render_path_tokens(settings.output_path, doc=doc, take=take_obj)
+                resolved_path = Scene.replace_render_path_tokens(
+                    settings.output_path, doc=doc, take=take_obj
+                )
                 asset_references.output_directories.add(os.path.dirname(resolved_path))
         else:
             if scene_output_path:
-                resolved_path = Scene.replace_render_path_tokens(scene_output_path, doc=doc, take=take_obj)
+                resolved_path = Scene.replace_render_path_tokens(
+                    scene_output_path, doc=doc, take=take_obj
+                )
                 asset_references.output_directories.add(os.path.dirname(resolved_path))
-        
+
         if settings.override_multi_pass_path:
             if settings.multi_pass_path:
-                resolved_path = Scene.replace_render_path_tokens(settings.multi_pass_path, doc=doc, take=take_obj)
+                resolved_path = Scene.replace_render_path_tokens(
+                    settings.multi_pass_path, doc=doc, take=take_obj
+                )
                 asset_references.output_directories.add(os.path.dirname(resolved_path))
         else:
             if scene_multi_pass_path:
-                resolved_path = Scene.replace_render_path_tokens(scene_multi_pass_path, doc=doc, take=take_obj)
+                resolved_path = Scene.replace_render_path_tokens(
+                    scene_multi_pass_path, doc=doc, take=take_obj
+                )
                 asset_references.output_directories.add(os.path.dirname(resolved_path))
-    
+
     # Set the global output paths (these will be used as fallback in parameter values)
     if settings.override_output_path:
         if settings.output_path:
@@ -525,7 +533,7 @@ def create_job_bundle(
     else:
         if scene_output_path:
             settings.output_path = Scene.replace_render_path_tokens(scene_output_path)
-    
+
     if settings.override_multi_pass_path:
         if settings.multi_pass_path:
             settings.multi_pass_path = Scene.replace_render_path_tokens(settings.multi_pass_path)

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -188,6 +188,14 @@ class Scene:
         if render_data is None:
             render_data = Scene.get_render_data(doc=doc, take=take)
 
+        # Store the current take to restore it later
+        take_data = doc.GetTakeData()
+        original_take = take_data.GetCurrentTake() if take_data else None
+        
+        # Temporarily set the document's current take to the one we're processing
+        if take and take_data:
+            take_data.SetCurrentTake(take)
+
         render_path_data = {
             "_doc": doc,
             "_rData": render_data,
@@ -197,7 +205,13 @@ class Scene:
         if take:
             render_path_data["_take"] = take
 
-        return c4d.modules.tokensystem.FilenameConvertTokens(path, render_path_data)
+        result = c4d.modules.tokensystem.FilenameConvertTokens(path, render_path_data)
+        
+        # Restore the original take
+        if original_take and take_data:
+            take_data.SetCurrentTake(original_take)
+        
+        return result
 
     @staticmethod
     def get_output_paths(take=None) -> Tuple[str, str]:

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -191,7 +191,7 @@ class Scene:
         # Store the current take to restore it later
         take_data = doc.GetTakeData()
         original_take = take_data.GetCurrentTake() if take_data else None
-        
+
         # Temporarily set the document's current take to the one we're processing
         if take and take_data:
             take_data.SetCurrentTake(take)
@@ -206,11 +206,11 @@ class Scene:
             render_path_data["_take"] = take
 
         result = c4d.modules.tokensystem.FilenameConvertTokens(path, render_path_data)
-        
+
         # Restore the original take
         if original_take and take_data:
             take_data.SetCurrentTake(original_take)
-        
+
         return result
 
     @staticmethod

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -666,7 +666,6 @@ class TestStartRenderWithTextCaching:
         mock_doc = Mock()
         mock_render_data = MagicMock()
         mock_render_data.GetDataInstance = Mock()
-        mock_doc.GetActiveRenderData.return_value = mock_render_data
         mock_doc.GetFps.return_value = 30
         handler.doc = mock_doc
 
@@ -675,10 +674,14 @@ class TestStartRenderWithTextCaching:
         with (
             patch.object(handler, "_reload_document") as mock_reload,
             patch.object(handler, "_cache_text_if_needed", return_value=False),
+            patch.object(
+                handler, "_get_take_render_data", return_value=mock_render_data
+            ) as mock_get_take,
         ):
             handler.start_render({"frame": 1})
 
         mock_reload.assert_called_once()
+        mock_get_take.assert_called_once_with(mock_doc)
 
     @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.RenderDocument")
     @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.bitmaps.MultipassBitmap")
@@ -694,7 +697,6 @@ class TestStartRenderWithTextCaching:
         mock_doc = Mock()
         mock_render_data = MagicMock()
         mock_render_data.GetDataInstance = Mock()
-        mock_doc.GetActiveRenderData.return_value = mock_render_data
         mock_doc.GetFps.return_value = 30
         handler.doc = mock_doc
 
@@ -703,10 +705,14 @@ class TestStartRenderWithTextCaching:
         with (
             patch.object(handler, "_reload_document") as mock_reload,
             patch.object(handler, "_cache_text_if_needed", return_value=False),
+            patch.object(
+                handler, "_get_take_render_data", return_value=mock_render_data
+            ) as mock_get_take,
         ):
             handler.start_render({"frame": 1})
 
         mock_reload.assert_not_called()
+        mock_get_take.assert_called_once_with(mock_doc)
 
     @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.RenderDocument")
     @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.bitmaps.MultipassBitmap")
@@ -722,7 +728,6 @@ class TestStartRenderWithTextCaching:
         mock_doc = Mock()
         mock_render_data = MagicMock()
         mock_render_data.GetDataInstance = Mock()
-        mock_doc.GetActiveRenderData.return_value = mock_render_data
         mock_doc.GetFps.return_value = 30
         handler.doc = mock_doc
 
@@ -732,6 +737,7 @@ class TestStartRenderWithTextCaching:
         with (
             patch.object(handler, "_reload_document"),
             patch.object(handler, "_cache_text_if_needed", return_value=True),
+            patch.object(handler, "_get_take_render_data", return_value=mock_render_data),
         ):
             handler.start_render({"frame": 1})
 
@@ -741,6 +747,7 @@ class TestStartRenderWithTextCaching:
         with (
             patch.object(handler, "_reload_document"),
             patch.object(handler, "_cache_text_if_needed", return_value=False),
+            patch.object(handler, "_get_take_render_data", return_value=mock_render_data),
         ):
             handler.start_render({"frame": 1})
 

--- a/test/unit/deadline_submitter_for_cinema4d/test_take_output_paths.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_take_output_paths.py
@@ -54,11 +54,11 @@ class TestTakeOutputPathResolution:
         mock_take_v = mock.MagicMock()
         mock_take_v.GetName.return_value = "V"
         mock_take_v.GetChildren.return_value = []
-        
+
         mock_take_e = mock.MagicMock()
         mock_take_e.GetName.return_value = "E"
         mock_take_e.GetChildren.return_value = []
-        
+
         mock_take_r = mock.MagicMock()
         mock_take_r.GetName.return_value = "R"
         mock_take_r.GetChildren.return_value = []
@@ -73,14 +73,34 @@ class TestTakeOutputPathResolution:
             return path.replace("$take", "E")
 
         with (
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name", return_value=str(scene_file)),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths", return_value=("", "")),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens", side_effect=replace_tokens_side_effect),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument", return_value=mock_doc),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
+                return_value=str(scene_file),
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths",
+                return_value=("", ""),
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens",
+                side_effect=replace_tokens_side_effect,
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument",
+                return_value=mock_doc,
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"
+            ),
         ):
             create_job_bundle(
                 settings,
@@ -138,7 +158,7 @@ class TestTakeOutputPathResolution:
         mock_take_v = mock.MagicMock()
         mock_take_v.GetName.return_value = "V"
         mock_take_v.GetChildren.return_value = []
-        
+
         mock_take_e = mock.MagicMock()
         mock_take_e.GetName.return_value = "E"
         mock_take_e.GetChildren.return_value = []
@@ -153,14 +173,34 @@ class TestTakeOutputPathResolution:
             return path.replace("$take", "E").replace("$prj", "Test")
 
         with (
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name", return_value=str(scene_file)),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths", return_value=("", "")),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens", side_effect=replace_tokens_side_effect),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument", return_value=mock_doc),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
+                return_value=str(scene_file),
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths",
+                return_value=("", ""),
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens",
+                side_effect=replace_tokens_side_effect,
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument",
+                return_value=mock_doc,
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"
+            ),
         ):
             create_job_bundle(
                 settings,
@@ -215,7 +255,7 @@ class TestTakeOutputPathResolution:
         mock_take1 = mock.MagicMock()
         mock_take1.GetName.return_value = "Take1"
         mock_take1.GetChildren.return_value = []
-        
+
         mock_take2 = mock.MagicMock()
         mock_take2.GetName.return_value = "Take2"
         mock_take2.GetChildren.return_value = []
@@ -229,14 +269,34 @@ class TestTakeOutputPathResolution:
             return path
 
         with (
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name", return_value=str(scene_file)),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths", return_value=("", "")),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens", side_effect=replace_tokens_side_effect),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument", return_value=mock_doc),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"),
-            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name",
+                return_value=str(scene_file),
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths",
+                return_value=("", ""),
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens",
+                side_effect=replace_tokens_side_effect,
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument",
+                return_value=mock_doc,
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"
+            ),
+            mock.patch(
+                "deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"
+            ),
         ):
             create_job_bundle(
                 settings,

--- a/test/unit/deadline_submitter_for_cinema4d/test_take_output_paths.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_take_output_paths.py
@@ -1,0 +1,256 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+from unittest import mock
+
+from deadline.cinema4d_submitter.cinema4d_render_submitter import (
+    TakeData,
+    create_job_bundle,
+)
+from deadline.cinema4d_submitter.data_classes import (
+    RenderSubmitterUISettings,
+    default_timeout_entries,
+)
+from deadline.cinema4d_submitter.takes import TakeSelection
+from deadline.client.job_bundle.submission import AssetReferences
+
+
+class TestTakeOutputPathResolution:
+    """Test cases for per-take output path resolution bug fix."""
+
+    def test_multiple_marked_takes_resolve_paths_individually(self, tmp_path):
+        """Test that each marked take resolves output paths with its own name."""
+        takes = {
+            "marked_data_list": [
+                TakeData("V", "V", "standard", "", None, "1-3", set(), True),
+                TakeData("E", "E", "standard", "", None, "1-3", set(), True),
+                TakeData("R", "R", "standard", "", None, "1-3", set(), True),
+            ],
+            "main_data_list": [TakeData("Main", "Main", "standard", "", None, "1-3", set(), False)],
+            "take_data_list": [],
+            "current_data_list": [],
+        }
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "Test Job"
+        settings.take_selection = TakeSelection.MARKED
+        settings.output_path = "_Renders/Test/$take/Test_$take"
+        settings.override_output_path = True
+        settings.timeouts = default_timeout_entries()
+
+        scene_file = tmp_path / "test_scene.c4d"
+        scene_file.write_text("dummy")
+        job_bundle_dir = tmp_path / "job_bundle"
+        job_bundle_dir.mkdir()
+
+        asset_references = AssetReferences()
+
+        mock_doc = mock.MagicMock()
+        mock_take_data = mock.MagicMock()
+        mock_main_take = mock.MagicMock()
+        mock_doc.GetTakeData.return_value = mock_take_data
+        mock_take_data.GetMainTake.return_value = mock_main_take
+
+        mock_take_v = mock.MagicMock()
+        mock_take_v.GetName.return_value = "V"
+        mock_take_v.GetChildren.return_value = []
+        
+        mock_take_e = mock.MagicMock()
+        mock_take_e.GetName.return_value = "E"
+        mock_take_e.GetChildren.return_value = []
+        
+        mock_take_r = mock.MagicMock()
+        mock_take_r.GetName.return_value = "R"
+        mock_take_r.GetChildren.return_value = []
+
+        mock_main_take.GetName.return_value = "Main"
+        mock_main_take.GetChildren.return_value = [mock_take_v, mock_take_e, mock_take_r]
+
+        def replace_tokens_side_effect(path, doc=None, take=None, render_data=None):
+            if take:
+                take_name = take.GetName()
+                return path.replace("$take", take_name)
+            return path.replace("$take", "E")
+
+        with (
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name", return_value=str(scene_file)),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths", return_value=("", "")),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens", side_effect=replace_tokens_side_effect),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument", return_value=mock_doc),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"),
+        ):
+            create_job_bundle(
+                settings,
+                takes,
+                str(job_bundle_dir),
+                asset_references,
+                [],
+                AssetReferences(),
+            )
+
+            output_dirs = asset_references.output_directories
+            assert len(output_dirs) == 3
+
+            expected_dirs = [
+                os.path.dirname("_Renders/Test/V/Test_V"),
+                os.path.dirname("_Renders/Test/E/Test_E"),
+                os.path.dirname("_Renders/Test/R/Test_R"),
+            ]
+
+            for expected_dir in expected_dirs:
+                assert expected_dir in output_dirs
+
+    def test_child_take_selected_does_not_affect_other_takes(self, tmp_path):
+        """Test that having a child take selected doesn't cause all takes to use that path."""
+        takes = {
+            "marked_data_list": [
+                TakeData("V", "V", "standard", "", None, "1-3", set(), True),
+                TakeData("E", "E", "standard", "", None, "1-3", set(), True),
+            ],
+            "main_data_list": [TakeData("Main", "Main", "standard", "", None, "1-3", set(), False)],
+            "take_data_list": [],
+            "current_data_list": [TakeData("E", "E", "standard", "", None, "1-3", set(), True)],
+        }
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "Test Job"
+        settings.take_selection = TakeSelection.MARKED
+        settings.output_path = "_Renders/$prj/$take/$prj_$take"
+        settings.override_output_path = True
+        settings.timeouts = default_timeout_entries()
+
+        scene_file = tmp_path / "test_scene.c4d"
+        scene_file.write_text("dummy")
+        job_bundle_dir = tmp_path / "job_bundle"
+        job_bundle_dir.mkdir()
+
+        asset_references = AssetReferences()
+
+        mock_doc = mock.MagicMock()
+        mock_take_data = mock.MagicMock()
+        mock_main_take = mock.MagicMock()
+        mock_doc.GetTakeData.return_value = mock_take_data
+        mock_take_data.GetMainTake.return_value = mock_main_take
+
+        mock_take_v = mock.MagicMock()
+        mock_take_v.GetName.return_value = "V"
+        mock_take_v.GetChildren.return_value = []
+        
+        mock_take_e = mock.MagicMock()
+        mock_take_e.GetName.return_value = "E"
+        mock_take_e.GetChildren.return_value = []
+
+        mock_main_take.GetName.return_value = "Main"
+        mock_main_take.GetChildren.return_value = [mock_take_v, mock_take_e]
+
+        def replace_tokens_side_effect(path, doc=None, take=None, render_data=None):
+            if take:
+                take_name = take.GetName()
+                return path.replace("$take", take_name).replace("$prj", "Test")
+            return path.replace("$take", "E").replace("$prj", "Test")
+
+        with (
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name", return_value=str(scene_file)),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths", return_value=("", "")),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens", side_effect=replace_tokens_side_effect),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument", return_value=mock_doc),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"),
+        ):
+            create_job_bundle(
+                settings,
+                takes,
+                str(job_bundle_dir),
+                asset_references,
+                [],
+                AssetReferences(),
+            )
+
+            output_dirs = asset_references.output_directories
+
+            v_dir = os.path.dirname("_Renders/Test/V/Test_V")
+            e_dir = os.path.dirname("_Renders/Test/E/Test_E")
+
+            assert v_dir in output_dirs
+            assert e_dir in output_dirs
+            assert v_dir != e_dir
+
+    def test_multipass_paths_resolved_per_take(self, tmp_path):
+        """Test that multi-pass paths are also resolved per-take."""
+        takes = {
+            "marked_data_list": [
+                TakeData("Take1", "Take1", "standard", "", None, "1-3", set(), True),
+                TakeData("Take2", "Take2", "standard", "", None, "1-3", set(), True),
+            ],
+            "main_data_list": [TakeData("Main", "Main", "standard", "", None, "1-3", set(), False)],
+            "take_data_list": [],
+            "current_data_list": [],
+        }
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "Test Job"
+        settings.take_selection = TakeSelection.MARKED
+        settings.multi_pass_path = "_Renders/multipass/$take/mp_$take"
+        settings.override_multi_pass_path = True
+        settings.timeouts = default_timeout_entries()
+
+        scene_file = tmp_path / "test_scene.c4d"
+        scene_file.write_text("dummy")
+        job_bundle_dir = tmp_path / "job_bundle"
+        job_bundle_dir.mkdir()
+
+        asset_references = AssetReferences()
+
+        mock_doc = mock.MagicMock()
+        mock_take_data = mock.MagicMock()
+        mock_main_take = mock.MagicMock()
+        mock_doc.GetTakeData.return_value = mock_take_data
+        mock_take_data.GetMainTake.return_value = mock_main_take
+
+        mock_take1 = mock.MagicMock()
+        mock_take1.GetName.return_value = "Take1"
+        mock_take1.GetChildren.return_value = []
+        
+        mock_take2 = mock.MagicMock()
+        mock_take2.GetName.return_value = "Take2"
+        mock_take2.GetChildren.return_value = []
+
+        mock_main_take.GetName.return_value = "Main"
+        mock_main_take.GetChildren.return_value = [mock_take1, mock_take2]
+
+        def replace_tokens_side_effect(path, doc=None, take=None, render_data=None):
+            if take:
+                return path.replace("$take", take.GetName())
+            return path
+
+        with (
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.name", return_value=str(scene_file)),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.get_output_paths", return_value=("", "")),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.Scene.replace_render_path_tokens", side_effect=replace_tokens_side_effect),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.GetActiveDocument", return_value=mock_doc),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.KillDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.LoadDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.InsertBaseDocument"),
+            mock.patch("deadline.cinema4d_submitter.cinema4d_render_submitter.c4d.documents.SetActiveDocument"),
+        ):
+            create_job_bundle(
+                settings,
+                takes,
+                str(job_bundle_dir),
+                asset_references,
+                [],
+                AssetReferences(),
+            )
+
+            output_dirs = asset_references.output_directories
+
+            take1_dir = os.path.dirname("_Renders/multipass/Take1/mp_Take1")
+            take2_dir = os.path.dirname("_Renders/multipass/Take2/mp_Take2")
+
+            assert take1_dir in output_dirs
+            assert take2_dir in output_dirs


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/350

### What was the problem/requirement? (What/Why)
When submitting a Cinema4D scene with multiple marked takes to Deadline Cloud, the output paths for each take are not respected if the currently selected take is one of the marked takes. Instead of rendering each take into its own directory, all takes overwrite each other into the same output file.

The issue only occurs when a child take (e.g., E) is selected at submission time. If the root take ("Main" or "Logo Reveal") is selected even with the same marked takes the renderer correctly outputs each take into its own folder using $take token.

### What was the solution? (How)
Modified submitter to resolve output paths per-take instead of globally, and moved adaptor token resolution from initialization to render time when take context is available.

### What is the impact of this change?
Fixes data loss bug where multiple marked takes would overwrite each other's frames. Each take now renders to its own directory as expected.

### How was this change tested?
Added unit tests for per-take path resolution and verified with test scene containing multiple marked takes with child take selected.

- Have you run the unit tests?
Yes

- Have you made changes to the submitter?
If yes, please include the results of both the automated tests and any manual tests that you ran.
Also, check if there is a change to the `integ_test_helpers.py` file within cinema4d_submitter as a result of your submitter change.
Yes, submitter changes were made. Here are the test results:

Automated Tests:

Added 3 new unit tests in test_take_output_paths.py:
- test_multiple_marked_takes_resolve_paths_individually ✓
- test_child_take_selected_does_not_affect_other_takes ✓
- test_multipass_paths_resolved_per_take ✓

Manual Tests:
- Submitted test scene with 4 marked takes (V, E, R, A) with child take selected
- Verified asset references correctly include separate output directories for each take
- Confirmed job logs show all take-specific paths registered

integ_test_helpers.py Check:
No changes required to integ_test_helpers.py - the modifications to create_job_bundle() maintain the same function signature and return behavior, only changing internal path resolution logic.

### Was this change documented?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*