### PR TITLE
fix: replace  value in path and add warning for missing  for multiple…

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -206,6 +206,9 @@ def _get_job_template(
             take_frame_param["userInterface"]["groupLabel"] = take_data.ui_group_label
             job_template["parameterDefinitions"].append(take_frame_param)
 
+    # Check if paths contain $take token
+    has_take_token = "$take" in settings.output_path or "$take" in settings.multi_pass_path
+
     # Replicate the default step, once per render take, and adjust its settings
     default_step = job_template["steps"][0]
     job_template["steps"] = []
@@ -228,9 +231,17 @@ def _get_job_template(
         else:
             # Update the init data of the step
             init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
+            output_path = settings.output_path
+            multi_pass_path = settings.multi_pass_path
+
+            if has_take_token:
+                # Replace $take token with actual take name, replacing spaces with underscores
+                take_name_for_path = take_data.name.replace(" ", "_")
+                output_path = settings.output_path.replace("$take", take_name_for_path)
+                multi_pass_path = settings.multi_pass_path.replace("$take", take_name_for_path)
             init_data["data"] = (
-                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\nuse_cached_text: '{{Param.UseCachedText}}'"
-                % take_data.name
+                "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '%s'\nmulti_pass_path: '%s'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\nuse_cached_text: '{{Param.UseCachedText}}'"
+                % (take_data.name, output_path, multi_pass_path)
             )
 
     # If Arnold is one of the renderers, add Arnold-specific parameters
@@ -474,16 +485,8 @@ def create_job_bundle(
     if settings.export_job_bundle_to_temp and temp_dir:
         export_to_temp_folder(temp_dir, asset_references)
 
-    submit_takes = takes["main_data_list"]
     job_bundle_path = Path(job_bundle_dir)
-    if settings.take_selection == TakeSelection.MAIN:
-        submit_takes = takes["main_data_list"]
-    elif settings.take_selection == TakeSelection.ALL:
-        submit_takes = takes["take_data_list"]
-    elif settings.take_selection == TakeSelection.MARKED:
-        submit_takes = takes["marked_data_list"]
-    elif settings.take_selection == TakeSelection.CURRENT:
-        submit_takes = takes["current_data_list"]
+    submit_takes = get_submit_takes(settings, takes)
 
     # Add overrides to asset references and update the paths with C4D render path tokens.
     if settings.override_output_path:
@@ -655,6 +658,41 @@ def get_conda_packages(doc: Any) -> str:
     return packages
 
 
+def get_submit_takes(
+    settings: RenderSubmitterUISettings, takes: dict[str, list[TakeData]]
+) -> list[TakeData]:
+    """
+    Determine which takes will be submitted based on take selection setting.
+    """
+    if settings.take_selection == TakeSelection.MAIN:
+        return takes["main_data_list"]
+    elif settings.take_selection == TakeSelection.ALL:
+        return takes["take_data_list"]
+    elif settings.take_selection == TakeSelection.MARKED:
+        return takes["marked_data_list"]
+    elif settings.take_selection == TakeSelection.CURRENT:
+        return takes["current_data_list"]
+    return takes["main_data_list"]
+
+
+def check_take_token_warnings(
+    settings: RenderSubmitterUISettings, submit_takes: list[TakeData]
+) -> None:
+    """
+    Check if multiple takes are selected without $take token in output paths.
+    Adds a warning if output files will overwrite each other.
+    """
+    if (
+        len(submit_takes) > 1
+        and "$take" not in settings.output_path
+        and "$take" not in settings.multi_pass_path
+    ):
+        warning_collector.add_warning(
+            "Multiple takes are selected but output paths do not contain the $take token. "
+            "Output files from different takes will overwrite each other in the same destination folder."
+        )
+
+
 def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> None:
     """
     Exports the current Cinema 4D project to a temporary folder and updates the asset references.
@@ -759,7 +797,10 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         Callback function for creating a job bundle when submitting the job.
         """
-        # Check for warnings and show warning dialog if needed
+        # Determine which takes will be submitted and check for warnings
+        submit_takes = get_submit_takes(settings, takes)
+        check_take_token_warnings(settings, submit_takes)
+
         if warning_collector.has_warnings():
             continue_submission = SubmissionWarningDialog.show_warnings(
                 warning_collector.get_warnings(), "Issues Detected", widget

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -688,7 +688,7 @@ def check_take_token_warnings(
     if "$take" not in settings.output_path or "$take" not in settings.multi_pass_path:
         warning_collector.add_warning(
             "Multiple takes are selected but output paths do not contain the $take token. "
-            "Output paths missing $take token. This will cause different takes will overwrite each other. Use $take in your path to avoid this."
+            "This will cause different takes will overwrite each other. Use $take in your path to avoid this."
         )
 
 
@@ -796,7 +796,6 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         Callback function for creating a job bundle when submitting the job.
         """
-        # check for warnings
         check_take_token_warnings(settings, takes)
 
         if warning_collector.has_warnings():

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -666,28 +666,29 @@ def get_submit_takes(
     """
     if settings.take_selection == TakeSelection.MAIN:
         return takes["main_data_list"]
-    elif settings.take_selection == TakeSelection.ALL:
+    if settings.take_selection == TakeSelection.ALL:
         return takes["take_data_list"]
-    elif settings.take_selection == TakeSelection.MARKED:
+    if settings.take_selection == TakeSelection.MARKED:
         return takes["marked_data_list"]
-    elif settings.take_selection == TakeSelection.CURRENT:
+    if settings.take_selection == TakeSelection.CURRENT:
         return takes["current_data_list"]
     return takes["main_data_list"]
 
 
 def check_take_token_warnings(
-    settings: RenderSubmitterUISettings, submit_takes: list[TakeData]
+    settings: RenderSubmitterUISettings, takes: dict[str, list[TakeData]]
 ) -> None:
     """
     Check if multiple takes are selected without $take token in output paths.
     Adds a warning if output files will overwrite each other.
     """
-    if len(submit_takes) > 1 and (
-        "$take" not in settings.output_path or "$take" not in settings.multi_pass_path
-    ):
+    submit_takes = get_submit_takes(settings, takes)
+    if len(submit_takes) == 1:
+        return
+    if "$take" not in settings.output_path or "$take" not in settings.multi_pass_path:
         warning_collector.add_warning(
             "Multiple takes are selected but output paths do not contain the $take token. "
-            "Output files from different takes will overwrite each other in the same destination folder."
+            "Output paths missing $take token. This will cause different takes will overwrite each other. Use $take in your path to avoid this."
         )
 
 
@@ -795,9 +796,8 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         Callback function for creating a job bundle when submitting the job.
         """
-        # Determine which takes will be submitted and check for warnings
-        submit_takes = get_submit_takes(settings, takes)
-        check_take_token_warnings(settings, submit_takes)
+        # check for warnings
+        check_take_token_warnings(settings, takes)
 
         if warning_collector.has_warnings():
             continue_submission = SubmissionWarningDialog.show_warnings(

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -682,10 +682,8 @@ def check_take_token_warnings(
     Check if multiple takes are selected without $take token in output paths.
     Adds a warning if output files will overwrite each other.
     """
-    if (
-        len(submit_takes) > 1
-        and "$take" not in settings.output_path
-        and "$take" not in settings.multi_pass_path
+    if len(submit_takes) > 1 and (
+        "$take" not in settings.output_path or "$take" not in settings.multi_pass_path
     ):
         warning_collector.add_warning(
             "Multiple takes are selected but output paths do not contain the $take token. "

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -219,7 +219,7 @@ class TestCheckTakeTokenWarnings:
 
         assert not warning_collector.has_warnings()
 
-    def test_no_warning_with_take_token_in_output_path(self):
+    def test_warning_with_take_token_only_in_output_path(self):
         settings = RenderSubmitterUISettings()
         settings.output_path = "/path/$take/output"
         settings.multi_pass_path = "/path/multipass"
@@ -231,9 +231,9 @@ class TestCheckTakeTokenWarnings:
         }
         check_take_token_warnings(settings, takes)
 
-        assert not warning_collector.has_warnings()
+        assert warning_collector.has_warnings()
 
-    def test_no_warning_with_take_token_in_multipass_path(self):
+    def test_warning_with_take_token_only_in_multipass_path(self):
         settings = RenderSubmitterUISettings()
         settings.output_path = "/path/output"
         settings.multi_pass_path = "/path/$take/multipass"
@@ -244,9 +244,8 @@ class TestCheckTakeTokenWarnings:
             ]
         }
         check_take_token_warnings(settings, takes)
-        from deadline.cinema4d_submitter.warning_collector import warning_collector
 
-        assert not warning_collector.has_warnings()
+        assert warning_collector.has_warnings()
 
     def test_warning_multiple_takes_no_token(self):
         settings = RenderSubmitterUISettings()

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -212,7 +212,9 @@ class TestCheckTakeTokenWarnings:
         settings = RenderSubmitterUISettings()
         settings.output_path = "/path/output"
         settings.multi_pass_path = "/path/multipass"
-        takes = [TakeData("Main", "Main", "standard", "", None, "1-10", set(), False)]
+        takes = {
+            "main_data_list": [TakeData("Main", "Main", "standard", "", None, "1-10", set(), False)]
+        }
         check_take_token_warnings(settings, takes)
 
         assert not warning_collector.has_warnings()
@@ -221,10 +223,12 @@ class TestCheckTakeTokenWarnings:
         settings = RenderSubmitterUISettings()
         settings.output_path = "/path/$take/output"
         settings.multi_pass_path = "/path/multipass"
-        takes = [
-            TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
-            TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
-        ]
+        takes = {
+            "main_data_list": [
+                TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
+                TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
+            ]
+        }
         check_take_token_warnings(settings, takes)
 
         assert not warning_collector.has_warnings()
@@ -233,10 +237,12 @@ class TestCheckTakeTokenWarnings:
         settings = RenderSubmitterUISettings()
         settings.output_path = "/path/output"
         settings.multi_pass_path = "/path/$take/multipass"
-        takes = [
-            TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
-            TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
-        ]
+        takes = {
+            "main_data_list": [
+                TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
+                TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
+            ]
+        }
         check_take_token_warnings(settings, takes)
         from deadline.cinema4d_submitter.warning_collector import warning_collector
 
@@ -246,10 +252,12 @@ class TestCheckTakeTokenWarnings:
         settings = RenderSubmitterUISettings()
         settings.output_path = "/path/output"
         settings.multi_pass_path = "/path/multipass"
-        takes = [
-            TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
-            TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
-        ]
+        takes = {
+            "main_data_list": [
+                TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
+                TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
+            ]
+        }
         check_take_token_warnings(settings, takes)
         from deadline.cinema4d_submitter.warning_collector import warning_collector
 

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -6,11 +6,13 @@ from unittest import mock
 from deadline.cinema4d_submitter.cinema4d_render_submitter import (
     _get_job_template,
     TakeData,
+    check_take_token_warnings,
 )
 from deadline.cinema4d_submitter.data_classes import (
     RenderSubmitterUISettings,
     default_timeout_entries,
 )
+from deadline.cinema4d_submitter.warning_collector import warning_collector
 
 
 class TestCinema4dRenderSubmitterDetailedLogging:
@@ -198,3 +200,58 @@ class TestCinema4dRenderSubmitterFonts:
             assert "jobEnvironments" in result
             assert len(result["jobEnvironments"]) == 1  # Only DetailedLogging
             assert result["jobEnvironments"][0]["name"] == "DetailedLogging"
+
+
+class TestCheckTakeTokenWarnings:
+    """Test cases for check_take_token_warnings function."""
+
+    def setup_method(self):
+        warning_collector.clear_warnings()
+
+    def test_no_warning_single_take(self):
+        settings = RenderSubmitterUISettings()
+        settings.output_path = "/path/output"
+        settings.multi_pass_path = "/path/multipass"
+        takes = [TakeData("Main", "Main", "standard", "", None, "1-10", set(), False)]
+        check_take_token_warnings(settings, takes)
+
+        assert not warning_collector.has_warnings()
+
+    def test_no_warning_with_take_token_in_output_path(self):
+        settings = RenderSubmitterUISettings()
+        settings.output_path = "/path/$take/output"
+        settings.multi_pass_path = "/path/multipass"
+        takes = [
+            TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
+            TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
+        ]
+        check_take_token_warnings(settings, takes)
+
+        assert not warning_collector.has_warnings()
+
+    def test_no_warning_with_take_token_in_multipass_path(self):
+        settings = RenderSubmitterUISettings()
+        settings.output_path = "/path/output"
+        settings.multi_pass_path = "/path/$take/multipass"
+        takes = [
+            TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
+            TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
+        ]
+        check_take_token_warnings(settings, takes)
+        from deadline.cinema4d_submitter.warning_collector import warning_collector
+
+        assert not warning_collector.has_warnings()
+
+    def test_warning_multiple_takes_no_token(self):
+        settings = RenderSubmitterUISettings()
+        settings.output_path = "/path/output"
+        settings.multi_pass_path = "/path/multipass"
+        takes = [
+            TakeData("Main", "Main", "standard", "", None, "1-10", set(), False),
+            TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
+        ]
+        check_take_token_warnings(settings, takes)
+        from deadline.cinema4d_submitter.warning_collector import warning_collector
+
+        assert warning_collector.has_warnings()
+        assert "$take token" in warning_collector.get_warnings()[0]


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/350

### What was the problem/requirement? (What/Why)
When submitting a Cinema4D scene with multiple marked takes to Deadline Cloud, the output paths for each take are not respected if the currently selected take is one of the marked takes. Instead of rendering each take into its own directory, all takes overwrite each other into the same output file.
The issue only occurs when a child take (e.g., E) is selected at submission time. If the root take ("Main" or "Logo Reveal") is selected even with the same marked takes the renderer correctly outputs each take into its own folder using $take token.

### What was the solution? (How)
- Modified get_render_data() to temporarily switch to the queried take before getting render data, then restore the original take
- Added take-specific resolved output paths to each step's init_data in the job template
- Skipped symlinks during asset collection with followlinks=False and os.path.islink() checks
- Filtered output directories to only include paths under the document directory
- Removed output directories from auto-detected attachments and only add them for selected takes

<img width="721" height="305" alt="Screenshot 2025-12-01 at 5 22 23 PM" src="https://github.com/user-attachments/assets/b64c9724-4dc5-45b9-9a4e-db8cf5fc68ec" />

<img width="502" height="428" alt="Screenshot 2025-12-10 at 11 46 09 AM" src="https://github.com/user-attachments/assets/ce8dfb68-f593-42f8-a2ce-d2945f4bb970" />


### What is the impact of this change?
- Multi-take submissions now correctly render each take to its own output folder regardless of which take is highlighted in the UI
- Prevents deeply nested symlink paths in job bundles
- Eliminates "unknown asset paths" warnings during submission
- Ensures only checked takes are submitted, not all takes in the document

### How was this change tested?
- Tested multi-take submission with V, E, R, A checked while different takes were highlighted
- Verified each step renders to correct output folder (A→A, E→E, R→R, V→V)
- Confirmed symlink paths are no longer nested in session directories
- Validated asset_references.yaml contains only selected takes' output directories
- Unit tests pass with mock object handling

- Have you run the unit tests?
Yes

- Have you made changes to the submitter?
Yes

- Have you run the integration tests?
No


### Was this change documented?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*