### PR TITLE
feat!: Add tile rendering within submitter.

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -119,7 +119,7 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
-        return SemanticVersion(major=0, minor=3)
+        return SemanticVersion(major=0, minor=4)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:
@@ -514,7 +514,14 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
             if name in run_data:
                 self._action_queue.enqueue_action(Action(name, {name: run_data[name]}))
 
-        self._action_queue.enqueue_action(Action("start_render", {"frame": run_data["frame"]}))
+        # Dispatch based on tile_action: "assemble", "render" (tile), or absent (normal)
+        tile_action = run_data.get("tile_action")
+        if tile_action == "assemble":
+            assemble_data = self._build_assemble_tiles_data(run_data)
+            self._action_queue.enqueue_action(Action("assemble_tiles", assemble_data))
+        else:
+            start_render_data = self._build_start_render_data(run_data)
+            self._action_queue.enqueue_action(Action("start_render", start_render_data))
 
         while self._cinema4d_is_rendering and not self._has_exception:
             time.sleep(0.1)  # busy wait so that on_cleanup is not called
@@ -529,6 +536,35 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                 "Cinema4D exited early and did not render successfully, please check render logs. "
                 f"Exit code {exit_code}"
             )
+
+    _TILE_KEYS = (
+        "current_tile_column",
+        "current_tile_row",
+        "total_tiles_column",
+        "total_tiles_row",
+    )
+
+    def _build_start_render_data(self, run_data: dict) -> dict:
+        """Build the data dict sent to the start_render action."""
+        data: dict = {"frame": run_data["frame"]}
+        if run_data.get("tile_action") == "render":
+            data["tile_action"] = "render"
+        for key in self._TILE_KEYS:
+            if key in run_data:
+                # OpenJD step parameters arrive as strings; cast to int for the renderer.
+                data[key] = int(run_data[key])
+        return data
+
+    def _build_assemble_tiles_data(self, run_data: dict) -> dict:
+        """Build the data dict sent to the assemble_tiles action."""
+        return {
+            "frame": run_data["frame"],
+            # OpenJD step parameters arrive as strings; cast to int for the renderer.
+            "total_tiles_column": int(run_data["total_tiles_column"]),
+            "total_tiles_row": int(run_data["total_tiles_row"]),
+            "output_path": run_data.get("output_path", ""),
+            "multi_pass_path": run_data.get("multi_pass_path", ""),
+        }
 
     def on_stop(self) -> None:
         """ """

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/run_data.schema.json
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/run_data.schema.json
@@ -2,7 +2,14 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-      "frame": { "type": "number" }
+      "frame": { "type": "string" },
+      "current_tile_column": { "type": "string" },
+      "current_tile_row": { "type": "string" },
+      "total_tiles_column": { "type": "integer" },
+      "total_tiles_row": { "type": "integer" },
+      "tile_action": { "type": "string", "enum": ["render", "assemble"] },
+      "output_path": { "type": "string" },
+      "multi_pass_path": { "type": "string" }
     },
     "required":[
       "frame"

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -5,6 +5,13 @@ import os
 import traceback
 from typing import Any, Callable, Dict
 
+# The Cinema4D Adaptor adds the `deadline` namespace directory to PYTHONPATH,
+# so that importing just the cinema4d_adaptor should work.
+try:
+    from cinema4d_adaptor.Cinema4DClient import tile_rendering  # type: ignore[import]
+except (ImportError, ModuleNotFoundError):
+    from deadline.cinema4d_adaptor.Cinema4DClient import tile_rendering  # type: ignore[import]
+
 try:
     import c4d  # type: ignore
     import maxon
@@ -31,6 +38,7 @@ OUTPUT_PATH_KEY = "output_path"
 MULTIPASS_PATH_KEY = "multi_pass_path"
 SCENE_FILE_KEY = "scene_file"
 START_RENDER_KEY = "start_render"
+ASSEMBLE_TILES_KEY = "assemble_tiles"
 TAKE_KEY = "take"
 
 
@@ -78,6 +86,7 @@ class Cinema4DHandler:
             TAKE_KEY: self.set_take,
             FRAME_KEY: self.set_frame,
             START_RENDER_KEY: self.start_render,
+            ASSEMBLE_TILES_KEY: self.assemble_tiles,
             OUTPUT_PATH_KEY: self.output_path,
             MULTIPASS_PATH_KEY: self.multi_pass_path,
             USE_CACHED_TEXT_KEY: self.use_cached_text,
@@ -273,11 +282,19 @@ class Cinema4DHandler:
                 self.render_data[c4d.RDATA_MULTIPASS_FILENAME]
             )
 
-        bm = bitmaps.MultipassBitmap(
-            int(self.render_data[c4d.RDATA_XRES]),
-            int(self.render_data[c4d.RDATA_YRES]),
-            c4d.COLORMODE_RGB,
-        )
+        # Set up tile rendering if this is a tile render action
+        tile_action = data.get("tile_action", "")
+        is_tile_render = tile_action == "render"
+        tile_ctx = None
+        if is_tile_render:
+            tile_ctx = tile_rendering.setup_tile_render(self.render_data, data)
+
+        width = int(self.render_data[c4d.RDATA_XRES])
+        height = int(self.render_data[c4d.RDATA_YRES])
+        if is_tile_render:
+            bm = tile_rendering.create_tile_bitmap(width, height)
+        else:
+            bm = bitmaps.MultipassBitmap(width, height, c4d.COLORMODE_RGB)
         rd = self.render_data.GetDataInstance()
 
         self.cached_text_was_used_in_previous_frame = self._cache_text_if_needed(frame_time)
@@ -289,13 +306,22 @@ class Cinema4DHandler:
             c4d.RENDERFLAGS_EXTERNAL | c4d.RENDERFLAGS_SHOWERRORS,
             prog=progress_callback,
         )
+
         result_description = _RENDERRESULT.get(result)
         if result_description is None:
             raise RuntimeError("Error: unhandled render result: %s" % result)
         if result != c4d.RENDERRESULT_OK:
             raise RuntimeError("Error: render result: %s" % result_description)
-        else:
-            print("Finished Rendering")
+
+        # Post-render tile processing: OCIO bake, crop, save tile, restore paths
+        if is_tile_render and tile_ctx is not None:
+            tile_rendering.finalize_tile_render(bm, rd, tile_ctx, self.render_data, frame)
+
+        print("Finished Rendering")
+
+    def assemble_tiles(self, data: dict) -> None:
+        """Assemble tile images into a single full-resolution image."""
+        tile_rendering.assemble_tiles(self.doc, data, self.map_path)
 
     def output_path(self, data: dict) -> None:
         output_path = data.get(OUTPUT_PATH_KEY, "")

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/tile_rendering.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/tile_rendering.py
@@ -1,0 +1,434 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import c4d  # type: ignore
+    from c4d import bitmaps
+except ImportError:  # pragma: no cover
+    raise OSError("Could not find the Cinema4D module. Are you running this inside of Cinema4D?")
+
+
+# Shared format map: render format ID -> (extension, save filter)
+FORMAT_MAP = {
+    c4d.FILTER_PNG: (".png", c4d.FILTER_PNG),
+    c4d.FILTER_JPG: (".jpg", c4d.FILTER_JPG),
+    c4d.FILTER_TIF: (".tif", c4d.FILTER_TIF),
+    c4d.FILTER_BMP: (".bmp", c4d.FILTER_BMP),
+    c4d.FILTER_EXR: (".exr", c4d.FILTER_EXR),
+    c4d.FILTER_HDR: (".hdr", c4d.FILTER_HDR),
+    c4d.FILTER_PSD: (".psd", c4d.FILTER_PSD),
+    c4d.FILTER_TGA: (".tga", c4d.FILTER_TGA),
+}
+
+EXT_TO_FILTER = {v[0]: v[1] for v in FORMAT_MAP.values()}
+
+
+def get_format_info(format_id: int) -> tuple[str, int]:
+    """Return (extension, save_filter) for a C4D render format ID."""
+    return FORMAT_MAP.get(format_id, (".png", c4d.FILTER_PNG))
+
+
+def determine_color_mode(bpp: int) -> tuple[int, int]:
+    """Determine C4D color mode and bytes-per-pixel increment from bits-per-pixel.
+
+    Returns:
+        (color_mode, inc) where inc is bytes per pixel for GetPixelCnt/SetPixelCnt.
+    """
+    bpc = bpp // 3  # bits per channel
+    if bpc == 32:
+        return c4d.COLORMODE_RGBf, 12  # 3 channels * 4 bytes (float)
+    elif bpc == 16:
+        return c4d.COLORMODE_RGBw, 6  # 3 channels * 2 bytes
+    else:
+        return c4d.COLORMODE_RGB, 3  # 3 channels * 1 byte
+
+
+def determine_save_bits(format_depth: int) -> int:
+    """Return the SAVEBIT flags appropriate for the given RDATA_FORMATDEPTH."""
+    if format_depth == c4d.RDATA_FORMATDEPTH_16:
+        return c4d.SAVEBIT_16BITCHANNELS
+    elif format_depth == c4d.RDATA_FORMATDEPTH_32:
+        return c4d.SAVEBIT_32BITCHANNELS
+    else:
+        return c4d.SAVEBIT_NONE
+
+
+def create_tile_bitmap(width: int, height: int) -> Any:
+    """Create a MultipassBitmap configured for tile rendering.
+
+    Tile renders need RGBf color mode and an alpha channel to preserve full
+    bit depth for OCIO baking and GetClonePart cropping.
+
+    Args:
+        width: Bitmap width in pixels.
+        height: Bitmap height in pixels.
+
+    Returns:
+        A configured MultipassBitmap ready for tile rendering.
+    """
+    bm = bitmaps.MultipassBitmap(width, height, c4d.COLORMODE_RGBf)
+    bm.AddChannel(True, True)
+    return bm
+
+
+def _tile_extent(index: int, count: int, full_size: int) -> tuple[int, int]:
+    """Return (offset, size) for tile ``index`` of ``count`` spanning ``full_size`` pixels.
+
+    The last tile absorbs any remainder pixels so that all tiles together
+    cover exactly ``full_size`` with no gaps.
+
+    Example: 1920px wide, 7 columns
+        Tiles 0-5: offset = i*274, size = 274  (274 = 1920 // 7)
+        Tile 6:    offset = 1644,  size = 276  (1920 - 1644, absorbs 2 remainder px)
+        Total: 6*274 + 276 = 1920 ✓
+    """
+    if count <= 0:
+        raise ValueError(f"count must be >= 1, got {count}")
+    base = full_size // count
+    offset = index * base
+    if index == count - 1:
+        size = full_size - offset
+    else:
+        size = base
+    return offset, size
+
+
+@dataclass
+class TileContext:
+    """Holds tile render state between setup and finalize phases."""
+
+    tile_col: int
+    tile_row: int
+    tile_w: int
+    tile_h: int
+    region_left: int
+    region_top: int
+    tile_output_path: str
+    tile_multipass_path: str
+    orig_bake_flag: Any
+    requires_baking: bool
+    save_bits: int
+
+
+def setup_tile_render(
+    render_data: Any,
+    data: dict,
+) -> TileContext:
+    """Configure render data for tile rendering and return a TileContext.
+
+    Sets the render region on render_data, adjusts output paths for tile saving,
+    and computes all values needed for post-render finalization.
+
+    Args:
+        render_data: The active C4D render data object.
+        data: The action data dict containing tile grid coordinates.
+
+    Returns:
+        A TileContext with all state needed by finalize_tile_render.
+    """
+    tiles_columns = int(data["total_tiles_column"])
+    tiles_rows = int(data["total_tiles_row"])
+    tile_col = int(data["current_tile_column"])
+    tile_row = int(data["current_tile_row"])
+
+    full_w = int(render_data[c4d.RDATA_XRES])
+    full_h = int(render_data[c4d.RDATA_YRES])
+
+    # Pixel coordinates of the tile region (absolute, for cropping later).
+    # _tile_extent ensures the last tile absorbs remainder pixels from integer division.
+    region_left, tile_w = _tile_extent(tile_col, tiles_columns, full_w)
+    region_top, tile_h = _tile_extent(tile_row, tiles_rows, full_h)
+    region_right = region_left + tile_w
+    region_bottom = region_top + tile_h
+
+    # C4D's RDATA_RENDERREGION_* values are offsets inward from each edge,
+    # NOT absolute pixel coordinates.  For example RIGHT=0 means "render up
+    # to the right edge" and BOTTOM=0 means "render down to the bottom edge".
+    render_data[c4d.RDATA_RENDERREGION] = True
+    render_data[c4d.RDATA_RENDERREGION_LEFT] = region_left
+    render_data[c4d.RDATA_RENDERREGION_TOP] = region_top
+    render_data[c4d.RDATA_RENDERREGION_RIGHT] = full_w - region_right
+    render_data[c4d.RDATA_RENDERREGION_BOTTOM] = full_h - region_bottom
+
+    # Save original output paths — we clear RDATA_PATH so C4D doesn't save the
+    # full-resolution beauty image (we crop and save it manually).
+    # For multi-pass, we set a tile-specific path so C4D saves multi-pass natively.
+    tile_output_path = render_data[c4d.RDATA_PATH] or ""
+    tile_multipass_path = render_data[c4d.RDATA_MULTIPASS_FILENAME] or ""
+    render_data[c4d.RDATA_PATH] = ""
+
+    # Build a tile-specific multi-pass path — C4D's native save appends its own
+    # frame numbering and format extension.
+    if tile_multipass_path:
+        mp_base, _mp_ext = os.path.splitext(tile_multipass_path)
+        tile_mp_save_path = f"{mp_base}_tile_{tile_col}_{tile_row}"
+        mp_output_dir = os.path.dirname(tile_mp_save_path)
+        if mp_output_dir:
+            os.makedirs(mp_output_dir, exist_ok=True)
+        render_data[c4d.RDATA_MULTIPASS_FILENAME] = tile_mp_save_path
+    else:
+        render_data[c4d.RDATA_MULTIPASS_FILENAME] = ""
+
+    # OCIO: for 8-bit output during tile renders, disable the render-time OCIO view
+    # transform bake so we can bake it manually after rendering.
+    rd = render_data.GetDataInstance()
+    requires_baking = rd[c4d.RDATA_FORMATDEPTH] == c4d.RDATA_FORMATDEPTH_8
+    orig_bake_flag = None
+    if requires_baking:
+        orig_bake_flag = rd.GetBool(c4d.RDATA_BAKE_OCIO_VIEW_TRANSFORM_RENDER)
+        rd[c4d.RDATA_BAKE_OCIO_VIEW_TRANSFORM_RENDER] = False
+
+    save_bits = determine_save_bits(rd[c4d.RDATA_FORMATDEPTH])
+
+    return TileContext(
+        tile_col=tile_col,
+        tile_row=tile_row,
+        tile_w=tile_w,
+        tile_h=tile_h,
+        region_left=region_left,
+        region_top=region_top,
+        tile_output_path=tile_output_path,
+        tile_multipass_path=tile_multipass_path,
+        orig_bake_flag=orig_bake_flag,
+        requires_baking=requires_baking,
+        save_bits=save_bits,
+    )
+
+
+def finalize_tile_render(
+    bm: Any,
+    rd: Any,
+    ctx: TileContext,
+    render_data: Any,
+    frame: int,
+) -> None:
+    """Post-render processing for a tile: OCIO bake, crop, save, and restore paths.
+
+    Args:
+        bm: The rendered MultipassBitmap.
+        rd: The live render data instance (from GetDataInstance).
+        ctx: The TileContext from setup_tile_render.
+        render_data: The render data object (to restore output paths).
+        frame: The current frame number.
+    """
+    # Restore the OCIO bake flag to its original value
+    if ctx.orig_bake_flag is not None:
+        rd[c4d.RDATA_BAKE_OCIO_VIEW_TRANSFORM_RENDER] = ctx.orig_bake_flag
+
+    if ctx.requires_baking:
+        baked = c4d.documents.BakeOcioViewToBitmap(bm, rd, c4d.SAVEBIT_NONE)
+        bm = baked or bm
+
+    bm.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_DISPLAYSPACE)
+    bm.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_VIEW_TRANSFORM)
+
+    # Crop the tile region from the full bitmap using GetClonePart to preserve
+    # bit depth and float data (GetPixel/SetPixel truncates to 8-bit integers).
+    tile_bmp = bm.GetClonePart(ctx.region_left, ctx.region_top, ctx.tile_w, ctx.tile_h)
+    if tile_bmp is None:
+        raise RuntimeError(
+            f"Failed to crop tile ({ctx.tile_col}, {ctx.tile_row}) from rendered bitmap"
+        )
+
+    # Determine file extension from render format setting
+    format_id = render_data[c4d.RDATA_FORMAT]
+    ext, save_filter = get_format_info(format_id)
+
+    if ctx.tile_output_path:
+        output_dir = os.path.dirname(ctx.tile_output_path)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+
+        base, existing_ext = os.path.splitext(ctx.tile_output_path)
+        if not existing_ext:
+            tile_path = f"{base}_{frame}_tile_{ctx.tile_col}_{ctx.tile_row}{ext}"
+            tile_save_filter = save_filter
+        else:
+            tile_path = f"{base}_{frame}_tile_{ctx.tile_col}_{ctx.tile_row}{existing_ext}"
+            tile_save_filter = EXT_TO_FILTER.get(existing_ext.lower(), save_filter)
+
+        tile_bmp.Save(tile_path, tile_save_filter, c4d.BaseContainer(), ctx.save_bits)
+        print(f"Saved tile ({ctx.tile_col}, {ctx.tile_row}) to {tile_path}")
+
+    # Restore output paths so subsequent tile renders can use them
+    if ctx.tile_output_path:
+        render_data[c4d.RDATA_PATH] = ctx.tile_output_path
+    if ctx.tile_multipass_path:
+        render_data[c4d.RDATA_MULTIPASS_FILENAME] = ctx.tile_multipass_path
+
+
+def _assemble_tiles_pass(
+    base: str,
+    ext: str,
+    frame: int,
+    tiles_columns: int,
+    tiles_rows: int,
+    full_w: int,
+    full_h: int,
+    save_filter: int,
+    *,
+    is_multipass: bool = False,
+) -> None:
+    """Assemble tile images for a single pass into one full-resolution image.
+
+    Handles both beauty and multi-pass tiles. The key differences:
+    - Beauty tiles are cropped to tile size; pixels are read from (0, 0).
+    - Multi-pass tiles are full-resolution with only the tile region rendered;
+      pixels are read from the tile's offset within the full image.
+    - Beauty tile filenames embed the raw frame number; multi-pass uses zero-padded.
+
+    Args:
+        base: The output path stem (without extension).
+        ext: The file extension to use.
+        frame: The current frame number.
+        tiles_columns: Number of tile columns.
+        tiles_rows: Number of tile rows.
+        full_w: Full image width in pixels.
+        full_h: Full image height in pixels.
+        save_filter: The C4D save filter ID (fallback).
+        is_multipass: If True, use multi-pass tile naming and full-res source coords.
+    """
+    pass_label = "multi-pass" if is_multipass else "beauty"
+    frame_str = str(frame).zfill(4) if is_multipass else str(frame)
+
+    # Build tile path: beauty  = {base}_{frame}_tile_{c}_{r}{ext}
+    #                  mp      = {base}_tile_{c}_{r}_{padded}{ext}
+    def _tile_path(col: int, row: int) -> str:
+        if is_multipass:
+            return f"{base}_tile_{col}_{row}_{frame_str}{ext}"
+        return f"{base}_{frame}_tile_{col}_{row}{ext}"
+
+    # Load first tile to determine bit depth
+    first_tile_path = _tile_path(0, 0)
+    first_tile = c4d.bitmaps.BaseBitmap()
+    result = first_tile.InitWith(first_tile_path)
+    if result[0] != c4d.IMAGERESULT_OK:
+        if is_multipass:
+            print(
+                f"WARNING: failed to load first {pass_label} tile: {first_tile_path}, "
+                f"skipping {pass_label} assembly"
+            )
+            return
+        raise RuntimeError(f"assemble_tiles: failed to load first tile: {first_tile_path}")
+
+    bpp = first_tile.GetBt()
+    color_mode, inc = determine_color_mode(bpp)
+
+    final_bmp = c4d.bitmaps.BaseBitmap()
+    final_bmp.Init(full_w, full_h, depth=bpp)
+
+    for row in range(tiles_rows):
+        for col in range(tiles_columns):
+            tile_path = _tile_path(col, row)
+            tile_bmp = c4d.bitmaps.BaseBitmap()
+            load_result = tile_bmp.InitWith(tile_path)
+            if load_result[0] != c4d.IMAGERESULT_OK:
+                if is_multipass:
+                    print(f"WARNING: failed to load {pass_label} tile: {tile_path}")
+                    continue
+                raise RuntimeError(f"assemble_tiles: failed to load tile: {tile_path}")
+
+            dst_x, cur_tile_w = _tile_extent(col, tiles_columns, full_w)
+            dst_y, cur_tile_h = _tile_extent(row, tiles_rows, full_h)
+
+            # Beauty tiles are cropped — read from (0, py).
+            # Multi-pass tiles are full-res — read from the tile's offset.
+            src_x = dst_x if is_multipass else 0
+            src_y = dst_y if is_multipass else 0
+
+            row_buffer = bytearray(cur_tile_w * inc)
+            row_view = memoryview(row_buffer)
+            for py in range(cur_tile_h):
+                tile_bmp.GetPixelCnt(
+                    src_x, src_y + py, cur_tile_w, row_view, inc, color_mode, c4d.PIXELCNT_0
+                )
+                final_bmp.SetPixelCnt(
+                    dst_x, dst_y + py, cur_tile_w, row_view, inc, color_mode, c4d.PIXELCNT_0
+                )
+
+    # Save assembled image
+    final_path = f"{base}_{frame}{ext}"
+    output_dir = os.path.dirname(final_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    first_tile_profile = first_tile.GetColorProfile()
+    if first_tile_profile is not None:
+        final_bmp.SetColorProfile(first_tile_profile)
+    elif not is_multipass:
+        # Beauty pass: fall back to empty profiles so the image is always tagged.
+        final_bmp.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_DISPLAYSPACE)
+        final_bmp.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_VIEW_TRANSFORM)
+
+    final_filter = EXT_TO_FILTER.get(ext.lower(), save_filter)
+    final_bmp.Save(final_path, final_filter)
+    print(f"Assembled {pass_label} {tiles_columns * tiles_rows} tiles into {final_path}")
+
+
+def assemble_tiles(
+    doc: Any,
+    data: dict,
+    map_path: Any,
+) -> None:
+    """Assemble tile images into a single full-resolution image.
+
+    Handles both beauty pass and multi-pass assembly.
+
+    Args:
+        doc: The active C4D document.
+        data: The action data dict with tile grid info, frame, and output paths.
+        map_path: Callable to remap file paths.
+    """
+    tiles_columns = int(data["total_tiles_column"])
+    tiles_rows = int(data["total_tiles_row"])
+    frame = int(data["frame"])
+    output_path = data.get("output_path", "")
+    multi_pass_path = data.get("multi_pass_path", "")
+
+    if not output_path:
+        raise RuntimeError("assemble_tiles: no output_path provided")
+
+    output_path = map_path(output_path)
+    if multi_pass_path:
+        multi_pass_path = map_path(multi_pass_path)
+
+    # Determine extension and save filter from the document's render format
+    render_data = doc.GetActiveRenderData()
+    format_id = render_data[c4d.RDATA_FORMAT]
+    ext, save_filter = get_format_info(format_id)
+
+    full_w = int(render_data[c4d.RDATA_XRES])
+    full_h = int(render_data[c4d.RDATA_YRES])
+
+    base, existing_ext = os.path.splitext(output_path)
+    if not existing_ext:
+        existing_ext = ext
+
+    _assemble_tiles_pass(
+        base, existing_ext, frame, tiles_columns, tiles_rows, full_w, full_h, save_filter
+    )
+
+    # Assemble multi-pass tiles if multi_pass_path is provided.
+    if multi_pass_path:
+        mp_base, mp_ext = os.path.splitext(multi_pass_path)
+        if not mp_ext:
+            mp_format_id = render_data[c4d.RDATA_MULTIPASS_SAVEFORMAT]
+            mp_ext = get_format_info(mp_format_id)[0]
+
+        _assemble_tiles_pass(
+            mp_base,
+            mp_ext,
+            frame,
+            tiles_columns,
+            tiles_rows,
+            full_w,
+            full_h,
+            save_filter,
+            is_multipass=True,
+        )
+
+    print("Finished Rendering")

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/tile_rendering.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/tile_rendering.py
@@ -26,10 +26,12 @@ FORMAT_MAP = {
 
 EXT_TO_FILTER = {v[0]: v[1] for v in FORMAT_MAP.values()}
 
+DEFAULT_FORMAT = FORMAT_MAP[c4d.FILTER_PNG]
+
 
 def get_format_info(format_id: int) -> tuple[str, int]:
     """Return (extension, save_filter) for a C4D render format ID."""
-    return FORMAT_MAP.get(format_id, (".png", c4d.FILTER_PNG))
+    return FORMAT_MAP.get(format_id, DEFAULT_FORMAT)
 
 
 def determine_color_mode(bpp: int) -> tuple[int, int]:

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/tile_rendering.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/tile_rendering.py
@@ -261,6 +261,95 @@ def finalize_tile_render(
         render_data[c4d.RDATA_MULTIPASS_FILENAME] = ctx.tile_multipass_path
 
 
+def _load_tile_bitmap(tile_path: str, pass_label: str, is_multipass: bool) -> Any | None:
+    """Load a tile bitmap from disk.
+
+    Returns the loaded BaseBitmap, or None if loading fails for a multi-pass tile.
+    Raises RuntimeError for beauty tile load failures.
+    """
+    tile_bmp = c4d.bitmaps.BaseBitmap()
+    result = tile_bmp.InitWith(tile_path)
+    if result[0] == c4d.IMAGERESULT_OK:
+        return tile_bmp
+    if is_multipass:
+        print(f"WARNING: failed to load {pass_label} tile: {tile_path}")
+        return None
+    raise RuntimeError(f"assemble_tiles: failed to load tile: {tile_path}")
+
+
+def _apply_color_profile(final_bmp: Any, source_bmp: Any, is_multipass: bool) -> None:
+    """Copy the color profile from source_bmp to final_bmp.
+
+    For beauty passes, falls back to empty profiles when the source has none.
+    """
+    profile = source_bmp.GetColorProfile()
+    if profile is not None:
+        final_bmp.SetColorProfile(profile)
+    elif not is_multipass:
+        final_bmp.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_DISPLAYSPACE)
+        final_bmp.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_VIEW_TRANSFORM)
+
+
+def _tile_path(base: str, ext: str, frame_str: str, col: int, row: int, is_multipass: bool) -> str:
+    """Return the file path for a specific tile."""
+    if is_multipass:
+        return f"{base}_tile_{col}_{row}_{frame_str}{ext}"
+    return f"{base}_{frame_str}_tile_{col}_{row}{ext}"
+
+
+def _copy_tile_pixels(
+    tile_bmp: Any,
+    final_bmp: Any,
+    col: int,
+    row: int,
+    tiles_columns: int,
+    tiles_rows: int,
+    full_w: int,
+    full_h: int,
+    color_mode: int,
+    inc: int,
+    is_multipass: bool,
+) -> None:
+    """Copy pixel data from a single tile bitmap into the final assembled bitmap."""
+    dst_x, cur_tile_w = _tile_extent(col, tiles_columns, full_w)
+    dst_y, cur_tile_h = _tile_extent(row, tiles_rows, full_h)
+
+    src_x = dst_x if is_multipass else 0
+    src_y = dst_y if is_multipass else 0
+
+    row_buffer = bytearray(cur_tile_w * inc)
+    row_view = memoryview(row_buffer)
+    for py in range(cur_tile_h):
+        tile_bmp.GetPixelCnt(
+            src_x, src_y + py, cur_tile_w, row_view, inc, color_mode, c4d.PIXELCNT_0
+        )
+        final_bmp.SetPixelCnt(
+            dst_x, dst_y + py, cur_tile_w, row_view, inc, color_mode, c4d.PIXELCNT_0
+        )
+
+
+def _save_assembled_image(
+    final_bmp: Any,
+    first_tile: Any,
+    base: str,
+    frame: int,
+    ext: str,
+    save_filter: int,
+    is_multipass: bool,
+) -> str:
+    """Save the assembled bitmap to disk and return the output path."""
+    final_path = f"{base}_{frame}{ext}"
+    output_dir = os.path.dirname(final_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    _apply_color_profile(final_bmp, first_tile, is_multipass)
+
+    final_filter = EXT_TO_FILTER.get(ext.lower(), save_filter)
+    final_bmp.Save(final_path, final_filter)
+    return final_path
+
+
 def _assemble_tiles_pass(
     base: str,
     ext: str,
@@ -280,40 +369,14 @@ def _assemble_tiles_pass(
     - Multi-pass tiles are full-resolution with only the tile region rendered;
       pixels are read from the tile's offset within the full image.
     - Beauty tile filenames embed the raw frame number; multi-pass uses zero-padded.
-
-    Args:
-        base: The output path stem (without extension).
-        ext: The file extension to use.
-        frame: The current frame number.
-        tiles_columns: Number of tile columns.
-        tiles_rows: Number of tile rows.
-        full_w: Full image width in pixels.
-        full_h: Full image height in pixels.
-        save_filter: The C4D save filter ID (fallback).
-        is_multipass: If True, use multi-pass tile naming and full-res source coords.
     """
     pass_label = "multi-pass" if is_multipass else "beauty"
     frame_str = str(frame).zfill(4) if is_multipass else str(frame)
 
-    # Build tile path: beauty  = {base}_{frame}_tile_{c}_{r}{ext}
-    #                  mp      = {base}_tile_{c}_{r}_{padded}{ext}
-    def _tile_path(col: int, row: int) -> str:
-        if is_multipass:
-            return f"{base}_tile_{col}_{row}_{frame_str}{ext}"
-        return f"{base}_{frame}_tile_{col}_{row}{ext}"
-
-    # Load first tile to determine bit depth
-    first_tile_path = _tile_path(0, 0)
-    first_tile = c4d.bitmaps.BaseBitmap()
-    result = first_tile.InitWith(first_tile_path)
-    if result[0] != c4d.IMAGERESULT_OK:
-        if is_multipass:
-            print(
-                f"WARNING: failed to load first {pass_label} tile: {first_tile_path}, "
-                f"skipping {pass_label} assembly"
-            )
-            return
-        raise RuntimeError(f"assemble_tiles: failed to load first tile: {first_tile_path}")
+    first_path = _tile_path(base, ext, frame_str, 0, 0, is_multipass)
+    first_tile = _load_tile_bitmap(first_path, pass_label, is_multipass)
+    if first_tile is None:
+        return
 
     bpp = first_tile.GetBt()
     color_mode, inc = determine_color_mode(bpp)
@@ -323,49 +386,33 @@ def _assemble_tiles_pass(
 
     for row in range(tiles_rows):
         for col in range(tiles_columns):
-            tile_path = _tile_path(col, row)
-            tile_bmp = c4d.bitmaps.BaseBitmap()
-            load_result = tile_bmp.InitWith(tile_path)
-            if load_result[0] != c4d.IMAGERESULT_OK:
-                if is_multipass:
-                    print(f"WARNING: failed to load {pass_label} tile: {tile_path}")
-                    continue
-                raise RuntimeError(f"assemble_tiles: failed to load tile: {tile_path}")
+            path = _tile_path(base, ext, frame_str, col, row, is_multipass)
+            tile_bmp = _load_tile_bitmap(path, pass_label, is_multipass)
+            if tile_bmp is None:
+                continue
+            _copy_tile_pixels(
+                tile_bmp,
+                final_bmp,
+                col,
+                row,
+                tiles_columns,
+                tiles_rows,
+                full_w,
+                full_h,
+                color_mode,
+                inc,
+                is_multipass,
+            )
 
-            dst_x, cur_tile_w = _tile_extent(col, tiles_columns, full_w)
-            dst_y, cur_tile_h = _tile_extent(row, tiles_rows, full_h)
-
-            # Beauty tiles are cropped — read from (0, py).
-            # Multi-pass tiles are full-res — read from the tile's offset.
-            src_x = dst_x if is_multipass else 0
-            src_y = dst_y if is_multipass else 0
-
-            row_buffer = bytearray(cur_tile_w * inc)
-            row_view = memoryview(row_buffer)
-            for py in range(cur_tile_h):
-                tile_bmp.GetPixelCnt(
-                    src_x, src_y + py, cur_tile_w, row_view, inc, color_mode, c4d.PIXELCNT_0
-                )
-                final_bmp.SetPixelCnt(
-                    dst_x, dst_y + py, cur_tile_w, row_view, inc, color_mode, c4d.PIXELCNT_0
-                )
-
-    # Save assembled image
-    final_path = f"{base}_{frame}{ext}"
-    output_dir = os.path.dirname(final_path)
-    if output_dir:
-        os.makedirs(output_dir, exist_ok=True)
-
-    first_tile_profile = first_tile.GetColorProfile()
-    if first_tile_profile is not None:
-        final_bmp.SetColorProfile(first_tile_profile)
-    elif not is_multipass:
-        # Beauty pass: fall back to empty profiles so the image is always tagged.
-        final_bmp.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_DISPLAYSPACE)
-        final_bmp.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_VIEW_TRANSFORM)
-
-    final_filter = EXT_TO_FILTER.get(ext.lower(), save_filter)
-    final_bmp.Save(final_path, final_filter)
+    final_path = _save_assembled_image(
+        final_bmp,
+        first_tile,
+        base,
+        frame,
+        ext,
+        save_filter,
+        is_multipass,
+    )
     print(f"Assembled {pass_label} {tiles_columns * tiles_rows} tiles into {final_path}")
 
 

--- a/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
+++ b/src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml
@@ -139,7 +139,7 @@ steps:
       filename: run-data.yaml
       type: TEXT
       data: |
-        frame: {{Task.Param.Frame}}
+        frame: '{{Task.Param.Frame}}'
     actions:
       onRun:
         command: cinema4d-openjd

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -37,6 +37,7 @@ from .scene import Animation, Scene
 from .style import C4D_STYLE
 from .takes import TakeSelection
 from .template_timeout_patcher import add_timeouts_to_job_template
+from .tile_utils import build_assembly_step, build_tile_task_parameters
 from .ui.components import SceneSettingsWidget, SubmissionWarningDialog
 
 LOADED = False
@@ -236,29 +237,57 @@ def _get_job_template(
                 "{{Param." + take_data.frames_parameter_name + "}}"
             )
 
+        # Add tile parameters when tile rendering is enabled
+        if settings.enable_tile_rendering:
+            tile_params, combination = build_tile_task_parameters(
+                settings.tiles_columns, settings.tiles_rows
+            )
+            parameter_space["taskParameterDefinitions"].extend(tile_params)
+            parameter_space["combination"] = combination
+
         if adaptor is False:
             variables = step["stepEnvironments"][0]["variables"]
             variables["TAKE"] = take_data.name
         else:
-            # Update the init data of the step
-            init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
+            # Resolve output paths: use $take-substituted paths or parameter references
+            output_path, multi_pass_path = _resolve_take_paths(
+                settings, take_data.name, has_take_token
+            )
 
-            if has_take_token:
-                # Replace $take token with sanitized take name for file path safety
-                # Use original name (not truncated display_name) but sanitize it
-                take_name_for_path = _STRIPPED_PATH_CHARS.sub("_", take_data.name)
-                output_path = settings.output_path.replace("$take", take_name_for_path)
-                multi_pass_path = settings.multi_pass_path.replace("$take", take_name_for_path)
-                init_data["data"] = (
-                    "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '%s'\nmulti_pass_path: '%s'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\nuse_cached_text: '{{Param.UseCachedText}}'"
-                    % (take_data.name, output_path, multi_pass_path)
+            init_data = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
+            init_data["data"] = deadline_yaml_dump(
+                {
+                    "scene_file": "{{Param.Cinema4DFile}}",
+                    "take": take_data.name,
+                    "output_path": output_path,
+                    "multi_pass_path": multi_pass_path,
+                    "activate_error_checking": "{{Param.ActivateErrorChecking}}",
+                    "use_cached_text": "{{Param.UseCachedText}}",
+                }
+            )
+
+            # Update run-data to include tile region references when tile rendering is enabled
+            if settings.enable_tile_rendering:
+                run_data = step["script"]["embeddedFiles"][0]
+                run_data["data"] = deadline_yaml_dump(
+                    {
+                        "frame": "{{Task.Param.Frame}}",
+                        "tile_action": "render",
+                        "current_tile_column": "{{Task.Param.TileCol}}",
+                        "current_tile_row": "{{Task.Param.TileRow}}",
+                        "total_tiles_column": settings.tiles_columns,
+                        "total_tiles_row": settings.tiles_rows,
+                    }
                 )
-            else:
-                # Use parameter references for paths without $take token
-                init_data["data"] = (
-                    "scene_file: '{{Param.Cinema4DFile}}'\ntake: '%s'\noutput_path: '{{Param.OutputPath}}'\nmulti_pass_path: '{{Param.MultiPassPath}}'\nactivate_error_checking: '{{Param.ActivateErrorChecking}}'\nuse_cached_text: '{{Param.UseCachedText}}'"
-                    % take_data.name
-                )
+
+    # Add tile assembly steps (one per render step) when tile rendering is enabled
+    if settings.enable_tile_rendering and adaptor:
+        render_steps = list(job_template["steps"])
+        for idx, render_step in enumerate(render_steps):
+            take_name = takes[idx].name
+            output_path, multi_pass_path = _resolve_take_paths(settings, take_name, has_take_token)
+            assembly_step = build_assembly_step(render_step, settings, output_path, multi_pass_path)
+            job_template["steps"].append(assembly_step)
 
     # If Arnold is one of the renderers, add Arnold-specific parameters
     if "arnold" in renderers:
@@ -402,6 +431,21 @@ def initialize_render_settings() -> RenderSubmitterUISettings:
 
 # Characters to strip from display names (replaced with underscore)
 _STRIPPED_PATH_CHARS = re.compile(r"[|:()\* ]")
+
+
+def _resolve_take_paths(
+    settings: RenderSubmitterUISettings,
+    take_name: Optional[str],
+    has_take_token: bool,
+) -> tuple[str, str]:
+    """Resolve output_path and multi_pass_path, substituting $take if present."""
+    if has_take_token and take_name is not None:
+        take_name_for_path = _STRIPPED_PATH_CHARS.sub("_", take_name)
+        return (
+            settings.output_path.replace("$take", take_name_for_path),
+            settings.multi_pass_path.replace("$take", take_name_for_path),
+        )
+    return "{{Param.OutputPath}}", "{{Param.MultiPassPath}}"
 
 
 def get_takes_from_doc(doc: Any) -> dict[str, list[TakeData]]:

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -42,6 +42,8 @@ from .ui.components import SceneSettingsWidget, SubmissionWarningDialog
 
 LOADED = False
 
+_TAKE_TOKEN = "$take"
+
 
 def _get_release_date() -> Optional[str]:
     """Safely retrieve release date from _version.py.
@@ -442,8 +444,8 @@ def _resolve_take_paths(
     if has_take_token and take_name is not None:
         take_name_for_path = _STRIPPED_PATH_CHARS.sub("_", take_name)
         return (
-            settings.output_path.replace("$take", take_name_for_path),
-            settings.multi_pass_path.replace("$take", take_name_for_path),
+            settings.output_path.replace(_TAKE_TOKEN, take_name_for_path),
+            settings.multi_pass_path.replace(_TAKE_TOKEN, take_name_for_path),
         )
     return "{{Param.OutputPath}}", "{{Param.MultiPassPath}}"
 
@@ -559,7 +561,9 @@ def create_job_bundle(
     multi_pass_before = (
         settings.multi_pass_path if settings.override_multi_pass_path else scene_multi_pass_path
     )
-    has_take_token = "$take" in (output_path_before or "") or "$take" in (multi_pass_before or "")
+    has_take_token = _TAKE_TOKEN in (output_path_before or "") or _TAKE_TOKEN in (
+        multi_pass_before or ""
+    )
 
     # Add overrides to asset references and update the paths with C4D render path tokens.
     if settings.override_output_path:
@@ -824,13 +828,13 @@ def check_take_token_warnings(
     submit_takes = get_submit_takes(settings, takes)
     if len(submit_takes) == 1:
         return
-    if "$take" in settings.output_path:
+    if _TAKE_TOKEN in settings.output_path:
         return
-    if "$take" in settings.multi_pass_path:
+    if _TAKE_TOKEN in settings.multi_pass_path:
         return
     warning_collector.add_warning(
-        "Multiple takes are selected but output paths do not contain the $take token. "
-        "This will cause different takes to overwrite each other. Use $take in your path to avoid this."
+        f"Multiple takes are selected but output paths do not contain the {_TAKE_TOKEN} token. "
+        f"This will cause different takes to overwrite each other. Use {_TAKE_TOKEN} in your path to avoid this."
     )
 
 

--- a/src/deadline/cinema4d_submitter/data_classes.py
+++ b/src/deadline/cinema4d_submitter/data_classes.py
@@ -68,6 +68,10 @@ class RenderSubmitterUISettings:
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
     output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
 
+    enable_tile_rendering: bool = field(default=False, metadata={"sticky": True})
+    tiles_columns: int = field(default=2, metadata={"sticky": True})
+    tiles_rows: int = field(default=2, metadata={"sticky": True})
+
     take_selection: TakeSelection = field(default=TakeSelection.MAIN, metadata={"sticky": True})
     activate_error_checking: str = field(
         default=ErrorChecking.ACTIVATE.value, metadata={"sticky": True}

--- a/src/deadline/cinema4d_submitter/integ_test_helpers.py
+++ b/src/deadline/cinema4d_submitter/integ_test_helpers.py
@@ -72,7 +72,11 @@ def sample_queue_params(doc: Any) -> list:
 
 
 def internal_create_job_bundle(
-    job_bundle_dir: str, take_selection: TakeSelection = TakeSelection.MAIN
+    job_bundle_dir: str,
+    take_selection: TakeSelection = TakeSelection.MAIN,
+    enable_tile_rendering: bool = False,
+    tiles_columns: int = 2,
+    tiles_rows: int = 2,
 ):
     """
     This function mimics the call that Cinema 4D submitter does to generate the job bundle.
@@ -80,6 +84,9 @@ def internal_create_job_bundle(
 
     render_settings = initialize_render_settings()
     render_settings.take_selection = take_selection
+    render_settings.enable_tile_rendering = enable_tile_rendering
+    render_settings.tiles_columns = tiles_columns
+    render_settings.tiles_rows = tiles_rows
 
     doc = c4d.documents.GetActiveDocument()
 

--- a/src/deadline/cinema4d_submitter/tile_utils.py
+++ b/src/deadline/cinema4d_submitter/tile_utils.py
@@ -1,0 +1,72 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from deadline.client.job_bundle._yaml import deadline_yaml_dump
+
+from .data_classes import RenderSubmitterUISettings
+
+
+def build_tile_task_parameters(tiles_columns: int, tiles_rows: int) -> tuple[list[dict], str]:
+    """
+    Build the task parameter definitions and combination expression for tile rendering.
+
+    Returns a tuple of (parameter_definitions, combination_expression) where
+    parameter_definitions is a list of TileCol/TileRow INT parameter dicts and
+    combination_expression is the parameterSpace combination string.
+    """
+    return (
+        [
+            {
+                "name": "TileCol",
+                "type": "INT",
+                "range": f"0-{tiles_columns - 1}",
+            },
+            {
+                "name": "TileRow",
+                "type": "INT",
+                "range": f"0-{tiles_rows - 1}",
+            },
+        ],
+        "Frame * TileCol * TileRow",
+    )
+
+
+def build_assembly_step(
+    render_step: dict[str, Any],
+    settings: RenderSubmitterUISettings,
+    output_path: str,
+    multi_pass_path: str,
+) -> dict[str, Any]:
+    """Build a tile-assembly step that depends on the given render step."""
+    # Only carry over the Frame parameter (first task param), not tile params
+    frame_param = deepcopy(render_step["parameterSpace"]["taskParameterDefinitions"][0])
+
+    return {
+        "name": f"{render_step['name']} - Assemble Tiles",
+        "dependencies": [{"dependsOn": render_step["name"]}],
+        "parameterSpace": {"taskParameterDefinitions": [frame_param]},
+        "stepEnvironments": deepcopy(render_step["stepEnvironments"]),
+        "script": {
+            "embeddedFiles": [
+                {
+                    "name": "runData",
+                    "filename": "run-data.yaml",
+                    "type": "TEXT",
+                    "data": deadline_yaml_dump(
+                        {
+                            "frame": "{{Task.Param.Frame}}",
+                            "tile_action": "assemble",
+                            "total_tiles_column": settings.tiles_columns,
+                            "total_tiles_row": settings.tiles_rows,
+                            "output_path": output_path,
+                            "multi_pass_path": multi_pass_path,
+                        }
+                    ),
+                }
+            ],
+            "actions": deepcopy(render_step["script"]["actions"]),
+        },
+    }

--- a/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/cinema4d_submitter/ui/components/scene_settings_tab.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import (  # type: ignore
     QPushButton,
     QSizePolicy,
     QSpacerItem,
+    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
@@ -185,6 +186,34 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(rendering_options_box, widget_row, 0, 1, 2)
         widget_row += 1
 
+        # Tile Rendering group box
+        tile_group_box = QGroupBox("Tile Rendering", self)
+        tile_layout = QGridLayout(tile_group_box)
+
+        self.tile_rendering_chck = QCheckBox("Enable Tile Rendering", self)
+        tile_layout.addWidget(self.tile_rendering_chck, 0, 0, 1, 2)
+
+        tile_layout.addWidget(QLabel("Columns"), 1, 0)
+        self.tiles_columns_spin = QSpinBox(self)
+        self.tiles_columns_spin.setMinimum(1)
+        # We added limits for now to keep it under 10k tasks for a single take.
+        # As 100 * 100 = 10k + 1 task for reassembly goes over 10k limit.
+        self.tiles_columns_spin.setMaximum(99)
+        self.tiles_columns_spin.setValue(2)
+        tile_layout.addWidget(self.tiles_columns_spin, 1, 1)
+
+        tile_layout.addWidget(QLabel("Rows"), 2, 0)
+        self.tiles_rows_spin = QSpinBox(self)
+        self.tiles_rows_spin.setMinimum(1)
+        self.tiles_rows_spin.setMaximum(99)
+        self.tiles_rows_spin.setValue(2)
+        tile_layout.addWidget(self.tiles_rows_spin, 2, 1)
+
+        self.tile_rendering_chck.stateChanged.connect(self.activate_tile_rendering_changed)
+
+        lyt.addWidget(tile_group_box, widget_row, 0, 1, 2)
+        widget_row += 1
+
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
@@ -213,6 +242,12 @@ class SceneSettingsWidget(QWidget):
             self.layers_box.setCurrentIndex(index)
 
         self.export_job_bundle_chck.setChecked(settings.export_job_bundle_to_temp)
+
+        self.tile_rendering_chck.setChecked(settings.enable_tile_rendering)
+        self.tiles_columns_spin.setValue(settings.tiles_columns)
+        self.tiles_rows_spin.setValue(settings.tiles_rows)
+        self.tiles_columns_spin.setEnabled(settings.enable_tile_rendering)
+        self.tiles_rows_spin.setEnabled(settings.enable_tile_rendering)
 
         if self.developer_options:
             self.include_adaptor_wheels.setChecked(settings.include_adaptor_wheels)
@@ -250,6 +285,10 @@ class SceneSettingsWidget(QWidget):
 
         settings.export_job_bundle_to_temp = self.export_job_bundle_chck.isChecked()
 
+        settings.enable_tile_rendering = self.tile_rendering_chck.isChecked()
+        settings.tiles_columns = self.tiles_columns_spin.value()
+        settings.tiles_rows = self.tiles_rows_spin.value()
+
         if self.developer_options:
             settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()
         else:
@@ -266,3 +305,8 @@ class SceneSettingsWidget(QWidget):
 
     def activate_multi_path_changed(self, state):
         self.op_multi_path_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)
+
+    def activate_tile_rendering_changed(self, state):
+        enabled = Qt.CheckState(state) == Qt.Checked
+        self.tiles_columns_spin.setEnabled(enabled)
+        self.tiles_rows_spin.setEnabled(enabled)

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -33,7 +33,16 @@ REFERENCE_INIT_DATA_SCHEMA = {
 REFERENCE_RUN_DATA_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "properties": {"frame": {"type": "number"}},
+    "properties": {
+        "frame": {"type": "string"},
+        "current_tile_column": {"type": "string"},
+        "current_tile_row": {"type": "string"},
+        "total_tiles_column": {"type": "integer"},
+        "total_tiles_row": {"type": "integer"},
+        "tile_action": {"type": "string", "enum": ["render", "assemble"]},
+        "output_path": {"type": "string"},
+        "multi_pass_path": {"type": "string"},
+    },
     "required": ["frame"],
 }
 
@@ -167,7 +176,7 @@ def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(i
     """
     # Expected version for these reference schemas
     EXPECTED_MAJOR = 0
-    EXPECTED_MINOR = 3
+    EXPECTED_MINOR = 4
 
     # Get the current version from the adaptor
     adapter = Cinema4DAdaptor(init_data)
@@ -268,7 +277,7 @@ def test_activate_error_checking(init_data: dict, activate_error_checking: int) 
 
 @pytest.fixture()
 def run_data() -> dict:
-    return {"frame": 42}
+    return {"frame": "42"}
 
 
 @pytest.mark.xdist_group(name="adaptor_tests")

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_tile_rendering.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_tile_rendering.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Unit tests for _tile_extent in tile_rendering.py."""
+
+import pytest
+
+from deadline.cinema4d_adaptor.Cinema4DClient.tile_rendering import _tile_extent
+
+
+class TestTileExtentInvalidCount:
+
+    def test_count_zero_raises_value_error(self):
+        with pytest.raises(ValueError, match="count must be >= 1, got 0"):
+            _tile_extent(0, 0, 1920)
+
+    def test_negative_count_raises_value_error(self):
+        with pytest.raises(ValueError, match="count must be >= 1, got -1"):
+            _tile_extent(0, -1, 1920)
+
+    def test_large_negative_count_raises_value_error(self):
+        with pytest.raises(ValueError, match="count must be >= 1, got -10"):
+            _tile_extent(0, -10, 500)
+
+
+class TestTileExtentValidInputs:
+
+    def test_first_tile_normal_case(self):
+        # 1920 // 7 = 274
+        assert _tile_extent(0, 7, 1920) == (0, 274)
+
+    def test_middle_tile(self):
+        # tile 3 of 7: offset = 3*274 = 822, size = 274
+        assert _tile_extent(3, 7, 1920) == (822, 274)
+
+    def test_last_tile_absorbs_remainder(self):
+        # tile 6 of 7: offset = 6*274 = 1644, size = 1920 - 1644 = 276
+        assert _tile_extent(6, 7, 1920) == (1644, 276)
+
+    def test_single_tile_covers_full_size(self):
+        assert _tile_extent(0, 1, 1920) == (0, 1920)
+
+    def test_even_division_first_tile(self):
+        # 100 // 4 = 25, divides evenly
+        assert _tile_extent(0, 4, 100) == (0, 25)
+
+    def test_even_division_last_tile(self):
+        # last tile of even division: offset = 75, size = 100 - 75 = 25
+        assert _tile_extent(3, 4, 100) == (75, 25)
+
+    def test_all_tiles_sum_to_full_size(self):
+        """All tiles together must cover exactly full_size pixels."""
+        full_size = 1920
+        count = 7
+        total = sum(_tile_extent(i, count, full_size)[1] for i in range(count))
+        assert total == full_size
+
+    def test_tiles_cover_without_gaps(self):
+        """Tiles must be contiguous — each tile starts where the previous one ended."""
+        full_size = 1080
+        count = 11
+        expected_offset = 0
+        for i in range(count):
+            offset, size = _tile_extent(i, count, full_size)
+            assert (
+                offset == expected_offset
+            ), f"Tile {i}: expected offset {expected_offset}, got {offset}"
+            expected_offset += size
+        assert expected_offset == full_size

--- a/test/unit/deadline_submitter_for_cinema4d/test_tile_utils.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_tile_utils.py
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+from deadline.cinema4d_submitter.tile_utils import build_tile_task_parameters
+
+
+class TestBuildTileTaskParameters:
+    def test_returns_correct_parameter_definitions(self):
+        params, _ = build_tile_task_parameters(3, 2)
+        assert params == [
+            {"name": "TileCol", "type": "INT", "range": "0-2"},
+            {"name": "TileRow", "type": "INT", "range": "0-1"},
+        ]
+
+    def test_returns_combination_expression(self):
+        _, expression = build_tile_task_parameters(3, 2)
+        assert expression == "Frame * TileCol * TileRow"
+
+    def test_single_tile(self):
+        params, _ = build_tile_task_parameters(1, 1)
+        assert params[0]["range"] == "0-0"
+        assert params[1]["range"] == "0-0"


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/210

### What was the problem/requirement? (What/Why)

We needed a way for customers to submit tile rendering jobs so that customers can increase their speed of rendering by dividing the scene across multiple machines. 

Unfortunately, the current tile rendering solution was too manual and required another library to stitch the files after the render.

### What was the solution? (How)

Investigated the issue further and after discussions with Maxon, implemented a solution which is 1-click for customers. 
This also includes tile assembly by using Cinema 4D and hence does not even require extra dependencies. 

**To make the PR manageable for review (this PR is already >800 line changes), I've divided the PR into 2:**

- This PR: Adds the business logic 
- Upcoming PR : Adds the integration tests modified by adding tile rendering + docs update

### What is the impact of this change?

Much better UX for tile rendering. 
<img width="536" height="623" alt="image" src="https://github.com/user-attachments/assets/e4001147-a09a-4b34-ae50-61be0755e0b8" />


### How was this change tested?

I tested it manually by testing various scenes in Cinema 4D. 

<img width="972" height="317" alt="image" src="https://github.com/user-attachments/assets/2e97b185-2220-4c05-b960-86b06d7bf1e9" />


- Have you run the unit tests?

Yes

- Have you run the integration tests? (Add your integration test report below)
Yes. 

I've also created 2 integration tests for tile rendering which I'll add in my upcoming PR. 

- Have you made changes to the submitter?
Yes. I've also updated integ_test_helpers file.

### Was this change documented?

The documentation change will be added in upcoming PR. 

### Is this a breaking change?

Yes. This PR adds some changes that needs a new run_data schema. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*