### PR TITLE
fix: do not pathmap Pyro output in C4D 2026 and up

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -85,6 +85,7 @@ class Cinema4DHandler:
         self.render_kwargs = {}
         self.take = "Main"
         self.map_path = map_path
+        self.has_unmapped_pyro = False
         self.cached_text_was_used_in_previous_frame = False
 
     def _remap_assets(self) -> None:
@@ -139,6 +140,15 @@ class Cinema4DHandler:
                         print(
                             f"{owner}[{param_id}] = {mapped_path} failed. Error: {f} {traceback.format_exc()}"
                         )
+
+        if self.has_unmapped_pyro:
+            print(
+                "Pyro elements were detected in the scene. If the pyro is not appearing in the "
+                "output, the you can use one of the following approaches to resolve the issue:\n"
+                " * Update the scene assets to use localized paths (Project Asset Inspector => [select all assets] => Asset => Localize Filenames)\n"
+                " * Save the scene using 'Save Project with Assets'\n"
+                " * Submit the scene with the 'Save Cinema 4D project with assets before submission' option"
+            )
 
     def _pathmap_recognized_types(
         self, owner, param_id, node_space, node_path, mapped_path
@@ -199,13 +209,7 @@ class Cinema4DHandler:
             # Opyro (i.e. Pyro output starting in C4D 2026) actually breaks if you try
             # to pathmap it, so we will simply return True to indicate that all applicable
             # pathmapping operations (i.e. none) are complete.
-            print(
-                "Pyro elements were detected in the scene. If the pyro is not appearing in the "
-                "output, the you can use one of the following approaches to resolve the issue:\n"
-                " * Update the scene assets to use localized paths (Project Asset Inspector => [select all assets] => Asset => Localize Filenames)\n"
-                " * Saved the scene using 'Save Project with Assets'\n"
-                " * Submit the scene with the 'Save Cinema 4D project with assets before submission' option"
-            )
+            self.has_unmapped_pyro = True
             return True
 
         return mapped

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -198,10 +198,14 @@ class Cinema4DHandler:
         if hasattr(c4d, "Opyro") and owner.GetType() == c4d.Opyro:
             # Opyro (i.e. Pyro output starting in C4D 2026) actually breaks if you try
             # to pathmap it, so we will simply return True to indicate that all applicable
-            # pathmapping operations (i.e. none) are complete. Users should either use
-            # localized paths, use the "Save Project with Assets" button in C4D, or use
-            # the "Save Cinema 4D project with assets before submission" job setting in the
-            # Deadline Cloud submitter instead.
+            # pathmapping operations (i.e. none) are complete.
+            print(
+                "Pyro elements were detected in the scene. If the pyro is not appearing in the "
+                "output, the you can use one of the following approaches to resolve the issue:\n"
+                " * Update the scene assets to use localized paths (Project Asset Inspector => [select all assets] => Asset => Localize Filenames)\n"
+                " * Saved the scene using 'Save Project with Assets'\n"
+                " * Submit the scene with the 'Save Cinema 4D project with assets before submission' option"
+            )
             return True
 
         return mapped

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -195,6 +195,15 @@ class Cinema4DHandler:
                 owner[desc_id] = mapped_path
                 mapped = True
 
+        if hasattr(c4d, "Opyro") and owner.GetType() == c4d.Opyro:
+            # Opyro (i.e. Pyro output starting in C4D 2026) actually breaks if you try
+            # to pathmap it, so we will simply return True to indicate that all applicable
+            # pathmapping operations (i.e. none) are complete. Users should either use
+            # localized paths, use the "Save Project with Assets" button in C4D, or use
+            # the "Save Cinema 4D project with assets before submission" job setting in the
+            # Deadline Cloud submitter instead.
+            return True
+
         return mapped
 
     def _pathmap_base_video_post(self, owner, mapped_path) -> bool:

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -745,3 +745,133 @@ class TestStartRenderWithTextCaching:
             handler.start_render({"frame": 1})
 
         assert handler.cached_text_was_used_in_previous_frame is False
+
+
+class TestPathmapBaseObject:
+    """Tests for the _pathmap_base_object method"""
+
+    @staticmethod
+    def _create_mock_owner(owner_type=None, getitem_return=None, getitem_side_effect=None):
+        """Helper to create a mock owner object with consistent setup"""
+        mock_owner = Mock()
+        mock_owner.GetType.return_value = owner_type or Mock()
+
+        if getitem_side_effect:
+            mock_owner.__getitem__ = Mock(side_effect=getitem_side_effect)
+        else:
+            mock_owner.__getitem__ = Mock(return_value=getitem_return)
+
+        mock_owner.__setitem__ = Mock()
+        return mock_owner
+
+    @staticmethod
+    def _create_mock_c4d(has_opyro=True, opyro_type=None):
+        """Helper to create a mock c4d module with consistent constants"""
+        mock_c4d = Mock()
+        mock_c4d.REDSHIFT_LIGHT_PHYSICAL_TEXTURE = 1001
+        mock_c4d.REDSHIFT_LIGHT_DOME_TEX0 = 1002
+        mock_c4d.REDSHIFT_LIGHT_DOME_TEX1 = 1003
+        mock_c4d.REDSHIFT_FILE_PATH = 2001
+        mock_c4d.DTYPE_STRING = 3001
+        mock_c4d.DescID = Mock(return_value=Mock())
+        mock_c4d.DescLevel = Mock(return_value=Mock())
+
+        if has_opyro:
+            mock_c4d.Opyro = opyro_type or Mock()
+        else:
+            # Simulate older C4D versions without Opyro
+            del mock_c4d.Opyro
+
+        return mock_c4d
+
+    def _run_pathmap_test(self, mock_owner, mock_c4d, mapped_path="/new/path/texture.jpg"):
+        """Helper to run the pathmap test with given mocks"""
+        handler = Cinema4DHandler(mock_map_path)
+
+        with patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d", mock_c4d):
+            return handler._pathmap_base_object(mock_owner, mapped_path)
+
+    def test_pathmap_base_object_maps_redshift_light_textures(self):
+        """Tests that _pathmap_base_object correctly maps Redshift light texture paths"""
+        mock_owner = self._create_mock_owner(getitem_return="/old/path/texture.jpg")
+        mock_c4d = self._create_mock_c4d(has_opyro=False)
+
+        result = self._run_pathmap_test(mock_owner, mock_c4d)
+
+        assert result is True
+        assert mock_owner.__setitem__.call_count == 3
+
+    def test_pathmap_base_object_returns_false_when_no_textures(self):
+        """Tests that _pathmap_base_object returns False when no textures are found"""
+        mock_owner = self._create_mock_owner(getitem_return=None)
+        mock_c4d = self._create_mock_c4d(has_opyro=False)
+
+        result = self._run_pathmap_test(mock_owner, mock_c4d)
+
+        assert result is False
+        mock_owner.__setitem__.assert_not_called()
+
+    def test_pathmap_base_object_handles_opyro_objects_in_c4d_2026_and_up(self):
+        """Tests that _pathmap_base_object returns True for Opyro objects after processing Redshift textures"""
+        mock_opyro_type = Mock()
+        mock_owner = self._create_mock_owner(owner_type=mock_opyro_type, getitem_return=None)
+        mock_c4d = self._create_mock_c4d(has_opyro=True, opyro_type=mock_opyro_type)
+
+        result = self._run_pathmap_test(mock_owner, mock_c4d, "/new/path/pyro_output.exr")
+
+        assert result is True
+        mock_owner.__setitem__.assert_not_called()
+        assert mock_owner.__getitem__.call_count == 3
+
+    def test_pathmap_base_object_handles_opyro_objects_when_c4d_has_no_opyro_attribute(self):
+        """Tests that _pathmap_base_object handles cases where c4d module doesn't have Opyro attribute (older versions)"""
+        mock_owner = self._create_mock_owner(getitem_return="/old/path/texture.jpg")
+        mock_c4d = self._create_mock_c4d(has_opyro=False)
+
+        result = self._run_pathmap_test(mock_owner, mock_c4d)
+
+        assert result is True
+        assert mock_owner.__setitem__.call_count == 3
+
+    def test_pathmap_base_object_handles_non_opyro_objects_when_opyro_exists(self):
+        """Tests that _pathmap_base_object correctly handles non-Opyro objects when Opyro class exists"""
+        mock_opyro_type = Mock()
+        mock_other_type = Mock()
+        mock_owner = self._create_mock_owner(
+            owner_type=mock_other_type, getitem_return="/old/path/texture.jpg"
+        )
+        mock_c4d = self._create_mock_c4d(has_opyro=True, opyro_type=mock_opyro_type)
+
+        result = self._run_pathmap_test(mock_owner, mock_c4d)
+
+        assert result is True
+        assert mock_owner.__setitem__.call_count == 3
+
+    def test_pathmap_base_object_opyro_returns_true_regardless_of_redshift_result(self):
+        """Tests that Opyro objects return True even if no Redshift textures were found"""
+        mock_opyro_type = Mock()
+        mock_owner = self._create_mock_owner(owner_type=mock_opyro_type, getitem_return=None)
+        mock_c4d = self._create_mock_c4d(has_opyro=True, opyro_type=mock_opyro_type)
+
+        result = self._run_pathmap_test(mock_owner, mock_c4d, "/new/path/pyro_output.exr")
+
+        assert result is True
+        mock_owner.__setitem__.assert_not_called()
+        assert mock_owner.__getitem__.call_count == 3
+
+    def test_pathmap_base_object_mixed_texture_presence(self):
+        """Tests that _pathmap_base_object correctly handles when only some Redshift textures are present"""
+        call_count = 0
+
+        def mock_getitem_side_effect(desc_id):
+            nonlocal call_count
+            call_count += 1
+            return "/old/path/physical_texture.jpg" if call_count == 1 else None
+
+        mock_owner = self._create_mock_owner(getitem_side_effect=mock_getitem_side_effect)
+        mock_c4d = self._create_mock_c4d(has_opyro=False)
+
+        result = self._run_pathmap_test(mock_owner, mock_c4d)
+
+        assert result is True
+        assert mock_owner.__setitem__.call_count == 1

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -784,20 +784,28 @@ class TestPathmapBaseObject:
 
         return mock_c4d
 
-    def _run_pathmap_test(self, mock_owner, mock_c4d, mapped_path="/new/path/texture.jpg"):
+    def _run_pathmap_test(
+        self, mock_owner, mock_c4d, mapped_path="/new/path/texture.jpg", expect_unmapped_pyro=False
+    ):
         """Helper to run the pathmap test with given mocks"""
         handler = Cinema4DHandler(mock_map_path)
 
         with patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d", mock_c4d):
-            return handler._pathmap_base_object(mock_owner, mapped_path)
+            result = handler._pathmap_base_object(mock_owner, mapped_path)
+
+        assert handler.has_unmapped_pyro == expect_unmapped_pyro
+        return result
 
     def _assert_setitem_calls_for_all_textures(self, mock_owner, mock_c4d, mapped_path):
         """Helper to assert __setitem__ is called correctly for all three texture types"""
         expected_calls: list[tuple[tuple[object, str], dict[str, object]]] = []
         desc_id = mock_c4d.DescID.return_value
 
+        # Three texture types: PHYSICAL_TEXTURE, DOME_TEX0, DOME_TEX1
+        assert mock_owner.__setitem__.call_count == 3
+
         # Create expected calls for all three texture types
-        for _ in range(3):  # Three texture types: PHYSICAL_TEXTURE, DOME_TEX0, DOME_TEX1
+        for _ in range(3):
             expected_calls.append(((desc_id, mapped_path), {}))
 
         assert mock_owner.__setitem__.call_args_list == expected_calls
@@ -808,10 +816,11 @@ class TestPathmapBaseObject:
         mock_c4d = self._create_mock_c4d(has_opyro=False)
         mapped_path = "/new/path/texture.jpg"
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d, mapped_path)
+        result = self._run_pathmap_test(
+            mock_owner, mock_c4d, mapped_path, expect_unmapped_pyro=False
+        )
 
         assert result is True
-        assert mock_owner.__setitem__.call_count == 3
 
         # Verify that __setitem__ is called with the correct desc_id and mapped_path for each texture type
         self._assert_setitem_calls_for_all_textures(mock_owner, mock_c4d, mapped_path)
@@ -821,7 +830,7 @@ class TestPathmapBaseObject:
         mock_owner = self._create_mock_owner(getitem_return=None)
         mock_c4d = self._create_mock_c4d(has_opyro=False)
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d)
+        result = self._run_pathmap_test(mock_owner, mock_c4d, expect_unmapped_pyro=False)
 
         assert result is False
         mock_owner.__setitem__.assert_not_called()
@@ -832,7 +841,9 @@ class TestPathmapBaseObject:
         mock_owner = self._create_mock_owner(owner_type=mock_opyro_type, getitem_return=None)
         mock_c4d = self._create_mock_c4d(has_opyro=True, opyro_type=mock_opyro_type)
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d, "/new/path/pyro_output.exr")
+        result = self._run_pathmap_test(
+            mock_owner, mock_c4d, "/new/path/pyro_output.exr", expect_unmapped_pyro=True
+        )
 
         assert result is True
         mock_owner.__setitem__.assert_not_called()
@@ -844,10 +855,11 @@ class TestPathmapBaseObject:
         mock_c4d = self._create_mock_c4d(has_opyro=False)
         mapped_path = "/new/path/texture.jpg"
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d, mapped_path)
+        result = self._run_pathmap_test(
+            mock_owner, mock_c4d, mapped_path, expect_unmapped_pyro=False
+        )
 
         assert result is True
-        assert mock_owner.__setitem__.call_count == 3
 
         # Verify that __setitem__ is called with the correct desc_id and mapped_path for each texture type
         self._assert_setitem_calls_for_all_textures(mock_owner, mock_c4d, mapped_path)
@@ -862,10 +874,11 @@ class TestPathmapBaseObject:
         mock_c4d = self._create_mock_c4d(has_opyro=True, opyro_type=mock_opyro_type)
         mapped_path = "/new/path/texture.jpg"
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d, mapped_path)
+        result = self._run_pathmap_test(
+            mock_owner, mock_c4d, mapped_path, expect_unmapped_pyro=False
+        )
 
         assert result is True
-        assert mock_owner.__setitem__.call_count == 3
 
         # Verify that __setitem__ is called with the correct desc_id and mapped_path for each texture type
         self._assert_setitem_calls_for_all_textures(mock_owner, mock_c4d, mapped_path)
@@ -876,7 +889,9 @@ class TestPathmapBaseObject:
         mock_owner = self._create_mock_owner(owner_type=mock_opyro_type, getitem_return=None)
         mock_c4d = self._create_mock_c4d(has_opyro=True, opyro_type=mock_opyro_type)
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d, "/new/path/pyro_output.exr")
+        result = self._run_pathmap_test(
+            mock_owner, mock_c4d, "/new/path/pyro_output.exr", expect_unmapped_pyro=True
+        )
 
         assert result is True
         mock_owner.__setitem__.assert_not_called()
@@ -895,7 +910,9 @@ class TestPathmapBaseObject:
         mock_c4d = self._create_mock_c4d(has_opyro=False)
         mapped_path = "/new/path/texture.jpg"
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d, mapped_path)
+        result = self._run_pathmap_test(
+            mock_owner, mock_c4d, mapped_path, expect_unmapped_pyro=False
+        )
 
         assert result is True
         assert mock_owner.__setitem__.call_count == 1

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -791,15 +791,30 @@ class TestPathmapBaseObject:
         with patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d", mock_c4d):
             return handler._pathmap_base_object(mock_owner, mapped_path)
 
+    def _assert_setitem_calls_for_all_textures(self, mock_owner, mock_c4d, mapped_path):
+        """Helper to assert __setitem__ is called correctly for all three texture types"""
+        expected_calls: list[tuple[tuple[object, str], dict[str, object]]] = []
+        desc_id = mock_c4d.DescID.return_value
+
+        # Create expected calls for all three texture types
+        for _ in range(3):  # Three texture types: PHYSICAL_TEXTURE, DOME_TEX0, DOME_TEX1
+            expected_calls.append(((desc_id, mapped_path), {}))
+
+        assert mock_owner.__setitem__.call_args_list == expected_calls
+
     def test_pathmap_base_object_maps_redshift_light_textures(self):
         """Tests that _pathmap_base_object correctly maps Redshift light texture paths"""
         mock_owner = self._create_mock_owner(getitem_return="/old/path/texture.jpg")
         mock_c4d = self._create_mock_c4d(has_opyro=False)
+        mapped_path = "/new/path/texture.jpg"
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d)
+        result = self._run_pathmap_test(mock_owner, mock_c4d, mapped_path)
 
         assert result is True
         assert mock_owner.__setitem__.call_count == 3
+
+        # Verify that __setitem__ is called with the correct desc_id and mapped_path for each texture type
+        self._assert_setitem_calls_for_all_textures(mock_owner, mock_c4d, mapped_path)
 
     def test_pathmap_base_object_returns_false_when_no_textures(self):
         """Tests that _pathmap_base_object returns False when no textures are found"""
@@ -827,11 +842,15 @@ class TestPathmapBaseObject:
         """Tests that _pathmap_base_object handles cases where c4d module doesn't have Opyro attribute (older versions)"""
         mock_owner = self._create_mock_owner(getitem_return="/old/path/texture.jpg")
         mock_c4d = self._create_mock_c4d(has_opyro=False)
+        mapped_path = "/new/path/texture.jpg"
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d)
+        result = self._run_pathmap_test(mock_owner, mock_c4d, mapped_path)
 
         assert result is True
         assert mock_owner.__setitem__.call_count == 3
+
+        # Verify that __setitem__ is called with the correct desc_id and mapped_path for each texture type
+        self._assert_setitem_calls_for_all_textures(mock_owner, mock_c4d, mapped_path)
 
     def test_pathmap_base_object_handles_non_opyro_objects_when_opyro_exists(self):
         """Tests that _pathmap_base_object correctly handles non-Opyro objects when Opyro class exists"""
@@ -841,11 +860,15 @@ class TestPathmapBaseObject:
             owner_type=mock_other_type, getitem_return="/old/path/texture.jpg"
         )
         mock_c4d = self._create_mock_c4d(has_opyro=True, opyro_type=mock_opyro_type)
+        mapped_path = "/new/path/texture.jpg"
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d)
+        result = self._run_pathmap_test(mock_owner, mock_c4d, mapped_path)
 
         assert result is True
         assert mock_owner.__setitem__.call_count == 3
+
+        # Verify that __setitem__ is called with the correct desc_id and mapped_path for each texture type
+        self._assert_setitem_calls_for_all_textures(mock_owner, mock_c4d, mapped_path)
 
     def test_pathmap_base_object_opyro_returns_true_regardless_of_redshift_result(self):
         """Tests that Opyro objects return True even if no Redshift textures were found"""
@@ -870,8 +893,14 @@ class TestPathmapBaseObject:
 
         mock_owner = self._create_mock_owner(getitem_side_effect=mock_getitem_side_effect)
         mock_c4d = self._create_mock_c4d(has_opyro=False)
+        mapped_path = "/new/path/texture.jpg"
 
-        result = self._run_pathmap_test(mock_owner, mock_c4d)
+        result = self._run_pathmap_test(mock_owner, mock_c4d, mapped_path)
 
         assert result is True
         assert mock_owner.__setitem__.call_count == 1
+
+        # Verify that __setitem__ is called only once with the correct desc_id and mapped_path
+        # (only for the first texture type that has a path)
+        desc_id = mock_c4d.DescID.return_value
+        mock_owner.__setitem__.assert_called_once_with(desc_id, mapped_path)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Pyro scenes were not working in Cinema 4D 2026 on Deadline Cloud.

### What was the solution? (How)
Investigated and determined that there was a breaking change between C4D 2025 and C4D 2026 in how Pyro Output was defined. Adding handling for the new Pyro output type. In C4D 2025, users had to use the "Save Cinema 4D Project with assets before submission" option 

### What is the impact of this change?
Users will now be able run Pyro scenes on Cinema 4D 2026.

### How was this change tested?
Rebuilt the adaptor and ran a Pyro scene.

With the existing adaptor, the Pyro caches are mapped correctly in the following cases:

C4D 2025:
Y localized paths with "Save Cinema 4D Project with assets before submission" option 
Y globalized paths with "Save Cinema 4D Project with assets before submission" option 
N localized paths only
N globalized paths only

C4D 2026:
N localized paths with "Save Cinema 4D Project with assets before submission" option
N globalized paths with "Save Cinema 4D Project with assets before submission" option
N localized paths only
N globalized paths only

With the updated adaptor, the Pyro caches are now mapped correctly in the following cases:

2025:
Y localized paths with "Save Cinema 4D Project with assets before submission" option 
Y globalized paths with "Save Cinema 4D Project with assets before submission" option 
N localized paths only
N globalized paths only

2026:
Y localized paths with "Save Cinema 4D Project with assets before submission" option
Y globalized paths with "Save Cinema 4D Project with assets before submission" option
Y localized paths only
N globalized paths only


- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*