### PR TITLE
fix: provide better instructions with RedShift/NVDIA version drivers

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -303,6 +303,17 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                 )
             )
 
+            nvidia_driver_regexes = re.compile(
+                r".*(?:Please make sure you have NVIDIA driver (\S+) or later installed|requires driver (\S+) but has (\S+)).*",
+                re.IGNORECASE,
+            )
+            callback_list.append(
+                RegexCallback(
+                    [nvidia_driver_regexes],
+                    self._handle_nvidia_driver_error,
+                )
+            )
+
             self._regex_callbacks = callback_list
         return self._regex_callbacks
 
@@ -365,6 +376,30 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
             f"Error: {match.group(0)}"
         )
 
+        self._exc_info = RuntimeError(message)
+
+    def _handle_nvidia_driver_error(self, match: re.Match) -> None:
+        """
+        Handle NVIDIA driver incompatibility errors during Redshift rendering.
+
+        Args:
+            match (re.Match): The match object from the regex pattern that was matched
+
+        Raises:
+            RuntimeError: Raised when the NVIDIA driver is incompatible with Redshift
+        """
+        required_version = match.group(1) or match.group(2)
+        current_version = match.group(3) if match.lastindex and match.lastindex >= 3 else None
+
+        if current_version:
+            detail = f"The worker has driver {current_version} but Redshift requires {required_version} or later."
+        else:
+            detail = f"Redshift requires NVIDIA driver version {required_version} or later."
+        message = (
+            f"{detail} "
+            "Please update the NVIDIA drivers on your worker fleet. "
+            f"Error: {match.group(0)}"
+        )
         self._exc_info = RuntimeError(message)
 
     def _add_deadline_openjd_paths(self) -> None:

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -153,6 +153,44 @@ class TestCinema4DAdaptor_errors_on_cleanup:
             f"Error: {stdout}"
         )
 
+    @pytest.mark.parametrize(
+        "stdout,expected_message",
+        [
+            (
+                "Redshift Error: Please make sure you have NVIDIA driver 551.78 or later installed.",
+                "Redshift requires NVIDIA driver version 551.78 or later. "
+                "Please update the NVIDIA drivers on your worker fleet. "
+                "Error: Redshift Error: Please make sure you have NVIDIA driver 551.78 or later installed.",
+            ),
+            (
+                "Redshift Error: Tesla T4 requires driver 551.78 but has 539.64",
+                "The worker has driver 539.64 but Redshift requires 551.78 or later. "
+                "Please update the NVIDIA drivers on your worker fleet. "
+                "Error: Redshift Error: Tesla T4 requires driver 551.78 but has 539.64",
+            ),
+        ],
+    )
+    def test_handle_nvidia_driver_error_on_stdout(
+        self, init_data: dict, stdout: str, expected_message: str
+    ) -> None:
+        """Tests that the _handle_nvidia_driver_error method throws a runtime error correctly"""
+        # GIVEN
+        adaptor = Cinema4DAdaptor(init_data)
+        regex_callbacks = adaptor._get_regex_callbacks()
+        # Currently the callback for NVIDIA driver errors is at index 4
+        regexes = regex_callbacks[4].regex_list
+
+        # WHEN
+        for regex in regexes:
+            match = regex.search(stdout)
+            if match:
+                adaptor._handle_nvidia_driver_error(match)
+                break
+
+        # THEN
+        assert match is not None
+        assert str(adaptor._exc_info) == expected_message
+
 
 @pytest.mark.xdist_group(name="adaptor_tests")
 def test_adaptor_rejects_malformed_init_data():


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/239

### What was the problem/requirement? (What/Why)

When Cinema 4D with Redshift jobs fail due to incompatible NVIDIA drivers, the error in the logs is not user-friendly:

```
Redshift Error: Please make sure you have NVIDIA driver 551.78 or later installed.
Redshift Error: Failed to load module binary! Either kernel is bad or the driver has crashed!
```

or 

```
2026/03/17 09:36:19-07:00 STDOUT: Redshift Error: NVIDIA A10G requires driver 551.78 but has 539.64

```
Customers have to search through logs to identify the root cause, which slows down troubleshooting. Also, this happens in windows only. 

### What was the solution? (How)

Added a regex callback in the adaptor that detects the NVIDIA driver incompatibility error and surfaces a clear, actionable message telling the customer which driver version is required and to update their worker fleet's NVIDIA drivers. This follows the same pattern used in PR #196 for the insufficient RAM error.

### What is the impact of this change?

Better customer experience — customers will see a clear error message instead of having to dig through logs to understand why their Redshift render failed.

<img width="1058" height="292" alt="Screenshot 2026-03-17 at 10 38 40 AM" src="https://github.com/user-attachments/assets/5d15895b-5ca6-453e-ae30-b00ae64bc5c1" />

### How was this change tested?

- Have you run the unit tests?
Yes 

```
===================================== 303 passed, 6 skipped in 5.46s =====================================
```

```
[gw0] [ 50%] PASSED test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_errors_on_cleanup::test_handle_nvidia_driver_error_on_stdout[Redshift Error: Please make sure you have NVIDIA driver 551.78 or later installed.-Redshift requires NVIDIA driver version 551.78 or later. Please update the NVIDIA drivers on your worker fleet. Error: Redshift Error: Please make sure you have NVIDIA driver 551.78 or later installed.]
test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_errors_on_cleanup::test_handle_nvidia_driver_error_on_stdout[Redshift Error: Tesla T4 requires driver 551.78 but has 539.64-The worker has driver 539.64 but Redshift requires 551.78 or later. Please update the NVIDIA drivers on your worker fleet. Error: Redshift Error: Tesla T4 requires driver 551.78 but has 539.64]
[gw0] [100%] PASSED test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py::TestCinema4DAdaptor_errors_on_cleanup::test_handle_nvidia_driver_error_on_stdout[Redshift Error: Tesla T4 requires driver 551.78 but has 539.64-The worker has driver 539.64 but Redshift requires 551.78 or later. Please update the NVIDIA drivers on your worker fleet. Error: Redshift Error: Tesla T4 requires driver 551.78 but has 539.64]
```

- Have you run the integration tests? (Add your integration test report below)
Yes
```

test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [ 11%] PASSED test/integ/test_cinema4d.py::test_integ[physical]
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 22%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured]
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 33%] PASSED test/integ/test_cinema4d.py::test_integ[redshift]
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 44%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes]
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 55%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured]
test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
[gw0] [ 66%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [ 77%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
test/integ/test_cinema4d.py::test_integ[physical_tiles]
[gw0] [ 88%] PASSED test/integ/test_cinema4d.py::test_integ[physical_tiles]
test/integ/test_cinema4d.py::test_integ[redshift_tiles]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_tiles]

================================================= slowest 5 durations =================================================
448.55s call     test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
163.16s call     test/integ/test_cinema4d.py::test_integ[physical_tiles]
111.85s call     test/integ/test_cinema4d.py::test_integ[redshift_tiles]
96.04s call     test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters]
76.04s call     test/integ/test_cinema4d.py::test_integ[redshift_textured]
=========================================== 9 passed in 1152.14s (0:19:12) ============================================
```
- Have you made changes to the submitter?
no

### Was this change documented?

No documentation change needed. This is an internal adaptor improvement that surfaces better error messages automatically.

### Is this a breaking change?

No. This adds a new regex callback and handler method. Existing behavior is unchanged — jobs that were succeeding will continue to succeed. Jobs that were failing with this error will now fail with a more helpful message.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*