### PR TITLE
chore: Pin the dependencies to deadline[gui] + add third party licenses

### DIFF
--- a/install_builder/deadline-cloud-for-cinema-4d.xml
+++ b/install_builder/deadline-cloud-for-cinema-4d.xml
@@ -44,6 +44,17 @@
                 </distributionDirectory>
             </distributionFileList>
         </folder>
+        <folder>
+            <description>Third Party Licenses</description>
+            <destination>${cinema_4d_submitter_installdir}</destination>
+            <name>thirdpartylicenses</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionFile>
+                    <origin>../THIRD_PARTY_LICENSES</origin>
+                </distributionFile>
+            </distributionFileList>
+        </folder>
     </folderList>
     <initializationActionList>
         <if>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.51.1,< 0.55",
+    "deadline[gui] >= 0.51.1,< 0.55",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
     # fonttools is Windows-only due to Cinema 4D technical limitations
     "fonttools >=4.59.2, <4.63; sys_platform == 'win32'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Fixes 2 problems:

- Ensure that the PySide dependencies are correctly installed and pinned adding `deadline[gui]`. 
- Adding Third party licenses file shipped with submitter installer. 

### How was this change tested?

Tested this manually and confirmed the installer works 

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*