### PR TITLE
feat: add release date to submitter "about" panel

### DIFF
--- a/hatch_custom_hook.py
+++ b/hatch_custom_hook.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 import shutil
+from datetime import datetime
 from typing import Any
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
@@ -24,6 +25,12 @@ class HatchCustomBuildHook(BuildHookInterface):
 
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
         self._validate_config()
+
+        # Append release_date to _version.py after hatch-vcs generates it
+        version_file = os.path.join(self.root, "_version.py")
+        with open(version_file, "a") as f:
+            release_date = datetime.today().strftime("%B %d, %Y")
+            f.write(f"\n__release_date__ = release_date = '{release_date}'\n")
 
         for destination in self.config["copy_version_py"]["destinations"]:
             print(f"Copying _version.py to {destination}")

--- a/hatch_custom_hook.py
+++ b/hatch_custom_hook.py
@@ -28,7 +28,7 @@ class HatchCustomBuildHook(BuildHookInterface):
 
         # Append release_date to _version.py after hatch-vcs generates it
         version_file = os.path.join(self.root, "_version.py")
-        with open(version_file, "a") as f:
+        with open(version_file, "a", encoding="utf-8") as f:
             release_date = datetime.today().strftime("%B %d, %Y")
             f.write(f"\n__release_date__ = release_date = '{release_date}'\n")
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -753,7 +753,9 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
 
     # Create SubmitterInfo with all available metadata
     release_date = _get_release_date()
-    additional_info = {"release_date": release_date} if release_date else None
+    additional_info: Optional[dict[str, Any]] = (
+        {"release_date": release_date} if release_date else None
+    )
 
     submitter_info = SubmitterInfo(
         submitter_name="Cinema4D",

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -752,10 +752,8 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
     conda_packages = get_conda_packages(doc)
 
     # Create SubmitterInfo with all available metadata
-    additional_info: Optional[dict[str, Any]] = None
     release_date = _get_release_date()
-    if release_date:
-        additional_info = {"release_date": release_date}
+    additional_info = {"release_date": release_date} if release_date else None
 
     submitter_info = SubmitterInfo(
         submitter_name="Cinema4D",

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -42,6 +42,20 @@ from .ui.components import SceneSettingsWidget, SubmissionWarningDialog
 LOADED = False
 
 
+def _get_release_date() -> Optional[str]:
+    """Safely retrieve release date from _version.py.
+
+    Returns:
+        The release date string if available, None otherwise.
+    """
+    try:
+        from ._version import release_date
+
+        return release_date
+    except (ImportError, AttributeError):
+        return None
+
+
 @dataclass
 class TakeData:
     name: str
@@ -55,7 +69,6 @@ class TakeData:
 
 
 def show_submitter():
-
     if _prompt_save_current_document() is False:
         return
 
@@ -573,7 +586,6 @@ def generate_take_parameter_names(submit_takes: list[TakeData]) -> None:
     parameter_names = set()
 
     for take_number in range(len(submit_takes)):
-
         take_data = submit_takes[take_number]
 
         # First, check for duplicate take names since this will result in overwriting files in the output
@@ -599,7 +611,7 @@ def generate_take_parameter_names(submit_takes: list[TakeData]) -> None:
         # ensure all parameter names are unique
         if parameter_name in parameter_names:
             # example: NewTake_00001
-            parameter_name = f"{parameter_name[:64 - len('Frames') - 6]}_{take_number:05}"
+            parameter_name = f"{parameter_name[: 64 - len('Frames') - 6]}_{take_number:05}"
             if parameter_name in parameter_names:
                 raise RuntimeError(
                     f"Unable to generate unique parameter name for take '{take_name}', please change the take name."
@@ -739,12 +751,19 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
 
     conda_packages = get_conda_packages(doc)
 
+    # Create SubmitterInfo with all available metadata
+    additional_info: Optional[dict[str, Any]] = None
+    release_date = _get_release_date()
+    if release_date:
+        additional_info = {"release_date": release_date}
+
     submitter_info = SubmitterInfo(
         submitter_name="Cinema4D",
         submitter_package_name="deadline-cloud-for-cinema4d",
         submitter_package_version=".".join(str(v) for v in adaptor_version_tuple),
         host_application_name="Cinema 4D",
         host_application_version=str(c4d.GetC4DVersion()),
+        additional_info=additional_info,
     )
 
     def on_create_job_bundle_callback(


### PR DESCRIPTION
<img width="572" height="753" alt="image" src="https://github.com/user-attachments/assets/109d93c8-66f5-4fe8-a1e4-d449601c01be" />

### What was the problem/requirement? (What/Why)
Users would like to see the release date to make sure they have the latest version
### What was the solution? (How)
Include data in the additional information section so it shows up in the about page
### What is the impact of this change?
You can now see the release date of the submitter
### How was this change tested?
Manually tested on windows machine 
See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/DEVELOPMENT.md) for information on running tests.

- Have you run the unit tests?
yes



- Have you run the integration tests? (Add your integration test report below)
yes
- Have you made changes to the submitter?
If yes, please include the results of both the automated tests and any manual tests that you ran.
Also, check if there is a change to the `integ_test_helpers.py` file within cinema4d_submitter as a result of your submitter change.

### Was this change documented?

- Did you update all relevant docstrings for Python functions that you modified? yes
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change? no
- Should the schema files for the adaptor's init-data or run-data be updated?
no
### Is this a breaking change?

no A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
that is not backwards compatible. Examples of changes that are breaking include:

1. Adding a new required value to the init-data or run-data of the adaptor;
2. Deleting or renaming a value in the init-data or run-data of the adaptor; and
3. Otherwise modifying the interface of the adaptor such that a job submitted with an older version of the Cinema 4D submitter plug-in will not work with a version of the adaptor that includes your modification.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*