### PR TITLE
fix: detect nested Redshift proxy references in job attachments

### DIFF
--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -51,7 +51,8 @@ class AssetIntrospector:
                 text = content.decode("utf-8", errors="ignore")
 
                 # Find all .rs file paths (both relative and absolute)
-                rs_pattern = re.compile(r"([^\x00]*\.rs)")
+                # Use possessive quantifier to prevent catastrophic backtracking
+                rs_pattern = re.compile(r"([^\x00]*?\.rs)")
                 matches = rs_pattern.findall(text)
 
                 for referenced_path in matches:

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -23,6 +23,60 @@ _FRAME_RE = re.compile("#+")
 
 class AssetIntrospector:
 
+    def _scan_redshift_proxy_for_references(
+        self, proxy_path: Path, visited: set[Path]
+    ) -> set[Path]:
+        """
+        Recursively scans a Redshift proxy file for nested proxy references.
+
+        Args:
+            proxy_path: Path to the .rs proxy file
+            visited: Set of already-visited proxy files to avoid infinite loops
+
+        Returns:
+            set[Path]: Set of all nested proxy file paths found
+        """
+        nested_proxies: set[Path] = set()
+
+        if proxy_path in visited or not proxy_path.exists():
+            return nested_proxies
+
+        visited.add(proxy_path)
+        logger.info(f"Scanning Redshift proxy for nested references: {proxy_path}")
+
+        try:
+            with open(proxy_path, "rb") as f:
+                content = f.read()
+                # Search for .rs file references in the binary content
+                text = content.decode("utf-8", errors="ignore")
+
+                # Find all .rs file paths (both relative and absolute)
+                rs_pattern = re.compile(r"([^\x00]*\.rs)")
+                matches = rs_pattern.findall(text)
+
+                for referenced_path in matches:
+                    # Skip if it's the same file
+                    if referenced_path == proxy_path.name or referenced_path == str(proxy_path):
+                        continue
+
+                    # Try to resolve the path
+                    nested_proxy = Path(referenced_path)
+                    if not nested_proxy.is_absolute():
+                        # Handle relative paths like "./ProxyB.rs"
+                        nested_proxy = (proxy_path.parent / referenced_path).resolve()
+
+                    if nested_proxy.exists() and nested_proxy != proxy_path:
+                        logger.info(f"Found nested proxy reference: {nested_proxy}")
+                        nested_proxies.add(nested_proxy)
+                        # Recursively scan this nested proxy
+                        nested_proxies.update(
+                            self._scan_redshift_proxy_for_references(nested_proxy, visited)
+                        )
+        except Exception as e:
+            logger.warning(f"Failed to scan Redshift proxy {proxy_path}: {e}")
+
+        return nested_proxies
+
     def parse_scene_assets(self) -> set[Path]:
         """
         Searches the scene for assets, and filters out assets that are not needed for Rendering.
@@ -78,6 +132,21 @@ class AssetIntrospector:
                 for font_file in fonts_dir.iterdir():
                     if font_file.is_file():
                         assets.add(font_file)
+
+        # Scan Redshift proxy files for nested references
+        rs_files = {asset for asset in assets if asset.suffix == ".rs"}
+        logger.info(
+            f"Found {len(rs_files)} Redshift proxy file(s) to scan: {[f.name for f in rs_files]}"
+        )
+        visited_proxies: set[Path] = set()
+
+        for rs_file in rs_files:
+            nested_proxies = self._scan_redshift_proxy_for_references(rs_file, visited_proxies)
+            if nested_proxies:
+                logger.info(
+                    f"Found {len(nested_proxies)} nested proxy reference(s) in {rs_file.name}"
+                )
+                assets.update(nested_proxies)
 
         # Validate asset paths for Windows-incompatible characters
         validate_asset_paths(assets)

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -51,8 +51,8 @@ class AssetIntrospector:
                 text = content.decode("utf-8", errors="ignore")
 
                 # Find all .rs file paths (both relative and absolute)
-                # Use possessive quantifier to prevent catastrophic backtracking
-                rs_pattern = re.compile(r"([^\x00]*?\.rs)")
+                # Use atomic group (?>...) to prevent backtracking
+                rs_pattern = re.compile(r"((?>[^\x00]*)\.rs)")
                 matches = rs_pattern.findall(text)
 
                 for referenced_path in matches:

--- a/test/unit/deadline_submitter_for_cinema4d/test_assets.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_assets.py
@@ -217,6 +217,158 @@ class TestAssetIntrospectorFonts:
             )
 
 
+class TestRedshiftProxyScanning:
+    """Test Redshift proxy nested reference scanning"""
+
+    def test_scan_proxy_with_nested_reference(self, tmp_path):
+        """Test scanning proxy file that references another proxy"""
+        # Create ProxyB.rs
+        proxy_b = tmp_path / "ProxyB.rs"
+        proxy_b.write_bytes(b"fake proxy data")
+
+        # Create ProxyA.rs with reference to ProxyB.rs
+        proxy_a = tmp_path / "ProxyA.rs"
+        proxy_a.write_bytes(b"./ProxyB.rs\x00fake data")
+
+        introspector = AssetIntrospector()
+        visited: set[Path] = set()
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, visited)
+
+        assert proxy_b in result
+        assert proxy_a in visited
+        assert proxy_b in visited
+
+    def test_scan_proxy_with_absolute_path(self, tmp_path):
+        """Test scanning proxy with absolute path reference"""
+        proxy_b = tmp_path / "ProxyB.rs"
+        proxy_b.write_bytes(b"fake proxy data")
+
+        proxy_a = tmp_path / "ProxyA.rs"
+        proxy_a.write_bytes(f"{proxy_b}\x00fake data".encode())
+
+        introspector = AssetIntrospector()
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, set())
+
+        assert proxy_b in result
+
+    def test_scan_proxy_three_level_nesting(self, tmp_path):
+        """Test three-level proxy nesting: A -> B -> C"""
+        proxy_c = tmp_path / "ProxyC.rs"
+        proxy_c.write_bytes(b"fake proxy data")
+
+        proxy_b = tmp_path / "ProxyB.rs"
+        proxy_b.write_bytes(b"./ProxyC.rs\x00fake data")
+
+        proxy_a = tmp_path / "ProxyA.rs"
+        proxy_a.write_bytes(b"./ProxyB.rs\x00fake data")
+
+        introspector = AssetIntrospector()
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, set())
+
+        assert proxy_b in result
+        assert proxy_c in result
+
+    def test_scan_proxy_circular_reference(self, tmp_path):
+        """Test circular reference doesn't cause infinite loop"""
+        proxy_b = tmp_path / "ProxyB.rs"
+        proxy_a = tmp_path / "ProxyA.rs"
+
+        # ProxyA references ProxyB
+        proxy_a.write_bytes(b"./ProxyB.rs\x00fake data")
+        # ProxyB references ProxyA (circular)
+        proxy_b.write_bytes(b"./ProxyA.rs\x00fake data")
+
+        introspector = AssetIntrospector()
+        visited: set[Path] = set()
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, visited)
+
+        # Should find ProxyB but not loop infinitely
+        assert proxy_b in result
+        assert len(visited) == 2  # Both proxies visited once
+
+    def test_scan_proxy_missing_nested_file(self, tmp_path, caplog):
+        """Test handling of missing nested proxy file"""
+        proxy_a = tmp_path / "ProxyA.rs"
+        proxy_a.write_bytes(b"./NonExistent.rs\x00fake data")
+
+        introspector = AssetIntrospector()
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, set())
+
+        # Should return empty set, not crash
+        assert len(result) == 0
+
+    def test_scan_proxy_already_visited(self, tmp_path):
+        """Test that already-visited proxies are skipped"""
+        proxy_a = tmp_path / "ProxyA.rs"
+        proxy_a.write_bytes(b"fake proxy data")
+
+        introspector = AssetIntrospector()
+        visited = {proxy_a}  # Already visited
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, visited)
+
+        assert len(result) == 0
+
+    def test_scan_proxy_nonexistent_file(self, tmp_path):
+        """Test scanning non-existent proxy file"""
+        proxy_a = tmp_path / "NonExistent.rs"
+
+        introspector = AssetIntrospector()
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, set())
+
+        assert len(result) == 0
+
+    def test_scan_proxy_self_reference(self, tmp_path):
+        """Test that self-references are ignored"""
+        proxy_a = tmp_path / "ProxyA.rs"
+        proxy_a.write_bytes(f"ProxyA.rs\x00{proxy_a}\x00fake data".encode())
+
+        introspector = AssetIntrospector()
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, set())
+
+        assert len(result) == 0
+
+    def test_scan_proxy_multiple_references(self, tmp_path):
+        """Test proxy with multiple nested references"""
+        proxy_b = tmp_path / "ProxyB.rs"
+        proxy_b.write_bytes(b"fake data")
+        proxy_c = tmp_path / "ProxyC.rs"
+        proxy_c.write_bytes(b"fake data")
+
+        proxy_a = tmp_path / "ProxyA.rs"
+        proxy_a.write_bytes(b"./ProxyB.rs\x00./ProxyC.rs\x00fake data")
+
+        introspector = AssetIntrospector()
+        result = introspector._scan_redshift_proxy_for_references(proxy_a, set())
+
+        assert proxy_b in result
+        assert proxy_c in result
+
+    def test_parse_scene_assets_includes_nested_proxies(self, tmp_path):
+        """Test that parse_scene_assets includes nested proxy references"""
+        scene_file = tmp_path / "test.c4d"
+        scene_file.write_text("fake scene")
+
+        proxy_b = tmp_path / "ProxyB.rs"
+        proxy_b.write_bytes(b"fake proxy data")
+
+        proxy_a = tmp_path / "ProxyA.rs"
+        proxy_a.write_bytes(b"./ProxyB.rs\x00fake data")
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [{"filename": str(proxy_a), "exists": True}], kwargs["assetList"]
+            )
+
+            assets = AssetIntrospector().parse_scene_assets()
+
+            assert scene_file in assets
+            assert proxy_a in assets
+            assert proxy_b in assets  # Nested proxy should be included
+
+
 class TestMaxonDBAssets:
     """Test Maxon DB asset filtering and warning messages"""
 


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/270

### What was the problem/requirement? (What/Why)
When a Redshift proxy file is used(ProxyA) that contains another Redshift proxy file ( ProxyB), when you submit and render Deadline fails to find ProxyB (not caught in JA) and will will no render it.

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

- Have you run the unit tests?
yes

- Have you run the integration tests? (Add your integration test report below)
no

- Have you made changes to the submitter?
Yes

### Was this change documented?
No

### Is this a breaking change?
No