### PR TITLE
feat: Notify customers if newer submitter is available.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.51.1,< 0.55",
+    "deadline[gui] >= 0.55.1,< 0.56",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
     # fonttools is Windows-only due to Cinema 4D technical limitations
     "fonttools >=4.59.2, <4.63; sys_platform == 'win32'",

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -40,6 +40,7 @@ from .template_timeout_patcher import add_timeouts_to_job_template
 from .tile_utils import build_assembly_step, build_tile_task_parameters
 from .ui.components import SceneSettingsWidget, SubmissionWarningDialog
 from ._yaml_utils import _build_embedded_yaml
+from .update_utils import check_and_show_update_dialog
 
 LOADED = False
 
@@ -82,6 +83,9 @@ def show_submitter():
             app = QtWidgets.QApplication([])
             app.setQuitOnLastWindowClosed(False)
             app.aboutToQuit.connect(app.deleteLater)
+
+        if check_and_show_update_dialog():
+            return
 
         # Get the scene file's directory path to create the temporary directory
         # in the same location as the original scene file. This ensures consistent

--- a/src/deadline/cinema4d_submitter/update_utils.py
+++ b/src/deadline/cinema4d_submitter/update_utils.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Utilities for checking and displaying update notifications."""
+
+import logging
+from dataclasses import dataclass
+
+from deadline.client.api import safe_check_for_updates, UpdateCheckResult, UpdateCheckStatus
+from deadline.client.ui.dialogs.update_available_dialog import UpdateAvailableDialog
+
+from ._version import version_tuple as adaptor_version_tuple
+from .style import C4D_STYLE
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SessionState:
+    """Session-level state: once the user dismisses the update dialog,
+    don't show it again until Cinema 4D is restarted."""
+
+    update_dismissed: bool = False
+
+
+_session_state = _SessionState()
+
+
+def _check_for_update() -> UpdateCheckResult:
+    """Check if a newer version of the Cinema 4D submitter is available.
+
+    Returns:
+        An UpdateCheckResult describing whether an update is available.
+    """
+    current_version = ".".join(str(v) for v in adaptor_version_tuple[:3])
+    return safe_check_for_updates(
+        integration_name="deadline-cloud-for-cinema-4d",
+        current_version=current_version,
+    )
+
+
+def check_and_show_update_dialog() -> bool:
+    """Check for updates and show the update dialog if one is available.
+
+    If the user previously dismissed the dialog in this Cinema 4D session,
+    the check is skipped entirely.
+
+    Returns:
+        True if the user clicked Download (caller should skip opening the submitter),
+        False otherwise.
+    """
+    if _session_state.update_dismissed:
+        return False
+
+    update_result = _check_for_update()
+    if update_result.status == UpdateCheckStatus.SUCCESS and update_result.update_available:
+        update_dialog = UpdateAvailableDialog(
+            integration_name="Cinema 4D",
+            current_version=update_result.current_version or "",
+            latest_version=update_result.latest_version or "",
+            download_url=update_result.download_url or "",
+            release_notes_url="https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/releases",
+        )
+        update_dialog.setStyleSheet(C4D_STYLE)
+        update_dialog.exec_()
+        if update_dialog.user_downloaded:
+            return True
+        # User dismissed — suppress for the rest of this Cinema 4D session
+        _session_state.update_dismissed = True
+    return False

--- a/test/unit/deadline_submitter_for_cinema4d/test_update_utils.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_update_utils.py
@@ -1,0 +1,161 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+from deadline.client.api import UpdateCheckResult, UpdateCheckStatus
+
+from deadline.cinema4d_submitter.update_utils import (
+    _check_for_update,
+    check_and_show_update_dialog,
+)
+
+
+class TestCheckForUpdate:
+    """Tests for _check_for_update()."""
+
+    @patch("deadline.cinema4d_submitter.update_utils.safe_check_for_updates")
+    def test_returns_result_on_success(self, mock_check):
+        # GIVEN
+        expected = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+        )
+        mock_check.return_value = expected
+
+        # WHEN
+        result = _check_for_update()
+
+        # THEN
+        assert result is expected
+        mock_check.assert_called_once()
+
+    @patch("deadline.cinema4d_submitter.update_utils.safe_check_for_updates")
+    def test_returns_error_result_on_unexpected_error(self, mock_check):
+        # GIVEN — safe_check_for_updates returns an error result, never raises
+        expected = UpdateCheckResult(
+            status=UpdateCheckStatus.UNEXPECTED_ERROR,
+            current_version="0.9.0",
+            error_message="Unexpected error: something broke",
+        )
+        mock_check.return_value = expected
+
+        # WHEN
+        result = _check_for_update()
+
+        # THEN
+        assert result is expected
+        assert result.update_available is False
+
+    @patch("deadline.cinema4d_submitter.update_utils.safe_check_for_updates")
+    def test_passes_correct_integration_name(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+        )
+
+        # WHEN
+        _check_for_update()
+
+        # THEN
+        call_kwargs = mock_check.call_args[1]
+        assert call_kwargs["integration_name"] == "deadline-cloud-for-cinema-4d"
+
+
+class TestCheckAndShowUpdateDialog:
+    """Tests for check_and_show_update_dialog()."""
+
+    @patch("deadline.cinema4d_submitter.update_utils._check_for_update")
+    def test_returns_false_when_no_update(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.10.0",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch("deadline.cinema4d_submitter.update_utils._check_for_update")
+    def test_returns_false_when_check_fails(self, mock_check):
+        # GIVEN — safe_check_for_updates never returns None; on failure it
+        # returns an UpdateCheckResult with an error status.
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.UNEXPECTED_ERROR,
+            current_version="0.9.0",
+            update_available=False,
+            error_message="Unexpected error: something broke",
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch("deadline.cinema4d_submitter.update_utils._check_for_update")
+    def test_returns_false_on_error_status(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.NETWORK_ERROR,
+            current_version="0.9.0",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch("deadline.cinema4d_submitter.update_utils.UpdateAvailableDialog")
+    @patch("deadline.cinema4d_submitter.update_utils._check_for_update")
+    def test_shows_dialog_and_returns_true_when_user_downloads(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is True
+        mock_dialog.exec_.assert_called_once()
+
+    @patch("deadline.cinema4d_submitter.update_utils.UpdateAvailableDialog")
+    @patch("deadline.cinema4d_submitter.update_utils._check_for_update")
+    def test_shows_dialog_and_returns_false_when_user_dismisses(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = False
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        mock_dialog.exec_.assert_called_once()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Customers did not know whether they were on the latest submitter or not. This means they would not have the latest bug fixes or features to work with our product. 

### What was the solution? (How)

Depends on: https://github.com/aws-deadline/deadline-cloud/pull/1070

This adds a dialog which checks our download manifests and if there's a new update available notifies customer  that. 

<img width="403" height="211" alt="image" src="https://github.com/user-attachments/assets/76594978-0c6b-4f3c-ae7f-f516dd10df35" />

Customers can deactivate the feature in the settings. 

<img width="588" height="293" alt="image" src="https://github.com/user-attachments/assets/5fb8cafe-3699-45bf-8201-c551a65c52c1" />

### What is the impact of this change?

Customers hopefully are always on the latest updated submitter. 

### How was this change tested?

Here's the test cases that I manually tested in Cinema 4D Mac:

| # | Test Case | Steps | Expected Result | Pass? |
|---|-----------|-------|-----------------|-------|
| | **Config GUI — setting visible** | | | |
| 1 | Setting in config GUI | Open Cinema4D → Deadline Cloud → Settings | "Show submitter update notifications" checkbox is visible | YES |
| | **Config disabled — no dialog** | | | |
| 2 | Notification disabled via GUI | Uncheck "Show submitter update notifications" → Apply → close & reopen submitter | No network call, no dialog, submitter opens normally | YES |
| | **Config enabled, no internet — graceful failure** | | | |
| 3 | Re-enable notification via GUI | Check "Show submitter update notifications" → Apply | Setting updated | YES |
| 4 | No internet / firewall | Disconnect network → open submitter | Submitter opens normally, no crash, no visible error | YES |
| | **Config enabled, internet available, no update** | | | |
| 5 | Current == latest | Restore network, ensure installed version matches manifest | No dialog, submitter opens normally | YES |
| 6 | Current > latest (dev build) | Install a version newer than manifest | No dialog, submitter opens normally | YES |
| | **Config enabled, internet available, update exists** | | | |
| 7 | Current < latest | Install an older version than manifest | Update dialog appears | YES |
| 8 | Dialog content | Inspect the dialog | Shows "Cinema4d", correct current & latest versions | YES |
| 9 | Dialog layout | Resize / check | Min width 400px, text wraps properly | YES |
| 10 | Dialog timing | Observe launch order | Dialog appears before Cinema4D submitter window | YES |
| | **Dialog interactions — Dismiss** | | | |
| 11 | Click "Dismiss" | Click Dismiss button | Dialog closes, submitter opens normally | YES |
| 12 | Close via X | Click X button on dialog | Dialog closes, submitter opens normally | YES |
| | **Dialog interactions — Download** | | | |
| 13 | Click "View release notes" | Click the link | Cinema4D GitHub releases page opens in browser | YES |
| 14 | Click "Download" | Click Download button | Correct installer URL opens in browser | YES |
| 15 | Restart reminder | After Download click | "Application Restart Required" info box appears | YES |
| | **Edge cases** | | | |
| 16 | Non-standard `_version.py` tuple | Modify version tuple | No crash | YES |


Here's the test cases that I manually tested in Cinema 4D Windows:

| # | Test Case | Steps | Expected Result | Pass? |
|---|-----------|-------|-----------------|-------|
| | **Config GUI — setting visible** | | | |
| 1 | Setting in config GUI | Open Cinema4D → Deadline Cloud → Settings | "Show submitter update notifications" checkbox is visible | YES |
| | **Config disabled — no dialog** | | | |
| 2 | Notification disabled via GUI | Uncheck "Show submitter update notifications" → Apply → close & reopen submitter | No network call, no dialog, submitter opens normally | YES |
| | **Config enabled, no internet — graceful failure** | | | |
| 3 | Re-enable notification via GUI | Check "Show submitter update notifications" → Apply | Setting updated | YES |
| 4 | No internet / firewall | Disconnect network → open submitter | Submitter opens normally, no crash, no visible error | YES |
| | **Config enabled, internet available, no update** | | | |
| 5 | Current == latest | Restore network, ensure installed version matches manifest | No dialog, submitter opens normally | YES |
| 6 | Current > latest (dev build) | Install a version newer than manifest | No dialog, submitter opens normally | YES |
| | **Config enabled, internet available, update exists** | | | |
| 7 | Current < latest | Install an older version than manifest | Update dialog appears | YES |
| 8 | Dialog content | Inspect the dialog | Shows "Cinema4d", correct current & latest versions | YES |
| 9 | Dialog layout | Resize / check | Min width 400px, text wraps properly | YES |
| 10 | Dialog timing | Observe launch order | Dialog appears before Cinema4D submitter window | YES |
| | **Dialog interactions — Dismiss** | | | |
| 11 | Click "Dismiss" | Click Dismiss button | Dialog closes, submitter opens normally | YES |
| 12 | Close via X | Click X button on dialog | Dialog closes, submitter opens normally | YES |
| | **Dialog interactions — Download** | | | |
| 13 | Click "View release notes" | Click the link | Cinema4D GitHub releases page opens in browser | YES |
| 14 | Click "Download" | Click Download button | Correct installer URL opens in browser | YES |
| 15 | Restart reminder | After Download click | "Application Restart Required" info box appears | YES |
| | **Edge cases** | | | |
| 16 | Non-standard `_version.py` tuple | Modify version tuple | No crash | YES |

- Have you run the unit tests?
Yes

- Have you run the integration tests? (Add your integration test report below)
Running it right now. 

- Have you made changes to the submitter?
Yes but this has no impact to the integration tests. 

### Was this change documented?

No but its not required. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*