### PR TITLE
fix: Upgrade Python to >= 3.10 as 3.9 is EoL.

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           pip install --upgrade hatch

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,7 +21,7 @@ Table of Contents:
 
 To develop the Python code in this repository you will need:
 
-1. Python 3.9 or higher. We recommend [mise](https://github.com/jdx/mise) if you would like to run more than one version
+1. Python 3.10 or higher. We recommend [mise](https://github.com/jdx/mise) if you would like to run more than one version
    of Python on the same system. When running unit tests against all supported Python versions, for instance.
 2. The [hatch](https://github.com/pypa/hatch) package installed (`pip install --upgrade hatch`) into your Python environment.
 3. An install of a supported version of Cinema 4D.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This library requires:
 1. Cinema 4D 2024 - 2026
    * Redshift, Arnold, and Cargo are supported natively
    * V-Ray, X-Particles, and Red Giant are supported but require additional setup
-2. Python 3.9 or higher; but Python 3.11 is recommended as this is the version Cinema 4D uses natively.
+2. Python 3.10 or higher; but Python 3.11 is recommended as this is the version Cinema 4D uses natively.
 3. Windows or macOS operating system for job submission
 4. Windows or Linux operating system for job rendering
     * Cinema 4D 2024 - 2026 is supported on Windows

--- a/hatch.toml
+++ b/hatch.toml
@@ -22,7 +22,7 @@ lint = [
 ]
 
 [[envs.all.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [envs.release]
 detached = true

--- a/hatch.toml
+++ b/hatch.toml
@@ -22,7 +22,7 @@ lint = [
 ]
 
 [[envs.all.matrix]]
-python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+python = ["3.10", "3.11", "3.12", "3.13"]
 
 [envs.release]
 detached = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "deadline-cloud-for-cinema-4d"
 dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "AWS Deadline Cloud for Cinema 4D"
 authors = [
   {name = "Amazon Web Services"},
@@ -17,10 +17,11 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",
@@ -79,7 +80,7 @@ packages = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 check_untyped_defs = true
 show_error_codes = true
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from _project import get_project_dict, get_dependencies, Dependency
 
-SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 SUPPORTED_PLATFORMS = ["Windows", "Linux", "Darwin"]
 NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
 

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from _project import get_project_dict, get_dependencies, Dependency
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 SUPPORTED_PLATFORMS = ["Windows", "Linux", "Darwin"]
 NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Python 3.9 was EoL and our actions started failing because the deps no longer supported 3.9. 

Example: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/377 

Cinema 4D 2024+ natively uses Python 3.11 so it should be fine to upgrade. Keeping it to Python 3.10 after discussing with @epmog .

### What was the solution? (How)

Removed 3.9 and added latest versions up till 3.13 (deadline cloud supports until 3.13 so we cannot use 3.14)

### What is the impact of this change?

No issues 

### How was this change tested?

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
No

- Have you made changes to the submitter?
No

### Was this change documented?

Yes

### Is this a breaking change?

No, this should have no customer impact whatsoever. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*