### PR TITLE
fix: auto-deduplicate duplicate take names instead of raising an error

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -608,7 +608,7 @@ def deduplicate_take_names(submit_takes: list[TakeData]) -> None:
     _validate_duplicate_name_lengths(duplicated_names)
 
     all_names = {take.name for take in submit_takes}
-    next_suffix: dict[str, int] = {name: 1 for name in duplicated_names}
+    next_suffix: dict[str, int] = dict.fromkeys(duplicated_names, 1)
 
     for take in submit_takes:
         if take.name in next_suffix:
@@ -901,7 +901,6 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         Callback function for creating a job bundle when submitting the job.
         """
-        # Check for warnings before submission
         submit_takes = get_submit_takes(settings, takes)
         warn_duplicate_take_names(submit_takes)
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -542,10 +542,9 @@ def create_job_bundle(
         take.frame_range != first_frame_range for take in submit_takes
     )
 
-    # If there are multiple frame ranges and we're not overriding the range,
-    # then we create per-take Frames parameters.
-    if per_take_frames_parameters:
-        generate_take_parameter_names(submit_takes)
+    # Always deduplicate take names; only generate per-take Frames parameters
+    # when there are multiple frame ranges and we're not overriding the range.
+    generate_take_parameter_names(submit_takes, set_frames_parameters=per_take_frames_parameters)
 
     renderers: set[str] = {take_data.renderer_name for take_data in submit_takes}
     job_template = _get_job_template(settings, renderers, submit_takes, has_take_token)
@@ -586,38 +585,56 @@ def create_job_bundle(
     }
 
 
-def generate_take_parameter_names(submit_takes: list[TakeData]) -> None:
+def generate_take_parameter_names(
+    submit_takes: list[TakeData], set_frames_parameters: bool = True
+) -> None:
     """
-    This function generates unique take frame range parameter names
-    by combining each takes name with a unique suffix (if required)
-    while still meeting the requirements (letters+numbers+underscores,
-    max 64 chars, etc.) of a parameter name.
+    This function deduplicates take names (appending _1, _2, etc. for duplicates)
+    and generates unique take frame range parameter names by combining each take's
+    name with a unique suffix (if required) while still meeting the requirements
+    (letters+numbers+underscores, max 64 chars, etc.) of a parameter name.
+
+    If set_frames_parameters is False, only deduplication is performed and
+    frames_parameter_name is not set on the takes.
 
     The frame parameter names are saved to the input submit_takes.
     """
+
+    # Deduplicate take names by appending _1, _2, etc. for duplicates
+    name_counts: dict[str, int] = {}
+    for take in submit_takes:
+        name_counts[take.name] = name_counts.get(take.name, 0) + 1
+
+    duplicated_names = {name for name, count in name_counts.items() if count > 1}
+    if duplicated_names:
+        next_suffix: dict[str, int] = {name: 1 for name in duplicated_names}
+        for take in submit_takes:
+            if take.name in next_suffix:
+                suffix = next_suffix[take.name]
+                new_name = f"{take.name}_{suffix}"
+                take.name = new_name
+                take.display_name = new_name[:64]
+                next_suffix[new_name.rsplit("_", 1)[0]] = suffix + 1
+
+        renamed_list = ", ".join(f"'{name}'" for name in sorted(duplicated_names))
+        warning_collector.add_warning(
+            f"Duplicate take names were found: {renamed_list}. "
+            "They have been automatically renamed with _1, _2, etc. suffixes to ensure uniqueness."
+        )
+
+    if not set_frames_parameters:
+        return
 
     # parameter names must start with a letter or underscore
     allowed_first_job_parameter_chars = re.compile("[a-zA-Z_]")
     # parameter names must only contain letters, numbers, or underscores
     removed_job_parameter_chars = re.compile("[^a-zA-Z0-9_]")
 
-    take_names = set()
     parameter_names = set()
 
     for take_number in range(len(submit_takes)):
         take_data = submit_takes[take_number]
-
-        # First, check for duplicate take names since this will result in overwriting files in the output
-        # or other unexpected behaviour
-        # We do this here rather than earlier in submission because we get an error popup
-        # (rather than a quieter console error) for errors here.
         take_name = take_data.name
-        if take_name in take_names:
-            raise RuntimeError(
-                f"You have multiple takes named '{take_name}' with different render settings among the takes. "
-                "Please use unique take names."
-            )
-        take_names.add(take_name)
 
         # Now, determine the frame parameter name
         # remove all disallowed characters
@@ -834,6 +851,10 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         Callback function for creating a job bundle when submitting the job.
         """
+        # Deduplicate take names early so the warning shows in the dialog
+        submit_takes = get_submit_takes(settings, takes)
+        generate_take_parameter_names(submit_takes, set_frames_parameters=False)
+
         check_take_token_warnings(settings, takes)
 
         if warning_collector.has_warnings():

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -542,9 +542,6 @@ def create_job_bundle(
         take.frame_range != first_frame_range for take in submit_takes
     )
 
-    # Deduplicate take names (appends _1, _2, etc. for duplicates)
-    deduplicate_take_names(submit_takes)
-
     # If there are multiple frame ranges and we're not overriding the range,
     # then we create per-take Frames parameters.
     if per_take_frames_parameters:
@@ -589,11 +586,14 @@ def create_job_bundle(
     }
 
 
-def deduplicate_take_names(submit_takes: list[TakeData]) -> None:
+def deduplicate_take_names(submit_takes: list[TakeData]) -> set[str]:
     """
-    Checks for duplicate take names among the submitted takes and makes them
-    unique by appending _1, _2, etc. Adds a warning via warning_collector
-    so the user is informed of the renaming.
+    Checks for duplicate take names and makes them unique by appending
+    _1, _2, etc. suffixes. Handles collisions with existing take names
+    (e.g. 'take', 'take', 'take_1' won't produce two 'take_1' entries).
+
+    Returns the set of original names that were duplicated, or an empty set
+    if no duplicates were found.
     """
     name_counts: dict[str, int] = {}
     for take in submit_takes:
@@ -601,22 +601,41 @@ def deduplicate_take_names(submit_takes: list[TakeData]) -> None:
 
     duplicated_names = {name for name, count in name_counts.items() if count > 1}
     if not duplicated_names:
-        return
+        return set()
+
+    # Collect all existing names so generated names don't collide with them
+    all_names = {take.name for take in submit_takes}
 
     next_suffix: dict[str, int] = {name: 1 for name in duplicated_names}
     for take in submit_takes:
         if take.name in next_suffix:
-            suffix = next_suffix[take.name]
-            new_name = f"{take.name}_{suffix}"
+            original_name = take.name
+            suffix = next_suffix[original_name]
+            new_name = f"{original_name}_{suffix}"
+            # Skip suffixes that collide with existing take names
+            while new_name in all_names:
+                suffix += 1
+                new_name = f"{original_name}_{suffix}"
             take.name = new_name
             take.display_name = new_name[:64]
-            next_suffix[new_name.rsplit("_", 1)[0]] = suffix + 1
+            all_names.add(new_name)
+            next_suffix[original_name] = suffix + 1
 
-    renamed_list = ", ".join(f"'{name}'" for name in sorted(duplicated_names))
-    warning_collector.add_warning(
-        f"Duplicate take names were found: {renamed_list}. "
-        "They have been automatically renamed with _1, _2, etc. suffixes to ensure uniqueness."
-    )
+    return duplicated_names
+
+
+def warn_duplicate_take_names(submit_takes: list[TakeData]) -> None:
+    """
+    Deduplicates take names and adds a warning via warning_collector
+    if any duplicates were found.
+    """
+    duplicated_names = deduplicate_take_names(submit_takes)
+    if duplicated_names:
+        renamed_list = ", ".join(f"'{name}'" for name in sorted(duplicated_names))
+        warning_collector.add_warning(
+            f"Duplicate take names were found: {renamed_list}. "
+            "They have been automatically renamed with _1, _2, etc. suffixes to ensure uniqueness."
+        )
 
 
 def generate_take_parameter_names(submit_takes: list[TakeData]) -> None:
@@ -857,7 +876,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         # Deduplicate take names early so the warning shows in the dialog
         submit_takes = get_submit_takes(settings, takes)
-        deduplicate_take_names(submit_takes)
+        warn_duplicate_take_names(submit_takes)
 
         check_take_token_warnings(settings, takes)
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -589,7 +589,6 @@ def create_job_bundle(
     }
 
 
-
 def deduplicate_take_names(submit_takes: list[TakeData]) -> None:
     """
     Checks for duplicate take names among the submitted takes and makes them
@@ -661,7 +660,6 @@ def generate_take_parameter_names(submit_takes: list[TakeData]) -> None:
         # Append "Frames"
         # example: NewTake_00001Frames
         take_data.frames_parameter_name = f"{parameter_name}Frames"
-
 
 
 def setup_auto_detected_attachments(take_data_list: list[TakeData]) -> AssetReferences:

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -542,8 +542,9 @@ def create_job_bundle(
         take.frame_range != first_frame_range for take in submit_takes
     )
 
-    # If there are multiple frame ranges and we're not overriding the range,
-    # then we create per-take Frames parameters.
+    # Deduplicate take names, then generate per-take Frames parameters
+    # if there are multiple frame ranges and we're not overriding the range.
+    deduplicate_take_names(submit_takes)
     if per_take_frames_parameters:
         generate_take_parameter_names(submit_takes)
 
@@ -586,50 +587,76 @@ def create_job_bundle(
     }
 
 
-def deduplicate_take_names(submit_takes: list[TakeData]) -> set[str]:
+def _find_duplicate_take_names(submit_takes: list[TakeData]) -> set[str]:
+    """Returns the set of take names that appear more than once."""
+    name_counts: dict[str, int] = {}
+    for take in submit_takes:
+        name_counts[take.name] = name_counts.get(take.name, 0) + 1
+    return {name for name, count in name_counts.items() if count > 1}
+
+
+def deduplicate_take_names(submit_takes: list[TakeData]) -> None:
     """
     Checks for duplicate take names and makes them unique by appending
     _1, _2, etc. suffixes. Handles collisions with existing take names
     (e.g. 'take', 'take', 'take_1' won't produce two 'take_1' entries).
-
-    Returns the set of original names that were duplicated, or an empty set
-    if no duplicates were found.
     """
-    name_counts: dict[str, int] = {}
-    for take in submit_takes:
-        name_counts[take.name] = name_counts.get(take.name, 0) + 1
-
-    duplicated_names = {name for name, count in name_counts.items() if count > 1}
+    duplicated_names = _find_duplicate_take_names(submit_takes)
     if not duplicated_names:
-        return set()
+        return
 
-    # Collect all existing names so generated names don't collide with them
+    _validate_duplicate_name_lengths(duplicated_names)
+
     all_names = {take.name for take in submit_takes}
-
     next_suffix: dict[str, int] = {name: 1 for name in duplicated_names}
+
     for take in submit_takes:
         if take.name in next_suffix:
-            original_name = take.name
-            suffix = next_suffix[original_name]
-            new_name = f"{original_name}_{suffix}"
-            # Skip suffixes that collide with existing take names
-            while new_name in all_names:
-                suffix += 1
-                new_name = f"{original_name}_{suffix}"
-            take.name = new_name
-            take.display_name = new_name[:64]
+            new_name, next_start = _generate_unique_name(
+                take.name, next_suffix[take.name], all_names
+            )
+            _apply_take_name(take, new_name)
             all_names.add(new_name)
-            next_suffix[original_name] = suffix + 1
+            next_suffix[take.name] = next_start
 
-    return duplicated_names
+
+def _validate_duplicate_name_lengths(duplicated_names: set[str]) -> None:
+    """Raises RuntimeError if any duplicated take name is already at the 64-char limit."""
+    for name in duplicated_names:
+        if len(name) >= 64:
+            raise RuntimeError(
+                f"Multiple takes share the name '{name}', which is already 64 characters long. "
+                "Please shorten or rename the duplicate takes so they can be uniquely identified."
+            )
+
+
+def _generate_unique_name(
+    original_name: str, start_suffix: int, existing_names: set[str]
+) -> tuple[str, int]:
+    """Finds the next available suffixed name that doesn't collide with existing names.
+
+    Returns the unique name and the next suffix to try for this original name.
+    """
+    suffix = start_suffix
+    new_name = f"{original_name}_{suffix}"
+    while new_name in existing_names:
+        suffix += 1
+        new_name = f"{original_name}_{suffix}"
+    return new_name, suffix + 1
+
+
+def _apply_take_name(take: TakeData, new_name: str) -> None:
+    """Applies a new name to a take, truncating display_name to 64 characters."""
+    take.name = new_name
+    take.display_name = new_name[:64]
 
 
 def warn_duplicate_take_names(submit_takes: list[TakeData]) -> None:
     """
-    Deduplicates take names and adds a warning via warning_collector
-    if any duplicates were found.
+    Checks for duplicate take names and adds a warning via warning_collector
+    if any are found.
     """
-    duplicated_names = deduplicate_take_names(submit_takes)
+    duplicated_names = _find_duplicate_take_names(submit_takes)
     if duplicated_names:
         renamed_list = ", ".join(f"'{name}'" for name in sorted(duplicated_names))
         warning_collector.add_warning(
@@ -874,7 +901,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         Callback function for creating a job bundle when submitting the job.
         """
-        # Deduplicate take names early so the warning shows in the dialog
+        # Check for warnings before submission
         submit_takes = get_submit_takes(settings, takes)
         warn_duplicate_take_names(submit_takes)
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -542,9 +542,13 @@ def create_job_bundle(
         take.frame_range != first_frame_range for take in submit_takes
     )
 
-    # Always deduplicate take names; only generate per-take Frames parameters
-    # when there are multiple frame ranges and we're not overriding the range.
-    generate_take_parameter_names(submit_takes, set_frames_parameters=per_take_frames_parameters)
+    # Deduplicate take names (appends _1, _2, etc. for duplicates)
+    deduplicate_take_names(submit_takes)
+
+    # If there are multiple frame ranges and we're not overriding the range,
+    # then we create per-take Frames parameters.
+    if per_take_frames_parameters:
+        generate_take_parameter_names(submit_takes)
 
     renderers: set[str] = {take_data.renderer_name for take_data in submit_takes}
     job_template = _get_job_template(settings, renderers, submit_takes, has_take_token)
@@ -585,45 +589,46 @@ def create_job_bundle(
     }
 
 
-def generate_take_parameter_names(
-    submit_takes: list[TakeData], set_frames_parameters: bool = True
-) -> None:
+
+def deduplicate_take_names(submit_takes: list[TakeData]) -> None:
     """
-    This function deduplicates take names (appending _1, _2, etc. for duplicates)
-    and generates unique take frame range parameter names by combining each take's
-    name with a unique suffix (if required) while still meeting the requirements
-    (letters+numbers+underscores, max 64 chars, etc.) of a parameter name.
-
-    If set_frames_parameters is False, only deduplication is performed and
-    frames_parameter_name is not set on the takes.
-
-    The frame parameter names are saved to the input submit_takes.
+    Checks for duplicate take names among the submitted takes and makes them
+    unique by appending _1, _2, etc. Adds a warning via warning_collector
+    so the user is informed of the renaming.
     """
-
-    # Deduplicate take names by appending _1, _2, etc. for duplicates
     name_counts: dict[str, int] = {}
     for take in submit_takes:
         name_counts[take.name] = name_counts.get(take.name, 0) + 1
 
     duplicated_names = {name for name, count in name_counts.items() if count > 1}
-    if duplicated_names:
-        next_suffix: dict[str, int] = {name: 1 for name in duplicated_names}
-        for take in submit_takes:
-            if take.name in next_suffix:
-                suffix = next_suffix[take.name]
-                new_name = f"{take.name}_{suffix}"
-                take.name = new_name
-                take.display_name = new_name[:64]
-                next_suffix[new_name.rsplit("_", 1)[0]] = suffix + 1
-
-        renamed_list = ", ".join(f"'{name}'" for name in sorted(duplicated_names))
-        warning_collector.add_warning(
-            f"Duplicate take names were found: {renamed_list}. "
-            "They have been automatically renamed with _1, _2, etc. suffixes to ensure uniqueness."
-        )
-
-    if not set_frames_parameters:
+    if not duplicated_names:
         return
+
+    next_suffix: dict[str, int] = {name: 1 for name in duplicated_names}
+    for take in submit_takes:
+        if take.name in next_suffix:
+            suffix = next_suffix[take.name]
+            new_name = f"{take.name}_{suffix}"
+            take.name = new_name
+            take.display_name = new_name[:64]
+            next_suffix[new_name.rsplit("_", 1)[0]] = suffix + 1
+
+    renamed_list = ", ".join(f"'{name}'" for name in sorted(duplicated_names))
+    warning_collector.add_warning(
+        f"Duplicate take names were found: {renamed_list}. "
+        "They have been automatically renamed with _1, _2, etc. suffixes to ensure uniqueness."
+    )
+
+
+def generate_take_parameter_names(submit_takes: list[TakeData]) -> None:
+    """
+    This function generates unique take frame range parameter names
+    by combining each takes name with a unique suffix (if required)
+    while still meeting the requirements (letters+numbers+underscores,
+    max 64 chars, etc.) of a parameter name.
+
+    The frame parameter names are saved to the input submit_takes.
+    """
 
     # parameter names must start with a letter or underscore
     allowed_first_job_parameter_chars = re.compile("[a-zA-Z_]")
@@ -636,7 +641,7 @@ def generate_take_parameter_names(
         take_data = submit_takes[take_number]
         take_name = take_data.name
 
-        # Now, determine the frame parameter name
+        # determine the frame parameter name
         # remove all disallowed characters
         parameter_name = removed_job_parameter_chars.sub("", take_data.display_name)[
             : 64 - len("Frames")
@@ -656,6 +661,7 @@ def generate_take_parameter_names(
         # Append "Frames"
         # example: NewTake_00001Frames
         take_data.frames_parameter_name = f"{parameter_name}Frames"
+
 
 
 def setup_auto_detected_attachments(take_data_list: list[TakeData]) -> AssetReferences:
@@ -853,7 +859,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowFlags()):
         """
         # Deduplicate take names early so the warning shows in the dialog
         submit_takes = get_submit_takes(settings, takes)
-        generate_take_parameter_names(submit_takes, set_frames_parameters=False)
+        deduplicate_take_names(submit_takes)
 
         check_take_token_warnings(settings, takes)
 

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -378,6 +378,51 @@ class TestDeduplicateTakeNames:
         assert takes[1].frames_parameter_name is not None
         assert takes[0].frames_parameter_name != takes[1].frames_parameter_name
 
+    def test_empty_list_no_error(self):
+        takes: list[TakeData] = []
+        deduplicate_take_names(takes)
+        assert takes == []
+
+    def test_single_take_no_changes(self):
+        takes = [
+            TakeData("OnlyTake", "OnlyTake", "standard", "", None, "1-10", set(), False),
+        ]
+        deduplicate_take_names(takes)
+        assert takes[0].name == "OnlyTake"
+
+    def test_duplicate_name_at_64_chars_raises_error(self):
+        long_name = "A" * 64
+        takes = [
+            TakeData(long_name, long_name, "standard", "", None, "1-10", set(), False),
+            TakeData(long_name, long_name, "standard", "", None, "1-20", set(), False),
+        ]
+        try:
+            deduplicate_take_names(takes)
+            assert False, "Expected RuntimeError was not raised"
+        except RuntimeError as e:
+            assert "shorten or rename the duplicate takes" in str(e)
+
+    def test_duplicate_name_at_63_chars_does_not_raise(self):
+        name_63 = "A" * 63
+        takes = [
+            TakeData(name_63, name_63, "standard", "", None, "1-10", set(), False),
+            TakeData(name_63, name_63, "standard", "", None, "1-20", set(), False),
+        ]
+        deduplicate_take_names(takes)
+        assert takes[0].name == f"{name_63}_1"
+        assert takes[1].name == f"{name_63}_2"
+
+    def test_display_name_truncated_to_64_chars(self):
+        name_63 = "A" * 63
+        takes = [
+            TakeData(name_63, name_63, "standard", "", None, "1-10", set(), False),
+            TakeData(name_63, name_63, "standard", "", None, "1-20", set(), False),
+        ]
+        deduplicate_take_names(takes)
+        # name_63 + "_1" = 65 chars, display_name should be truncated to 64
+        assert len(takes[0].display_name) == 64
+        assert len(takes[1].display_name) == 64
+
 
 class TestWarnDuplicateTakeNames:
     """Test cases for warn_duplicate_take_names warning behavior."""

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -7,6 +7,7 @@ from deadline.cinema4d_submitter.cinema4d_render_submitter import (
     _get_job_template,
     TakeData,
     check_take_token_warnings,
+    deduplicate_take_names,
     generate_take_parameter_names,
 )
 from deadline.cinema4d_submitter.data_classes import (
@@ -266,7 +267,7 @@ class TestCheckTakeTokenWarnings:
 
 
 class TestGenerateTakeParameterNamesDeduplication:
-    """Test cases for duplicate take name deduplication in generate_take_parameter_names."""
+    """Test cases for duplicate take name deduplication in deduplicate_take_names."""
 
     def setup_method(self):
         warning_collector.clear_warnings()
@@ -276,7 +277,7 @@ class TestGenerateTakeParameterNamesDeduplication:
             TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
             TakeData("Take2", "Take2", "standard", "", None, "1-20", set(), False),
         ]
-        generate_take_parameter_names(takes)
+        deduplicate_take_names(takes)
 
         assert not warning_collector.has_warnings()
         assert takes[0].name == "Take1"
@@ -287,7 +288,7 @@ class TestGenerateTakeParameterNamesDeduplication:
             TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
             TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
         ]
-        generate_take_parameter_names(takes)
+        deduplicate_take_names(takes)
 
         assert takes[0].name == "MyTake_1"
         assert takes[1].name == "MyTake_2"
@@ -297,7 +298,7 @@ class TestGenerateTakeParameterNamesDeduplication:
             TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
             TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
         ]
-        generate_take_parameter_names(takes)
+        deduplicate_take_names(takes)
 
         assert warning_collector.has_warnings()
         warnings = warning_collector.get_warnings()
@@ -311,7 +312,7 @@ class TestGenerateTakeParameterNamesDeduplication:
             TakeData("Dup", "Dup", "standard", "", None, "1-20", set(), False),
             TakeData("Dup", "Dup", "standard", "", None, "1-30", set(), False),
         ]
-        generate_take_parameter_names(takes)
+        deduplicate_take_names(takes)
 
         assert takes[0].name == "Dup_1"
         assert takes[1].name == "Dup_2"
@@ -324,7 +325,7 @@ class TestGenerateTakeParameterNamesDeduplication:
             TakeData("A", "A", "standard", "", None, "1-30", set(), False),
             TakeData("B", "B", "standard", "", None, "1-40", set(), False),
         ]
-        generate_take_parameter_names(takes)
+        deduplicate_take_names(takes)
 
         assert takes[0].name == "A_1"
         assert takes[1].name == "B_1"
@@ -337,7 +338,7 @@ class TestGenerateTakeParameterNamesDeduplication:
             TakeData("Dup", "Dup", "standard", "", None, "1-20", set(), False),
             TakeData("Dup", "Dup", "standard", "", None, "1-30", set(), False),
         ]
-        generate_take_parameter_names(takes)
+        deduplicate_take_names(takes)
 
         assert takes[0].name == "Unique"
         assert takes[1].name == "Dup_1"
@@ -348,21 +349,18 @@ class TestGenerateTakeParameterNamesDeduplication:
             TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
             TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
         ]
-        generate_take_parameter_names(takes)
+        deduplicate_take_names(takes)
 
         assert takes[0].display_name == "MyTake_1"
         assert takes[1].display_name == "MyTake_2"
 
-    def test_dedup_only_mode_skips_frames_parameters(self):
+    def test_dedup_does_not_set_frames_parameters(self):
         takes = [
             TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
             TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
         ]
-        generate_take_parameter_names(takes, set_frames_parameters=False)
+        deduplicate_take_names(takes)
 
-        assert takes[0].name == "MyTake_1"
-        assert takes[1].name == "MyTake_2"
-        # frames_parameter_name should remain None
         assert takes[0].frames_parameter_name is None
         assert takes[1].frames_parameter_name is None
 
@@ -371,7 +369,8 @@ class TestGenerateTakeParameterNamesDeduplication:
             TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
             TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
         ]
-        generate_take_parameter_names(takes, set_frames_parameters=True)
+        deduplicate_take_names(takes)
+        generate_take_parameter_names(takes)
 
         assert takes[0].frames_parameter_name is not None
         assert takes[1].frames_parameter_name is not None

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -8,6 +8,7 @@ from deadline.cinema4d_submitter.cinema4d_render_submitter import (
     TakeData,
     check_take_token_warnings,
     deduplicate_take_names,
+    warn_duplicate_take_names,
     generate_take_parameter_names,
 )
 from deadline.cinema4d_submitter.data_classes import (
@@ -266,20 +267,19 @@ class TestCheckTakeTokenWarnings:
         assert "$take token" in warning_collector.get_warnings()[0]
 
 
-class TestGenerateTakeParameterNamesDeduplication:
-    """Test cases for duplicate take name deduplication in deduplicate_take_names."""
+class TestDeduplicateTakeNames:
+    """Test cases for duplicate take name deduplication."""
 
     def setup_method(self):
         warning_collector.clear_warnings()
 
-    def test_no_duplicates_no_warning(self):
+    def test_no_duplicates_no_changes(self):
         takes = [
             TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
             TakeData("Take2", "Take2", "standard", "", None, "1-20", set(), False),
         ]
         deduplicate_take_names(takes)
 
-        assert not warning_collector.has_warnings()
         assert takes[0].name == "Take1"
         assert takes[1].name == "Take2"
 
@@ -292,19 +292,6 @@ class TestGenerateTakeParameterNamesDeduplication:
 
         assert takes[0].name == "MyTake_1"
         assert takes[1].name == "MyTake_2"
-
-    def test_duplicate_names_warning_is_added(self):
-        takes = [
-            TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
-            TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
-        ]
-        deduplicate_take_names(takes)
-
-        assert warning_collector.has_warnings()
-        warnings = warning_collector.get_warnings()
-        assert len(warnings) == 1
-        assert "MyTake" in warnings[0]
-        assert "_1, _2" in warnings[0]
 
     def test_three_duplicates_get_suffixed(self):
         takes = [
@@ -364,6 +351,21 @@ class TestGenerateTakeParameterNamesDeduplication:
         assert takes[0].frames_parameter_name is None
         assert takes[1].frames_parameter_name is None
 
+    def test_suffix_collision_with_existing_name(self):
+        """e.g. my_take, my_take, my_take_1 should not produce two my_take_1 entries."""
+        takes = [
+            TakeData("my_take", "my_take", "standard", "", None, "1-10", set(), False),
+            TakeData("my_take", "my_take", "standard", "", None, "1-20", set(), False),
+            TakeData("my_take_1", "my_take_1", "standard", "", None, "1-30", set(), False),
+        ]
+        deduplicate_take_names(takes)
+
+        assert takes[0].name == "my_take_2"
+        assert takes[1].name == "my_take_3"
+        assert takes[2].name == "my_take_1"
+        names = [t.name for t in takes]
+        assert len(names) == len(set(names))
+
     def test_frames_parameters_set_after_dedup(self):
         takes = [
             TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
@@ -375,3 +377,32 @@ class TestGenerateTakeParameterNamesDeduplication:
         assert takes[0].frames_parameter_name is not None
         assert takes[1].frames_parameter_name is not None
         assert takes[0].frames_parameter_name != takes[1].frames_parameter_name
+
+
+class TestWarnDuplicateTakeNames:
+    """Test cases for warn_duplicate_take_names warning behavior."""
+
+    def setup_method(self):
+        warning_collector.clear_warnings()
+
+    def test_no_duplicates_no_warning(self):
+        takes = [
+            TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
+            TakeData("Take2", "Take2", "standard", "", None, "1-20", set(), False),
+        ]
+        warn_duplicate_take_names(takes)
+
+        assert not warning_collector.has_warnings()
+
+    def test_duplicate_names_warning_is_added(self):
+        takes = [
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
+        ]
+        warn_duplicate_take_names(takes)
+
+        assert warning_collector.has_warnings()
+        warnings = warning_collector.get_warnings()
+        assert len(warnings) == 1
+        assert "MyTake" in warnings[0]
+        assert "_1, _2" in warnings[0]

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -7,6 +7,7 @@ from deadline.cinema4d_submitter.cinema4d_render_submitter import (
     _get_job_template,
     TakeData,
     check_take_token_warnings,
+    generate_take_parameter_names,
 )
 from deadline.cinema4d_submitter.data_classes import (
     RenderSubmitterUISettings,
@@ -262,3 +263,116 @@ class TestCheckTakeTokenWarnings:
 
         assert warning_collector.has_warnings()
         assert "$take token" in warning_collector.get_warnings()[0]
+
+
+class TestGenerateTakeParameterNamesDeduplication:
+    """Test cases for duplicate take name deduplication in generate_take_parameter_names."""
+
+    def setup_method(self):
+        warning_collector.clear_warnings()
+
+    def test_no_duplicates_no_warning(self):
+        takes = [
+            TakeData("Take1", "Take1", "standard", "", None, "1-10", set(), False),
+            TakeData("Take2", "Take2", "standard", "", None, "1-20", set(), False),
+        ]
+        generate_take_parameter_names(takes)
+
+        assert not warning_collector.has_warnings()
+        assert takes[0].name == "Take1"
+        assert takes[1].name == "Take2"
+
+    def test_duplicate_names_get_suffixed(self):
+        takes = [
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
+        ]
+        generate_take_parameter_names(takes)
+
+        assert takes[0].name == "MyTake_1"
+        assert takes[1].name == "MyTake_2"
+
+    def test_duplicate_names_warning_is_added(self):
+        takes = [
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
+        ]
+        generate_take_parameter_names(takes)
+
+        assert warning_collector.has_warnings()
+        warnings = warning_collector.get_warnings()
+        assert len(warnings) == 1
+        assert "MyTake" in warnings[0]
+        assert "_1, _2" in warnings[0]
+
+    def test_three_duplicates_get_suffixed(self):
+        takes = [
+            TakeData("Dup", "Dup", "standard", "", None, "1-10", set(), False),
+            TakeData("Dup", "Dup", "standard", "", None, "1-20", set(), False),
+            TakeData("Dup", "Dup", "standard", "", None, "1-30", set(), False),
+        ]
+        generate_take_parameter_names(takes)
+
+        assert takes[0].name == "Dup_1"
+        assert takes[1].name == "Dup_2"
+        assert takes[2].name == "Dup_3"
+
+    def test_multiple_duplicate_groups(self):
+        takes = [
+            TakeData("A", "A", "standard", "", None, "1-10", set(), False),
+            TakeData("B", "B", "standard", "", None, "1-20", set(), False),
+            TakeData("A", "A", "standard", "", None, "1-30", set(), False),
+            TakeData("B", "B", "standard", "", None, "1-40", set(), False),
+        ]
+        generate_take_parameter_names(takes)
+
+        assert takes[0].name == "A_1"
+        assert takes[1].name == "B_1"
+        assert takes[2].name == "A_2"
+        assert takes[3].name == "B_2"
+
+    def test_mixed_unique_and_duplicate(self):
+        takes = [
+            TakeData("Unique", "Unique", "standard", "", None, "1-10", set(), False),
+            TakeData("Dup", "Dup", "standard", "", None, "1-20", set(), False),
+            TakeData("Dup", "Dup", "standard", "", None, "1-30", set(), False),
+        ]
+        generate_take_parameter_names(takes)
+
+        assert takes[0].name == "Unique"
+        assert takes[1].name == "Dup_1"
+        assert takes[2].name == "Dup_2"
+
+    def test_display_name_updated_on_dedup(self):
+        takes = [
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
+        ]
+        generate_take_parameter_names(takes)
+
+        assert takes[0].display_name == "MyTake_1"
+        assert takes[1].display_name == "MyTake_2"
+
+    def test_dedup_only_mode_skips_frames_parameters(self):
+        takes = [
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
+        ]
+        generate_take_parameter_names(takes, set_frames_parameters=False)
+
+        assert takes[0].name == "MyTake_1"
+        assert takes[1].name == "MyTake_2"
+        # frames_parameter_name should remain None
+        assert takes[0].frames_parameter_name is None
+        assert takes[1].frames_parameter_name is None
+
+    def test_frames_parameters_set_after_dedup(self):
+        takes = [
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-10", set(), False),
+            TakeData("MyTake", "MyTake", "standard", "", None, "1-20", set(), False),
+        ]
+        generate_take_parameter_names(takes, set_frames_parameters=True)
+
+        assert takes[0].frames_parameter_name is not None
+        assert takes[1].frames_parameter_name is not None
+        assert takes[0].frames_parameter_name != takes[1].frames_parameter_name


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/398

### What was the problem/requirement? (What/Why)
When a customer creates multiple takes with the same name in Cinema 4D, submission to Deadline Cloud fails with a RuntimeError. This is a poor user experience — the error is unhelpful and blocks submission entirely.

### What was the solution? (How)
Refactored deduplicate_take_names by extracting its internal logic into single-responsibility helper functions:

- _find_duplicate_take_names — identifies which take names appear more than once.
- _validate_duplicate_name_lengths — raises a RuntimeError if any duplicated take name is already at the 64-character limit, since a suffix can't be appended without truncating the display name.
- _generate_unique_name — finds the next available _{n} suffix that doesn't collide with any existing take name.
- _apply_take_name — writes the new name onto the take and truncates display_name to 64 characters.
- deduplicate_take_names now orchestrates these helpers: find duplicates, validate lengths, then loop through takes and rename collisions. The behavior is identical — e.g. take, take, take_1 still correctly produces take_2, take_3, take_1 — but each piece is independently testable and easier to reason about.

The callback calls warn_duplicate_take_names before the warning dialog, so the user sees the dedup warning alongside any other warnings and can choose to continue or cancel.

### What is the impact of this change?
Duplicate take names no longer block submission with a RuntimeError. Instead, they are automatically made unique and the user is informed via the existing warning dialog. No changes to the adaptor, init-data, or run-data.

### How was this change tested?
16 unit tests across two test classes:

TestDeduplicateTakeNames (14 tests):

1. test_no_duplicates_no_changes — unique takes are left unchanged
2. test_duplicate_names_get_suffixed — two identical names become MyTake_1, MyTake_2
3. test_three_duplicates_get_suffixed — three identical names get _1, _2, _3
4. test_multiple_duplicate_groups — separate duplicate groups (A, B) are suffixed independently
5. test_mixed_unique_and_duplicate — unique takes stay unchanged, only duplicates get suffixed
6. test_display_name_updated_on_dedup — display_name is updated alongside name
7. test_dedup_does_not_set_frames_parameters — dedup leaves frames_parameter_name as None
8. test_suffix_collision_with_existing_name — my_take, my_take, my_take_1 correctly produces my_take_2, my_take_3, my_take_1 with no collisions
9. test_frames_parameters_set_after_dedup — generate_take_parameter_names produces unique frame parameter names after deduplication
10. test_empty_list_no_error — empty input doesn't error
11. test_single_take_no_changes — single take is left unchanged
12. test_duplicate_name_at_64_chars_raises_error — RuntimeError raised when duplicate name is already 64 chars
13. test_duplicate_name_at_63_chars_does_not_raise — 63-char duplicates are suffixed normally without error
14. test_display_name_truncated_to_64_chars — display_name is capped at 64 chars when suffix pushes it over

TestWarnDuplicateTakeNames (2 tests):

1. test_no_duplicates_no_warning — no warning when all names are unique
2. test_duplicate_names_warning_is_added — warning is emitted mentioning the duplicated name and the _1, _2 suffixes

- Have you run the unit tests?
Yes.

<img width="2080" height="492" alt="Screenshot 2026-03-03 at 10 25 45 AM" src="https://github.com/user-attachments/assets/d5089d53-d4d9-4897-bf6d-b35ae5817e12" />

- Have you run the integration tests?
Yes.
<img width="1245" height="697" alt="Screenshot 2026-03-03 at 10 53 13 AM" src="https://github.com/user-attachments/assets/ad81fc58-f7c4-4b9f-a950-050d89283c48" />

- Have you made changes to the submitter?
Yes. Changes are limited to generate_take_parameter_names in cinema4d_render_submitter.py and the on_create_job_bundle_callback that calls it. No changes to integ_test_helpers.py.

<img width="369" height="241" alt="Screenshot 2026-03-04 at 9 27 00 AM" src="https://github.com/user-attachments/assets/fba15f03-ebbc-45c6-bd3d-356bbb41360f" />

<img width="499" height="428" alt="2" src="https://github.com/user-attachments/assets/6db62bfc-f318-4c10-98ca-d4fab0bfb763" />

<img width="791" height="442" alt="Screenshot 2026-03-04 at 9 26 47 AM" src="https://github.com/user-attachments/assets/f388ad48-8d76-4d48-9762-5e60ba343039" />

<img width="731" height="288" alt="Screenshot 2026-03-04 at 9 38 00 AM" src="https://github.com/user-attachments/assets/7feb5f92-bdc7-4f1a-a636-f17159ad6eb6" />

<img width="706" height="158" alt="Screenshot 2026-03-04 at 2 34 37 PM" src="https://github.com/user-attachments/assets/cc83db1f-c207-4cbd-9630-35fd967902d2" />

### Was this change documented?
No.

### Is this a breaking change?
No.