### PR TITLE
fix: Show dialog to open a project instead of crashing on an empty pr…

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -383,6 +383,13 @@ def _get_job_template(
 
 def _prompt_save_current_document():
     doc = c4d.documents.GetActiveDocument()
+    if not doc.GetDocumentPath():
+        c4d.gui.MessageDialog(
+            "Please open an existing project or save the current scene to disk\n"
+            "before launching the submitter."
+        )
+        return False
+
     if not doc.GetChanged():
         # Document has no unsaved changes
         return True


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/424

### What was the problem/requirement? (What/Why)

The submitter used to crash when opening on an empty project. 

### What was the solution? (How)

Check if the project is empty before trying to launch the submitter. If project is empty, notify user to open a project before opening the submitter. 

<img width="270" height="242" alt="image" src="https://github.com/user-attachments/assets/d55f80aa-3b53-404b-a63d-c0c80008a2ca" />


### What is the impact of this change?

Less crashes. 

### How was this change tested?

- Have you run the unit tests?
Yes. Unfortunately, as this involves C4D APIs we cannot add unit tests. 

- Have you run the integration tests? (Add your integration test report below)
Running it right now. 

- Have you made changes to the submitter?
Yes, but has not impact on the submitter. 

### Was this change documented?
This is a bug fix, we don't need documentation. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*