### PR TITLE
docs: correct user guide troubleshooting page indentation

### DIFF
--- a/docs/user_guide/support.md
+++ b/docs/user_guide/support.md
@@ -11,9 +11,9 @@ Before reaching out for help, try these troubleshooting steps. They often resolv
 - **✅ Render one frame locally** - Before submitting to the cloud, render at least one frame locally in Cinema 4D to verify your scene renders correctly. This helps identify scene-specific issues vs. cloud rendering issues.
 
 - **✅ Update to the latest submitter** - We release updates frequently with bug fixes and improvements. Your issue may already be fixed in a newer version. To check if you're running the latest version:
-  1. Find your current version: The version is displayed in the submitter window title
-  2. Compare with the latest release: Visit the [releases page](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/releases) to see the most recent version
-  3. If your version is older, update the submitter and test again before reporting the issue
+  - Find your current version: The version is displayed in the submitter window title
+  - Compare with the latest release: Visit the [releases page](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/releases) to see the most recent version
+  - If your version is older, update the submitter and test again before reporting the issue
 
 - **✅ Check your Job-Specific Settings** - Review the Job-Specific Settings tab in the submitter. In particular, enable the **"Save Cinema 4D Project with Assets"** checkbox. This creates a temporary copy of your project with all assets and fixes file paths, helping identify missing files and organizing assets for render farms. [Learn more about this feature](submitter-features.md#job-specific-settings).
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The indentation of the "Update to the latest submitter" section in the [C4D user guide troubleshooting page](https://aws-deadline.github.io/cinema-4d/support/) has an unexpected indentation.

<img width="1085" height="520" alt="image" src="https://github.com/user-attachments/assets/78b1ee9d-78f5-4866-89ff-68720576318b" />

### What was the solution? (How)
Fixed the indentation.

### How was this change tested?

Previewed the page.

<img width="1303" height="858" alt="image" src="https://github.com/user-attachments/assets/874aa439-d3a3-44d6-a4e5-f377d0216fc7" />

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*