### PR TITLE
fix: warn on .rs file detection and add FAQ for nested Redshift proxy files

### DIFF
--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -92,7 +92,7 @@ A: The submitter includes built-in error detection to catch common issues like m
 
 **Q: Are nested Redshift proxy files detected when submitting Cinema 4D jobs to Deadline?**
 
-A: No, Redshift proxy files are not detected when submitting Cinema 4D jobs to Deadline. This is a limitation of the Redshift .rs file format. When you export a Cinema 4D scene containing RS Proxy objects to.rs, all referenced proxy data is flattened/inlined into a single file - no external references are preserved. The Cinema 4D SDK cannot read.rs files to discover nested dependencies, and the Redshift Core doesn't expose this functionality either.
+A: No, Redshift proxy files are not detected when submitting Cinema 4D jobs to Deadline. This is a limitation of the Redshift *.rs file format. When you export a Cinema 4D scene containing RS Proxy objects to *.rs, all referenced proxy data is flattened/inlined into a single file - no external references are preserved. The Cinema 4D SDK cannot read *.rs files to discover nested dependencies, and the Redshift Core doesn't expose this functionality either.
 
 **Q: How do I enable detailed logging for debugging rendering issues?**
 

--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -93,6 +93,7 @@ A: The submitter includes built-in error detection to catch common issues like m
 **Q: Are nested Redshift proxy files detected when submitting Cinema 4D jobs to Deadline?**
 
 A: No, Redshift proxy files are not detected when submitting Cinema 4D jobs to Deadline. This is a limitation of the Redshift *.rs file format. When you export a Cinema 4D scene containing RS Proxy objects to *.rs, all referenced proxy data is flattened/inlined into a single file - no external references are preserved. The Cinema 4D SDK cannot read *.rs files to discover nested dependencies, and the Redshift Core doesn't expose this functionality either.
+Link to the forum post: https://developers.maxon.net/forum/topic/16370/cinema-4d-redshift-nested-redshift-proxy-files-not-detected-by-project-asset-inspector/2
 
 **Q: How do I enable detailed logging for debugging rendering issues?**
 

--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -90,6 +90,10 @@ A: Yes, you can set job priority levels in the submitter to control render queue
 
 A: The submitter includes built-in error detection to catch common issues like missing assets before submission. This can be deactivated in the submitter.
 
+**Q: Are nested Redshift proxy files detected when submitting Cinema 4D jobs to Deadline?**
+
+A: No, Redshift proxy files are not detected when submitting Cinema 4D jobs to Deadline. This is a limitation of the Redshift .rs file format. When you export a Cinema 4D scene containing RS Proxy objects to.rs, all referenced proxy data is flattened/inlined into a single file - no external references are preserved. The Cinema 4D SDK cannot read.rs files to discover nested dependencies, and the Redshift Core doesn't expose this functionality either.
+
 **Q: How do I enable detailed logging for debugging rendering issues?**
 
 A: The submitter includes an "Activate detailed logging" checkbox in the Job-Specific Settings that captures detailed logs for troubleshooting. When enabled:

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -21,6 +21,22 @@ if not any(isinstance(h, WarningCollectorHandler) for h in logger.handlers):
 _FRAME_RE = re.compile("#+")
 
 
+def _warn_if_redshift_proxies_detected(assets: set[Path]) -> None:
+    """
+    Log a warning if any Redshift proxy (.rs) files are present in the assets.
+
+    Args:
+        assets: Set of asset file paths
+    """
+    if any(str(asset).lower().endswith(".rs") for asset in assets):
+        logger.warning(
+            "Redshift proxy (.rs) file(s) detected in the scene assets.\n"
+            "Note that any nested .rs files referenced within these proxies "
+            "will NOT be automatically included in the job bundle. "
+            "Please manually verify and add any nested proxy dependencies "
+            "to ensure your render completes successfully."
+        )
+
 class AssetIntrospector:
 
     def parse_scene_assets(self) -> set[Path]:
@@ -71,15 +87,7 @@ class AssetIntrospector:
             if exists is True and filename is not None:
                 assets.add(Path(filename))
 
-        # Warn if any Redshift proxy files are present in assets
-        if any(str(asset).lower().endswith(".rs") for asset in assets):
-            logger.warning(
-                "Redshift proxy (.rs) file(s) detected in the scene assets.\n"
-                "Note that any nested .rs files referenced within these proxies "
-                "will NOT be automatically included in the job bundle. "
-                "Please manually verify and add any nested proxy dependencies "
-                "to ensure your render completes successfully."
-            )
+        _warn_if_redshift_proxies_detected(assets)
 
         # Add all font files from the fonts directory to assets (Windows only)
         if is_windows():

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -71,6 +71,16 @@ class AssetIntrospector:
             if exists is True and filename is not None:
                 assets.add(Path(filename))
 
+        # Warn if any Redshift proxy files are present in assets
+        if any(str(asset).lower().endswith(".rs") for asset in assets):
+            logger.warning(
+                "Redshift proxy (.rs) file(s) detected in the scene assets.\n"
+                "Note that any nested .rs files referenced within these proxies "
+                "will NOT be automatically included in the job bundle. "
+                "Please manually verify and add any nested proxy dependencies "
+                "to ensure your render completes successfully."
+            )
+
         # Add all font files from the fonts directory to assets (Windows only)
         if is_windows():
             fonts_dir = path_to_scene_file_dir / FONTS_DIR

--- a/src/deadline/cinema4d_submitter/assets.py
+++ b/src/deadline/cinema4d_submitter/assets.py
@@ -37,6 +37,7 @@ def _warn_if_redshift_proxies_detected(assets: set[Path]) -> None:
             "to ensure your render completes successfully."
         )
 
+
 class AssetIntrospector:
 
     def parse_scene_assets(self) -> set[Path]:

--- a/test/unit/deadline_submitter_for_cinema4d/test_assets.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_assets.py
@@ -267,3 +267,78 @@ class TestMaxonDBAssets:
                 in caplog.text
             )
             assert "File > Save Project with Assets" in caplog.text
+
+
+class TestRedshiftProxyWarning:
+    """Test warning message when .rs files are detected in scene assets"""
+
+    def test_warning_shown_when_rs_file_present(self, caplog):
+        """Test that a warning is logged when at least one .rs file is in assets"""
+        rs_asset = {"filename": "C:\\Users\\test-user\\proxy.rs", "exists": True}
+
+        with (
+            mock.patch.object(Scene, "name", return_value=TEST_SCENE_FILE_LOCATION),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [rs_asset], kwargs["assetList"]
+            )
+
+            assets = AssetIntrospector().parse_scene_assets()
+
+            assert Path("C:\\Users\\test-user\\proxy.rs") in assets
+            assert "Redshift proxy (.rs) file(s) detected" in caplog.text
+            assert "nested .rs files" in caplog.text
+            assert "will NOT be automatically included" in caplog.text
+
+    def test_no_warning_when_no_rs_files(self, caplog):
+        """Test that no .rs warning is logged when there are no .rs files"""
+        regular_asset = {"filename": "C:\\Users\\test-user\\texture.png", "exists": True}
+
+        with (
+            mock.patch.object(Scene, "name", return_value=TEST_SCENE_FILE_LOCATION),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [regular_asset], kwargs["assetList"]
+            )
+
+            AssetIntrospector().parse_scene_assets()
+
+            assert "Redshift proxy (.rs) file(s) detected" not in caplog.text
+
+    def test_warning_with_mixed_assets_including_rs(self, caplog):
+        """Test warning fires when .rs file is among other asset types"""
+        assets_list = [
+            {"filename": "C:\\Users\\test-user\\texture.png", "exists": True},
+            {"filename": "C:\\Users\\test-user\\model.rs", "exists": True},
+            {"filename": "C:\\Users\\test-user\\scene.obj", "exists": True},
+        ]
+
+        with (
+            mock.patch.object(Scene, "name", return_value=TEST_SCENE_FILE_LOCATION),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                assets_list, kwargs["assetList"]
+            )
+
+            AssetIntrospector().parse_scene_assets()
+
+            assert "Redshift proxy (.rs) file(s) detected" in caplog.text
+
+    def test_warning_with_uppercase_rs_extension(self, caplog):
+        """Test warning triggers for case-insensitive .RS extension"""
+        rs_asset = {"filename": "C:\\Users\\test-user\\proxy.RS", "exists": True}
+
+        with (
+            mock.patch.object(Scene, "name", return_value=TEST_SCENE_FILE_LOCATION),
+            mock.patch.object(c4d, "documents") as mock_docs,
+        ):
+            mock_docs.GetAllAssetsNew.side_effect = lambda *_, **kwargs: append_asset_list(
+                [rs_asset], kwargs["assetList"]
+            )
+
+            AssetIntrospector().parse_scene_assets()
+
+            assert "Redshift proxy (.rs) file(s) detected" in caplog.text


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/270

### What was the problem/requirement? (What/Why)
When a Redshift proxy file (.rs) references another nested .rs proxy file, the Cinema 4D submitter's job attachments process does not detect or include the nested dependency. This causes renders to fail on Deadline Cloud because the nested proxy (e.g., ProxyB) cannot be found on the worker. The Cinema 4D SDK cannot read .rs files to discover nested dependencies, and the Redshift Core doesn't expose this functionality either, so automatic detection is not feasible.

### What was the solution? (How)
Since we cannot programmatically resolve nested .rs dependencies, we removed the previous nested proxy scanning logic (which attempted to parse binary .rs files for references) and replaced it with a simple, always-on warning. Now, whenever at least one .rs file is detected in the scene assets, the submitter logs a warning informing the user that nested .rs files will not be automatically included in the job bundle and that they should manually verify and add any nested proxy dependencies. A corresponding FAQ entry was also added to the user guide explaining this limitation.

**Link to the forum post:** https://developers.maxon.net/forum/topic/16370/cinema-4d-redshift-nested-redshift-proxy-files-not-detected-by-project-asset-inspector/2

<img width="499" height="426" alt="Screenshot 2026-02-16 at 12 15 59 PM" src="https://github.com/user-attachments/assets/b09441cc-1288-4a1b-bb65-7f1db5484b86" />

### What is the impact of this change?
Users will now be proactively warned about the nested proxy limitation every time they submit a scene containing .rs files, rather than silently failing at render time. This gives them the opportunity to manually add nested dependencies (e.g., by including the proxy folder as a job attachments input folder) before submission.

### How was this change tested?
Tested by submitting nested proxies, .rs files, non .rs files, and mixed asset scenes in Cinema 4D. Unit tests were added covering: warning is shown when at least one .rs file is present, no warning when no .rs files exist, warning fires with mixed asset types including .rs, and case-insensitive .RS extension detection.

- Have you run the unit tests?
Yes
<img width="1257" height="319" alt="Screenshot 2026-02-16 at 1 03 50 PM" src="https://github.com/user-attachments/assets/dd973ec9-26ad-44f4-9041-d93013bef7ba" />

- Have you run the integration tests? 
Yes
<img width="1248" height="696" alt="Screenshot 2026-02-16 at 2 08 33 PM" src="https://github.com/user-attachments/assets/8891c6db-0bad-4497-8945-5c3d18eefa7f" />

- Have you made changes to the submitter?
Yes

### Was this change documented?
Yes

### Is this a breaking change?
No