### PR TITLE
Fix: Display warning message for $take token missing in both output and multipass paths

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -697,11 +697,14 @@ def check_take_token_warnings(
     submit_takes = get_submit_takes(settings, takes)
     if len(submit_takes) == 1:
         return
-    if "$take" not in settings.output_path or "$take" not in settings.multi_pass_path:
-        warning_collector.add_warning(
-            "Multiple takes are selected but output paths do not contain the $take token. "
-            "This will cause different takes will overwrite each other. Use $take in your path to avoid this."
-        )
+    if "$take" in settings.output_path:
+        return
+    if "$take" in settings.multi_pass_path:
+        return
+    warning_collector.add_warning(
+        "Multiple takes are selected but output paths do not contain the $take token. "
+        "This will cause different takes will overwrite each other. Use $take in your path to avoid this."
+    )
 
 
 def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> None:

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -703,7 +703,7 @@ def check_take_token_warnings(
         return
     warning_collector.add_warning(
         "Multiple takes are selected but output paths do not contain the $take token. "
-        "This will cause different takes will overwrite each other. Use $take in your path to avoid this."
+        "This will cause different takes to overwrite each other. Use $take in your path to avoid this."
     )
 
 

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -231,7 +231,7 @@ class TestCheckTakeTokenWarnings:
         }
         check_take_token_warnings(settings, takes)
 
-        assert warning_collector.has_warnings()
+        assert not warning_collector.has_warnings()
 
     def test_warning_with_take_token_only_in_multipass_path(self):
         settings = RenderSubmitterUISettings()
@@ -245,7 +245,7 @@ class TestCheckTakeTokenWarnings:
         }
         check_take_token_warnings(settings, takes)
 
-        assert warning_collector.has_warnings()
+        assert not warning_collector.has_warnings()
 
     def test_warning_multiple_takes_no_token(self):
         settings = RenderSubmitterUISettings()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/350

### What was the problem/requirement? (What/Why)
Currently displaying warning message for $take token missing in either output path or multipass path. 
Requirement:
To display the warning message if $take is missing in both output path and multipass patj

### What was the solution? (How)
- Modified check_take_token_warnings() method to return if $take is present either in output path or multipass path
- Modified test cases to test accordingly

<img width="721" height="305" alt="Screenshot 2025-12-01 at 5 22 23 PM" src="https://github.com/user-attachments/assets/b64c9724-4dc5-45b9-9a4e-db8cf5fc68ec" />

<img width="499" height="425" alt="Screenshot 2025-12-18 at 2 39 59 PM" src="https://github.com/user-attachments/assets/7cb9a2ac-635d-4890-8e6a-c40c472c9f24" />


### What is the impact of this change?
- Ensures warning message is displayed only when $take is missing from both output path and multipass path.

### How was this change tested?
- Tested multi-take submission with V, E, R, A checked while different takes were highlighted
- Verified warning message for missing $take sign in both output path and multipass path

- Have you run the unit tests?
Yes

- Have you made changes to the submitter?
Yes

- Have you run the integration tests?
No

### Was this change documented?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*