### PR TITLE
feat: Print the submitter version in the logs.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -83,9 +83,12 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         1  # 0=deactivate, 1=activate - controls whether error regex callbacks are added
     )
 
-    def _print_adaptor_version(self) -> None:
-        """Prints the adaptor version information."""
+    def _print_adaptor_and_submitter_versions(self) -> None:
+        """Prints the adaptor and submitter version information."""
         print(f"Deadline Cloud for Cinema 4D adaptor version: {adaptor_version}")
+        submitter_version = os.environ.get("SUBMITTER_INTEGRATION_VERSION", "")
+        if submitter_version:
+            print(f"This job was submitted from submitter integration version: {submitter_version}")
 
     def __init__(self, *args, **kwargs):
         if sys.platform == "linux" and "path_mapping_data" in kwargs:
@@ -112,7 +115,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                         prefixed_rule["destination_os"] = rule["destination_os"]
                     path_mapping_rules.append(prefixed_rule)
         super().__init__(*args, **kwargs)
-        self._print_adaptor_version()
+        self._print_adaptor_and_submitter_versions()
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -18,6 +18,13 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+- name: SubmitterIntegrationVersion
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Submitter Integration Version
+    groupLabel: Cinema4D Settings
+  description: The Cinema 4D submitter integration version.
 - name: Frames
   type: STRING
   userInterface:
@@ -90,6 +97,7 @@ steps:
     variables:
       # Turn off buffering in Python
       PYTHONUNBUFFERED: "1"
+      SUBMITTER_INTEGRATION_VERSION: "{{Param.SubmitterIntegrationVersion}}"
     script:
       embeddedFiles:
       - name: initData

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -21,7 +21,7 @@ parameterDefinitions:
 - name: SubmitterIntegrationVersion
   type: STRING
   userInterface:
-    control: LINE_EDIT
+    control: HIDDEN
     label: Submitter Integration Version
     groupLabel: Cinema4D Settings
   description: The Cinema 4D submitter integration version.

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -97,6 +97,12 @@ def _get_parameter_values(
 
     # Set the c4d scene file value
     parameter_values.append({"name": "Cinema4DFile", "value": Scene.name()})
+    parameter_values.append(
+        {
+            "name": "SubmitterIntegrationVersion",
+            "value": ".".join(str(v) for v in adaptor_version_tuple),
+        }
+    )
     parameter_values.append({"name": "OutputPath", "value": settings.output_path})
     parameter_values.append({"name": "MultiPassPath", "value": settings.multi_pass_path})
     parameter_values.append(

--- a/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/parameter_values.yaml
@@ -1,6 +1,8 @@
 parameterValues:
 - name: Cinema4DFile
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical\generated_bundle\physical.c4d
+- name: SubmitterIntegrationVersion
+  value: 0.8.0
 - name: OutputPath
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical\generated_bundle\renders\physical
 - name: MultiPassPath

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -20,7 +20,7 @@ parameterDefinitions:
 - name: SubmitterIntegrationVersion
   type: STRING
   userInterface:
-    control: LINE_EDIT
+    control: HIDDEN
     label: Submitter Integration Version
     groupLabel: Cinema4D Settings
   description: The Cinema 4D submitter integration version.

--- a/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical/expected_job_bundle/template.yaml
@@ -17,6 +17,13 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+- name: SubmitterIntegrationVersion
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Submitter Integration Version
+    groupLabel: Cinema4D Settings
+  description: The Cinema 4D submitter integration version.
 - name: Frames
   type: STRING
   userInterface:
@@ -88,6 +95,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/parameter_values.yaml
@@ -1,6 +1,8 @@
 parameterValues:
 - name: Cinema4DFile
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical_multi_takes\generated_bundle\physical_multi_takes.c4d
+- name: SubmitterIntegrationVersion
+  value: 0.8.0
 - name: OutputPath
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical_multi_takes\generated_bundle\renders\physical_multi_takes_$take
 - name: MultiPassPath

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -20,7 +20,7 @@ parameterDefinitions:
 - name: SubmitterIntegrationVersion
   type: STRING
   userInterface:
-    control: LINE_EDIT
+    control: HIDDEN
     label: Submitter Integration Version
     groupLabel: Cinema4D Settings
   description: The Cinema 4D submitter integration version.

--- a/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_multi_takes/expected_job_bundle/template.yaml
@@ -17,6 +17,13 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+- name: SubmitterIntegrationVersion
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Submitter Integration Version
+    groupLabel: Cinema4D Settings
+  description: The Cinema 4D submitter integration version.
 - name: OutputPath
   type: PATH
   objectType: FILE
@@ -200,6 +207,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -268,6 +276,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -333,6 +342,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -398,6 +408,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -463,6 +474,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -528,6 +540,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -593,6 +606,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -658,6 +672,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -723,6 +738,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -788,6 +804,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -853,6 +870,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -918,6 +936,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -983,6 +1002,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -1048,6 +1068,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData
@@ -1113,6 +1134,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/parameter_values.yaml
@@ -1,6 +1,8 @@
 parameterValues:
 - name: Cinema4DFile
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical_textured\generated_bundle\physical_textured.c4d
+- name: SubmitterIntegrationVersion
+  value: 0.8.0
 - name: OutputPath
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\physical_textured\generated_bundle\renders\physical_textured
 - name: MultiPassPath

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -20,7 +20,7 @@ parameterDefinitions:
 - name: SubmitterIntegrationVersion
   type: STRING
   userInterface:
-    control: LINE_EDIT
+    control: HIDDEN
     label: Submitter Integration Version
     groupLabel: Cinema4D Settings
   description: The Cinema 4D submitter integration version.

--- a/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/physical_textured/expected_job_bundle/template.yaml
@@ -17,6 +17,13 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+- name: SubmitterIntegrationVersion
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Submitter Integration Version
+    groupLabel: Cinema4D Settings
+  description: The Cinema 4D submitter integration version.
 - name: Frames
   type: STRING
   userInterface:
@@ -88,6 +95,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData

--- a/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/parameter_values.yaml
@@ -1,6 +1,8 @@
 parameterValues:
 - name: Cinema4DFile
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift\generated_bundle\redshift.c4d
+- name: SubmitterIntegrationVersion
+  value: 0.8.0
 - name: OutputPath
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift\generated_bundle\renders\redshift
 - name: MultiPassPath

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -20,7 +20,7 @@ parameterDefinitions:
 - name: SubmitterIntegrationVersion
   type: STRING
   userInterface:
-    control: LINE_EDIT
+    control: HIDDEN
     label: Submitter Integration Version
     groupLabel: Cinema4D Settings
   description: The Cinema 4D submitter integration version.

--- a/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift/expected_job_bundle/template.yaml
@@ -17,6 +17,13 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+- name: SubmitterIntegrationVersion
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Submitter Integration Version
+    groupLabel: Cinema4D Settings
+  description: The Cinema 4D submitter integration version.
 - name: Frames
   type: STRING
   userInterface:
@@ -88,6 +95,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/parameter_values.yaml
@@ -1,6 +1,8 @@
 parameterValues:
 - name: Cinema4DFile
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift_takes\generated_bundle\redshift_takes.c4d
+- name: SubmitterIntegrationVersion
+  value: 0.8.0
 - name: OutputPath
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift_takes\generated_bundle\renders\redshift_takes_$take
 - name: MultiPassPath

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -20,7 +20,7 @@ parameterDefinitions:
 - name: SubmitterIntegrationVersion
   type: STRING
   userInterface:
-    control: LINE_EDIT
+    control: HIDDEN
     label: Submitter Integration Version
     groupLabel: Cinema4D Settings
   description: The Cinema 4D submitter integration version.

--- a/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_takes/expected_job_bundle/template.yaml
@@ -17,6 +17,13 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+- name: SubmitterIntegrationVersion
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Submitter Integration Version
+    groupLabel: Cinema4D Settings
+  description: The Cinema 4D submitter integration version.
 - name: Frames
   type: STRING
   userInterface:
@@ -88,6 +95,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/parameter_values.yaml
@@ -1,6 +1,8 @@
 parameterValues:
 - name: Cinema4DFile
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift_textured\generated_bundle\redshift_textured.c4d
+- name: SubmitterIntegrationVersion
+  value: 0.8.0
 - name: OutputPath
   value: PATH_TO_BE_REPLACED\deadline-cloud-for-cinema-4d\test\integ\test_scenes\redshift_textured\generated_bundle\renders\redshift_textured
 - name: MultiPassPath

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -20,7 +20,7 @@ parameterDefinitions:
 - name: SubmitterIntegrationVersion
   type: STRING
   userInterface:
-    control: LINE_EDIT
+    control: HIDDEN
     label: Submitter Integration Version
     groupLabel: Cinema4D Settings
   description: The Cinema 4D submitter integration version.

--- a/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured/expected_job_bundle/template.yaml
@@ -17,6 +17,13 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+- name: SubmitterIntegrationVersion
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Submitter Integration Version
+    groupLabel: Cinema4D Settings
+  description: The Cinema 4D submitter integration version.
 - name: Frames
   type: STRING
   userInterface:
@@ -88,6 +95,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/parameter_values.yaml
@@ -3,6 +3,8 @@ parameterValues:
   value: "PATH_TO_BE_REPLACED\\deadline-cloud-for-cinema-4d\\test\\integ\\\
     test_scenes\\redshift_textured_with_nonascii_characters\\generated_bundle\\redshift_textured-_\u20BF\
     _\u0119_\xF1_\u03B2_\u0411_\u062A.c4d"
+- name: SubmitterIntegrationVersion
+  value: 0.8.0
 - name: OutputPath
   value: "PATH_TO_BE_REPLACED\\deadline-cloud-for-cinema-4d\\test\\integ\\\
     test_scenes\\redshift_textured_with_nonascii_characters\\generated_bundle\\renders\\\

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -20,7 +20,7 @@ parameterDefinitions:
 - name: SubmitterIntegrationVersion
   type: STRING
   userInterface:
-    control: LINE_EDIT
+    control: HIDDEN
     label: Submitter Integration Version
     groupLabel: Cinema4D Settings
   description: The Cinema 4D submitter integration version.

--- a/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
+++ b/test/integ/test_scenes/redshift_textured_with_nonascii_characters/expected_job_bundle/template.yaml
@@ -17,6 +17,13 @@ parameterDefinitions:
       patterns:
       - '*'
   description: The Cinema4D document file to render.
+- name: SubmitterIntegrationVersion
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Submitter Integration Version
+    groupLabel: Cinema4D Settings
+  description: The Cinema 4D submitter integration version.
 - name: Frames
   type: STRING
   userInterface:
@@ -88,6 +95,7 @@ steps:
     description: Runs Cinema4D in the background.
     variables:
       PYTHONUNBUFFERED: '1'
+      SUBMITTER_INTEGRATION_VERSION: '{{Param.SubmitterIntegrationVersion}}'
     script:
       embeddedFiles:
       - name: initData

--- a/test/integ/utils.py
+++ b/test/integ/utils.py
@@ -182,6 +182,8 @@ def assert_expected_job_bundle_and_generated_job_bundle_are_equal(
             if file == "parameter_values.yaml":
                 content1 = _normalize_conda_packages_version(content1)
                 content2 = _normalize_conda_packages_version(content2)
+                content1 = _normalize_submitter_integration_version(content1)
+                content2 = _normalize_submitter_integration_version(content2)
 
             # Special handling for template.yaml to strip job environments.
             # Job environments can contain code that changes frequently
@@ -218,6 +220,20 @@ def _normalize_conda_packages_version(content: str) -> str:
     content = re.sub(
         r"cinema4d=202[4-9].\* cinema4d-openjd=0.\d.\*",
         "cinema4d=2026.* cinema4d-openjd=0.8.*",
+        content,
+    )
+    return content
+
+
+def _normalize_submitter_integration_version(content: str) -> str:
+    """
+    Normalize the SubmitterIntegrationVersion parameter to match the expected test format.
+    This allows tests to pass regardless of the actual version numbers by
+    normalizing the generated content to match the expected format.
+    """
+    content = re.sub(
+        r"(name: SubmitterIntegrationVersion\n\s+value: )\d+\.\d+\.\d+[^\n]*",
+        r"\g<1>0.8.0",
         content,
     )
     return content

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -217,6 +217,22 @@ def test_adaptor_prints_version_on_init(init_data, capfd):
 
 
 @pytest.mark.xdist_group(name="adaptor_tests")
+def test_adaptor_prints_submitter_version_on_init(init_data, capfd, monkeypatch):
+    """
+    Test that the adaptor prints the submitter version during initialization
+    when the SUBMITTER_INTEGRATION_VERSION environment variable is set
+    """
+    test_version = "1.2.3"
+    monkeypatch.setenv("SUBMITTER_INTEGRATION_VERSION", test_version)
+    Cinema4DAdaptor(init_data)
+    captured = capfd.readouterr()
+    expected_output = f"This job was submitted from submitter integration version: {test_version}"
+    assert (
+        expected_output in captured.out
+    ), f"Expected output to contain {expected_output}, but got {captured.out}"
+
+
+@pytest.mark.xdist_group(name="adaptor_tests")
 @pytest.mark.parametrize("activate_error_checking", [0, 1])
 def test_activate_error_checking(init_data: dict, activate_error_checking: int) -> None:
     """


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

It is currently not possible to know which submitter version was used to submit the job. 

### What was the solution? (How)

This adds the submitter integration version as a job parameter value, this means customers can know which version was used by just checking their job parameters. 

To print the version, I added it as an environment variable and print it in the adaptor next to the submitter version.  

### What is the impact of this change?

This can improve customer's experience and also devs trying to help customers if we have already fixed the issue in the latest submitter instead. 

### How was this change tested?

Tested this manually. 

```
2025/12/04 12:50:43-08:00 INFO: Deadline Cloud for Cinema 4D adaptor version: 0.8.2
2025/12/04 12:50:43-08:00 INFO: This job was submitted from submitter integration version: 0.8.2.post29.g179e4b7ed.d2025110
```

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Yes. The non-ASCII test failed because of improper line endings. But all other tests have passed.

```
========================================================= slowest 5 durations ========================================================= 
437.72s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
73.72s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
72.50s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
70.36s call     test/integ/test_cinema4d.py::test_integ[redshift]
52.46s call     test/integ/test_cinema4d.py::test_integ[physical]
======================================================= short test summary info ======================================================= 
FAILED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] - AssertionError
=============================================== 1 failed, 6 passed in 785.31s (0:13:05) =============================================== 
```

- Have you made changes to the submitter?
Yes and updated the tests. 

### Was this change documented?
Not required

### Is this a breaking change?

No

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*