### PR TITLE
fix(adaptor): Clamp render progress to 100%

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -344,7 +344,9 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         percent = text[loc : loc + 2]
         # check for % in case of single digit progress
         percent = percent[0] if percent.endswith("%") else percent
-        progress = int(percent)
+        # C4D can report progress > 100%. This is also clamped in progress_callback(),
+        # but we clamp here too to prevent regression if progress_callback() is modified.
+        progress = min(int(percent), 100)
         self.update_status(progress=progress)
 
     def _handle_error(self, match: re.Match) -> None:

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -62,10 +62,10 @@ def progress_callback(progress_percent, progress_type_int):
     else:
         progress_type_text = f"Unknown progress type ({progress_type_int})"
 
-    print(f"Progress update ({progress_type_text}): {progress_percent * 100.0}%")
+    print(f"Progress update ({progress_type_text}): {min(progress_percent * 100.0, 100.0)}%")
 
     if progress_type_int == c4d.RENDERPROGRESSTYPE_DURINGRENDERING:
-        print("ALF_PROGRESS %g" % (progress_percent * 100))
+        print("ALF_PROGRESS %g" % min(progress_percent * 100, 100))
 
 
 class Cinema4DHandler:

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -13,17 +13,29 @@ def mock_map_path(path: str):
 
 class TestProgress:
     def test_progress(self, capsys):
-        progress_callback(42, 0)
+        progress_callback(0.5, 0)
         progress = capsys.readouterr()
-        assert progress.out == "Progress update (Unknown progress type (0)): 4200.0%\n"
+        assert progress.out == "Progress update (Unknown progress type (0)): 50.0%\n"
 
     def test_progress_during_rendering(self, capsys):
         with patch.object(c4d, "RENDERPROGRESSTYPE_DURINGRENDERING", 0):
-            progress_callback(42, 0)
+            progress_callback(0.5, 0)
             progress = capsys.readouterr()
-            assert (
-                progress.out == "Progress update (during rendering): 4200.0%\nALF_PROGRESS 4200\n"
-            )
+            assert progress.out == "Progress update (during rendering): 50.0%\nALF_PROGRESS 50\n"
+
+    def test_progress_clamped_to_100(self, capsys):
+        """C4D can report progress > 1.0 during non-rendering phases (e.g. before rendering).
+        The log output should be clamped to 100%."""
+        progress_callback(1.33, 0)
+        progress = capsys.readouterr()
+        assert progress.out == "Progress update (Unknown progress type (0)): 100.0%\n"
+
+    def test_progress_during_rendering_clamped_to_100(self, capsys):
+        """ALF_PROGRESS should also be clamped to 100 if C4D reports > 1.0 during rendering."""
+        with patch.object(c4d, "RENDERPROGRESSTYPE_DURINGRENDERING", 0):
+            progress_callback(1.16, 0)
+            progress = capsys.readouterr()
+            assert progress.out == "Progress update (during rendering): 100.0%\nALF_PROGRESS 100\n"
 
 
 class TestCinema4DHandler:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Cinema 4D can report render progress values exceeding 1.0 (100%) during certain render phases, particularly "before rendering." This results in misleading log entries like Progress update (before rendering): 133.0% in task logs. Additionally, the progress value passed to the Deadline Cloud UI was not clamped, which could cause unexpected behavior in the progress bar. Deadline 10 already handled this case by clamping progress to 100%.

<img width="774" height="75" alt="Screenshot 2026-04-09 at 9 27 18 PM" src="https://github.com/user-attachments/assets/43da41bb-5d81-42b5-b53b-14841bd1c1c3" />


### What was the solution? (How)
Clamped progress values to a maximum of 100% in two places:
- progress_callback() in cinema4d_handler.py — clamps both the log output and the ALF_PROGRESS value emitted to stdout
- _handle_progress() in adaptor.py — clamps the parsed progress before calling update_status() as a defensive measure in case progress_callback() is modified in the future

### What is the impact of this change?
- Task logs will no longer show progress values exceeding 100%
- The Deadline Cloud UI progress bar is protected from receiving values >100%
- No functional impact on rendering — this only affects progress reporting

### How was this change tested?
- Updated existing unit tests in test_cinema4d_handler.py to use realistic progress values (0.0–1.0 range). Added two new unit tests:

- test_progress_clamped_to_100 — verifies log output is clamped when C4D reports >1.0
- test_progress_during_rendering_clamped_to_100 — verifies ALF_PROGRESS is clamped when C4D reports >1.0 during rendering

- Have you run the unit tests?
Yes 

- Have you run the integration tests? (Add your integration test report below)
No - this change only affects progress reporting (log output and UI progress bar clamping). It does not modify any rendering logic, scene parsing, or job bundle generation. Integration tests require a Windows machine with Cinema 4D installed and are not applicable to this change.

- Have you made changes to the submitter?
no 

### Was this change documented?

no
### Is this a breaking change?
no 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*