### PR TITLE
fix: fail fast with clear error when LoadDocument fails on corrupted …

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -408,20 +408,21 @@ class Cinema4DHandler:
             scene_file, c4d.SCENEFILTER_OBJECTS | c4d.SCENEFILTER_MATERIALS
         )
         if doc is None:
-            print("Error: LoadDocument failed: %s" % scene_file)
-        else:
-            # Build animations, caches and expressions for all frames in the document.
-            # This is essential for dynamic content like Pyro simulations (fluid/smoke effects)
-            # which would otherwise render as blank. The parameters ensure all necessary
-            # elements (animation, expressions, caches) are processed.
-            doc.ExecutePasses(
-                bt=None, animation=True, expressions=True, caches=True, flags=c4d.BUILDFLAGS_NONE
+            raise RuntimeError(
+                f"Failed to load the scene file '{scene_file}'. The file may be corrupt or not a valid Cinema 4D document."
             )
+        # Build animations, caches and expressions for all frames in the document.
+        # This is essential for dynamic content like Pyro simulations (fluid/smoke effects)
+        # which would otherwise render as blank. The parameters ensure all necessary
+        # elements (animation, expressions, caches) are processed.
+        doc.ExecutePasses(
+            bt=None, animation=True, expressions=True, caches=True, flags=c4d.BUILDFLAGS_NONE
+        )
 
-            c4d.documents.InsertBaseDocument(doc)
-            c4d.documents.SetActiveDocument(doc)
-            self.doc = doc
-            self._remap_assets()
+        c4d.documents.InsertBaseDocument(doc)
+        c4d.documents.SetActiveDocument(doc)
+        self.doc = doc
+        self._remap_assets()
 
     def _has_cached_text(self, objects: list[Any]) -> bool:
         for obj in objects:

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -44,6 +44,15 @@ class TestCinema4DHandler:
         with pytest.raises(FileNotFoundError):
             handler.set_scene_file({"scene_file": "file.c4d"})
 
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.LoadDocument")
+    @patch("deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.os.path.isfile")
+    def test_set_scene_file_load_document_fails(self, mock_isfile: Mock, mock_load: Mock):
+        mock_isfile.return_value = True
+        mock_load.return_value = None
+        handler = Cinema4DHandler(mock_map_path)
+        with pytest.raises(RuntimeError, match="Failed to load the scene file"):
+            handler.set_scene_file({"scene_file": "file.c4d"})
+
 
 class TestShouldCacheText:
     """Tests for the use_cached_text method"""


### PR DESCRIPTION

Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/337

### What was the problem/requirement? (What/Why)

When a corrupt or invalid `.c4d` scene file was loaded, `LoadDocument` returned `None` but the adaptor only printed an error and continued execution. This meant `self.doc` was never set, causing a confusing `AttributeError: 'Cinema4DHandler' object has no attribute 'doc'` later during the render task - making it difficult for users to understand the root cause.

### What was the solution? (How)

Changed `set_scene_file` in `cinema4d_handler.py` to raise a `RuntimeError` with a clear message when LoadDocument returns None, instead of printing and continuing. This causes the adaptor to fail fast during initialization with the message: `"Failed to load the scene file '...'. The file may be corrupt or not a valid Cinema 4D document."`

Also moved the now-unnecessary else branch since the raise exits early.

### What is the impact of this change?

Jobs with corrupt or invalid `.c4d` files will now fail immediately during the "Entering Environment: Cinema 4D" action with a clear error message, instead of failing later in the "Render Task" action with a confusing `AttributeError`.

### How was this change tested?

- Submitted the job with adaptor and verified in DCM that it errored in `Launch C4D` 
<img width="1358" height="544" alt="Screenshot 2026-03-11 at 11 16 13 AM" src="https://github.com/user-attachments/assets/d9c73038-f88f-4b01-bb66-b121bbaac26c" />

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/DEVELOPMENT.md) for information on running tests.

- Have you run the unit tests?
```
===================================== 301 passed, 6 skipped in 4.40s =====================================
```
- added unittest: 
```
[gw0] [100%] PASSED test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py::TestCinema4DHandler::test_set_scene_file_load_document_fails 
```
- Have you run the integration tests? (Add your integration test report below)
```

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 14%] PASSED test/integ/test_cinema4d.py::test_integ[physical]
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 28%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured]
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 42%] PASSED test/integ/test_cinema4d.py::test_integ[redshift]
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 57%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes]
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 71%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured]
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 85%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes]

================================================= slowest 5 durations =================================================
464.45s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
101.18s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
80.45s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
76.32s call     test/integ/test_cinema4d.py::test_integ[redshift]
75.06s call     test/integ/test_cinema4d.py::test_integ[redshift_takes]
============================================ 7 passed in 910.88s (0:15:10) ============================================
```
- Have you made changes to the submitter?
If yes, please include the results of both the automated tests and any manual tests that you ran.
Also, check if there is a change to the `integ_test_helpers.py` file within cinema4d_submitter as a result of your submitter change.

### Was this change documented?

No documentation changes needed. The change is internal error handling behavior. No docstrings, README, DEVELOPMENT.md, or schema files need updating.

### Is this a breaking change?

No. This change only affects error handling for an already-failing scenario (corrupt scene files). Jobs with valid scene files are unaffected.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*