### PR TITLE
docs: Add FAQ explaining Tile rendering only available for C4D 2025+ …

### DIFF
--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -64,6 +64,16 @@ A: It depends on your scene. A 3×3 or 4×4 grid is a good starting point. More 
 
 For example, a 99×99 grid on a single frame would produce 9,801 render tasks, which is close to the limit.
 
+**Q: Why is tile rendering failing with an `AttributeError: module 'c4d.documents' has no attribute 'BakeOcioViewToBitmap'`?**
+
+A: Tile rendering requires Cinema 4D 2025 or above. The tile assembly step uses the `c4d.documents.BakeOcioViewToBitmap` API, which was introduced in Cinema 4D 2025. If you're running an older version, the assemble step will fail with an error like:
+
+```
+AttributeError: module 'c4d.documents' has no attribute 'BakeOcioViewToBitmap'
+```
+
+To fix this, upgrade to Cinema 4D 2025 or later.
+
 **Q: Can I use Redshift?**
 
 A: Yes! Redshift GPU rendering is supported.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Cinema 4D uses some newer Cinema 4D APIs like `BakeOcioViewToBitmap` to fix the colouring in tile rendering. 

### What was the solution? (How)

Cinema 4D 2024 is 3 years old and hence just updated the docs to suggest customers to upgrade to newer versions of Cinema 4D. 

Also cut a Github issue in case there are many customers who want us to support the workflow: 
https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/409

### What is the impact of this change?

Customer awareness for the issue. 

### How was this change tested?

Just doc changes. 

### Was this change documented?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*