### PR TITLE
feat: Add the 'About' panel for the submitter.

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -14,6 +14,7 @@ import yaml  # type: ignore[import]
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt  # type: ignore[attr-defined]
 
+from deadline.client.dataclasses import SubmitterInfo
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.parameters import JobParameter
@@ -738,6 +739,14 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
 
     conda_packages = get_conda_packages(doc)
 
+    submitter_info = SubmitterInfo(
+        submitter_name="Cinema4D",
+        submitter_package_name="deadline-cloud-for-cinema4d",
+        submitter_package_version=".".join(str(v) for v in adaptor_version_tuple),
+        host_application_name="Cinema 4D",
+        host_application_version=str(c4d.GetC4DVersion()),
+    )
+
     def on_create_job_bundle_callback(
         widget: SubmitJobToDeadlineDialog,
         job_bundle_dir: str,
@@ -783,6 +792,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         parent=parent,
         f=f,
         show_host_requirements_tab=True,
+        submitter_info=submitter_info,
     )
 
     return submitter_dialog

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -46,8 +46,6 @@ class RenderSubmitterUISettings:
     Settings that the submitter UI will use
     """
 
-    submitter_name: str = field(default="Cinema4D")
-
     name: str = field(default="", metadata={"sticky": True})
     description: str = field(default="", metadata={"sticky": True})
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We want to provide better information for our customers on the "About" panel. This is based on the PR: https://github.com/aws-deadline/deadline-cloud/pull/940

### What was the solution? (How)

Added the "SubmitterInfo" object during submission so that the values get populated into the "About" panel. 

### What is the impact of this change?

Customers can easily see which  (adaptor) version they are using. 

### How was this change tested?

Ran it manually on Windows and Mac. 

<img width="570" height="752" alt="image" src="https://github.com/user-attachments/assets/b5b0e474-e4b7-495a-b8bf-f895de3bc24f" />


- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Ran it and everything passed. 

- Have you made changes to the submitter?
Yes, but this does not change the job bundle created. 

### Was this change documented?

Not required. (This is a customer experience improvement)

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*