### PR TITLE
fix: detect nested Redshift proxy references in job attachments

### DIFF
--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -21,6 +21,54 @@ if not any(isinstance(h, WarningCollectorHandler) for h in logger.handlers):
 _FRAME_RE = re.compile("#+")
 
 
+def _collect_nested_redshift_proxies(proxy_path: Path, collected: set[Path]) -> None:
+    """
+    Recursively collects Redshift proxy files referenced within a proxy file.
+    Redshift proxy files (.rs) can reference other proxy files, creating nested dependencies.
+
+    Args:
+        proxy_path: Path to the Redshift proxy file to scan
+        collected: Set to accumulate all discovered proxy files (prevents infinite loops)
+    """
+    if not proxy_path.exists() or proxy_path in collected:
+        return
+
+    collected.add(proxy_path)
+
+    try:
+        with open(proxy_path, "rb") as f:
+            content = f.read()
+
+        # Search for .rs file references in the binary content
+        # Redshift proxy files store paths as null-terminated strings
+        # Split by null bytes and search for .rs extensions
+        null_separated = content.split(b"\x00")
+
+        for segment in null_separated:
+            try:
+                text = segment.decode("latin-1", errors="ignore").strip()
+            except Exception:
+                continue
+
+            # Check if this segment ends with .rs (case-insensitive)
+            if not text or len(text) < 3:
+                continue
+
+            if text.lower().endswith(".rs"):
+                nested_path = Path(text)
+
+                # If relative, resolve relative to the proxy file's directory
+                if not nested_path.is_absolute():
+                    nested_path = (proxy_path.parent / nested_path).resolve()
+
+                # Recursively collect nested proxies
+                if nested_path.exists() and nested_path.suffix.lower() == ".rs":
+                    _collect_nested_redshift_proxies(nested_path, collected)
+
+    except Exception as e:
+        logger.warning(f"Failed to scan Redshift proxy file {proxy_path} for nested proxies: {e}")
+
+
 class AssetIntrospector:
 
     def parse_scene_assets(self) -> set[Path]:
@@ -51,6 +99,9 @@ class AssetIntrospector:
             flags=c4d.ASSETDATA_FLAG_WITHFONTS,
         )
 
+        # Track Redshift proxy files for nested dependency scanning
+        redshift_proxies: set[Path] = set()
+
         for asset in asset_list:
             # Only process fonts on Windows. Mac font functionality is not supported
             if is_windows() and is_asset_a_font(asset):
@@ -69,7 +120,20 @@ class AssetIntrospector:
                 continue
 
             if exists is True and filename is not None:
-                assets.add(Path(filename))
+                asset_path = Path(filename)
+                assets.add(asset_path)
+
+                # Track Redshift proxy files for nested scanning
+                if asset_path.suffix.lower() == ".rs":
+                    redshift_proxies.add(asset_path)
+
+        # Recursively collect nested Redshift proxy dependencies
+        all_redshift_proxies: set[Path] = set()
+        for proxy_path in redshift_proxies:
+            _collect_nested_redshift_proxies(proxy_path, all_redshift_proxies)
+
+        # Add all discovered nested proxies to assets
+        assets.update(all_redshift_proxies)
 
         # Add all font files from the fonts directory to assets (Windows only)
         if is_windows():

--- a/test/unit/deadline_submitter_for_cinema4d/test_assets.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_assets.py
@@ -267,3 +267,119 @@ class TestMaxonDBAssets:
                 in caplog.text
             )
             assert "File > Save Project with Assets" in caplog.text
+
+
+class TestRedshiftProxyNesting:
+    """Test nested Redshift proxy file detection"""
+
+    def test_nested_redshift_proxies_are_collected(self, tmp_path):
+        """Test that nested Redshift proxy files are recursively collected"""
+        scene_dir = tmp_path / "scene"
+        scene_dir.mkdir()
+        scene_file = scene_dir / "test.c4d"
+
+        # Create mock Redshift proxy files
+        proxy_a = scene_dir / "ProxyA.rs"
+        proxy_b = scene_dir / "ProxyB.rs"
+        proxy_c = scene_dir / "ProxyC.rs"
+
+        # ProxyA references ProxyB
+        proxy_a.write_bytes(b"some binary data\x00ProxyB.rs\x00more data")
+        # ProxyB references ProxyC
+        proxy_b.write_bytes(b"some binary data\x00ProxyC.rs\x00more data")
+        # ProxyC has no nested references
+        proxy_c.write_bytes(b"some binary data\x00no nested proxies")
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            # GetAllAssetsNew only returns ProxyA (the top-level proxy)
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [{"filename": str(proxy_a), "exists": True}], kwargs["assetList"]
+            )
+
+            assets = AssetIntrospector().parse_scene_assets()
+
+            # All three proxies should be in the assets
+            assert proxy_a in assets
+            assert proxy_b in assets
+            assert proxy_c in assets
+
+    def test_circular_proxy_references_handled(self, tmp_path):
+        """Test that circular references in proxy files don't cause infinite loops"""
+        scene_dir = tmp_path / "scene"
+        scene_dir.mkdir()
+        scene_file = scene_dir / "test.c4d"
+
+        proxy_a = scene_dir / "ProxyA.rs"
+        proxy_b = scene_dir / "ProxyB.rs"
+
+        # Create circular reference: A -> B -> A
+        proxy_a.write_bytes(b"data\x00ProxyB.rs\x00data")
+        proxy_b.write_bytes(b"data\x00ProxyA.rs\x00data")
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [{"filename": str(proxy_a), "exists": True}], kwargs["assetList"]
+            )
+
+            # Should not hang or crash
+            assets = AssetIntrospector().parse_scene_assets()
+
+            assert proxy_a in assets
+            assert proxy_b in assets
+
+    def test_non_existent_nested_proxy_handled(self, tmp_path):
+        """Test that references to non-existent proxy files are handled gracefully"""
+        scene_dir = tmp_path / "scene"
+        scene_dir.mkdir()
+        scene_file = scene_dir / "test.c4d"
+
+        proxy_a = scene_dir / "ProxyA.rs"
+        # ProxyA references non-existent ProxyB
+        proxy_a.write_bytes(b"data\x00NonExistent.rs\x00data")
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [{"filename": str(proxy_a), "exists": True}], kwargs["assetList"]
+            )
+
+            # Should not crash
+            assets = AssetIntrospector().parse_scene_assets()
+
+            assert proxy_a in assets
+
+    def test_relative_path_proxy_references(self, tmp_path):
+        """Test that relative paths in proxy files are resolved correctly"""
+        scene_dir = tmp_path / "scene"
+        scene_dir.mkdir()
+        proxies_dir = scene_dir / "proxies"
+        proxies_dir.mkdir()
+        scene_file = scene_dir / "test.c4d"
+
+        proxy_a = scene_dir / "ProxyA.rs"
+        proxy_b = proxies_dir / "ProxyB.rs"
+
+        # ProxyA uses relative path to reference ProxyB
+        proxy_a.write_bytes(b"data\x00proxies/ProxyB.rs\x00data")
+        proxy_b.write_bytes(b"data\x00no nested")
+
+        with (
+            mock.patch.object(Scene, "name", return_value=str(scene_file)),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [{"filename": str(proxy_a), "exists": True}], kwargs["assetList"]
+            )
+
+            assets = AssetIntrospector().parse_scene_assets()
+
+            assert proxy_a in assets
+            assert proxy_b in assets


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/270

### What was the problem/requirement? (What/Why)
When a Redshift proxy file is used(ProxyA) that contains another Redshift proxy file ( ProxyB), when you submit and render Deadline fails to find ProxyB (not caught in JA) and will will no render it.

### What was the solution? (How)
Added recursive scanning of .rs files to detect nested proxy dependencies. The solution parses proxy files by splitting on null bytes, searches for .rs paths, and recursively collects all nested proxies. Includes cycle detection to prevent infinite loops.

### What is the impact of this change?
Nested Redshift proxies are now automatically included in job bundles, eliminating render failures and the need for manual workarounds. Minimal risk - only affects .rs file handling with proper error handling.

### How was this change tested?
Unit tests in test_assets.py covering: nested proxy chains (A→B→C), circular references, missing files, and relative path resolution.

- Have you run the unit tests?
Yes
<img width="1199" height="235" alt="Screenshot 2026-01-12 at 9 34 54 AM" src="https://github.com/user-attachments/assets/84977d95-ec04-4375-9b25-030cbee1edcd" />

- Have you run the integration tests? 
Yes
<img width="1894" height="699" alt="Screenshot 2026-01-12 at 10 04 42 AM" src="https://github.com/user-attachments/assets/84da7a35-a0dd-4b31-8fa6-9fdf084fb873" />

- Have you made changes to the submitter?
Yes
<img width="1178" height="590" alt="Screenshot 2026-01-12 at 9 56 55 AM" src="https://github.com/user-attachments/assets/b67eeba4-b786-4d7d-9ab6-14a9155151ff" />

### Was this change documented?
No

### Is this a breaking change?
No