### PR TITLE
fix: support tile rendering in 2024

### DIFF
--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -66,13 +66,7 @@ For example, a 99×99 grid on a single frame would produce 9,801 render tasks, w
 
 **Q: Why is tile rendering failing with an `AttributeError: module 'c4d.documents' has no attribute 'BakeOcioViewToBitmap'`?**
 
-A: Tile rendering requires Cinema 4D 2025 or above. The tile assembly step uses the `c4d.documents.BakeOcioViewToBitmap` API, which was introduced in Cinema 4D 2025. If you're running an older version, the assemble step will fail with an error like:
-
-```
-AttributeError: module 'c4d.documents' has no attribute 'BakeOcioViewToBitmap'
-```
-
-To fix this, upgrade to Cinema 4D 2025 or later.
+A: This error occurs on older versions of the Cinema 4D submitter that required Cinema 4D 2025 or above for tile rendering. Update to the latest version of `deadline-cloud-for-cinema-4d`, which supports tile rendering on Cinema 4D 2024 and later. Note that on Cinema 4D 2024, OCIO view transform baking is skipped during tile rendering because the required API (`BakeOcioViewToBitmap`) is not available.
 
 **Q: Can I use Redshift?**
 

--- a/docs/user_guide/faq-and-glossary.md
+++ b/docs/user_guide/faq-and-glossary.md
@@ -64,10 +64,6 @@ A: It depends on your scene. A 3×3 or 4×4 grid is a good starting point. More 
 
 For example, a 99×99 grid on a single frame would produce 9,801 render tasks, which is close to the limit.
 
-**Q: Why is tile rendering failing with an `AttributeError: module 'c4d.documents' has no attribute 'BakeOcioViewToBitmap'`?**
-
-A: This error occurs on older versions of the Cinema 4D submitter that required Cinema 4D 2025 or above for tile rendering. Update to the latest version of `deadline-cloud-for-cinema-4d`, which supports tile rendering on Cinema 4D 2024 and later. Note that on Cinema 4D 2024, OCIO view transform baking is skipped during tile rendering because the required API (`BakeOcioViewToBitmap`) is not available.
-
 **Q: Can I use Redshift?**
 
 A: Yes! Redshift GPU rendering is supported.

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/tile_rendering.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/tile_rendering.py
@@ -28,6 +28,12 @@ EXT_TO_FILTER = {v[0]: v[1] for v in FORMAT_MAP.values()}
 
 DEFAULT_FORMAT = FORMAT_MAP[c4d.FILTER_PNG]
 
+# Cinema 4D 2025.2 introduced BakeOcioViewToBitmap and the index parameter
+# for SetColorProfile. The COLORPROFILE_INDEX_* constants exist in earlier
+# versions but SetColorProfile does not accept them until 2025.2.
+# https://developers.maxon.net/docs/py/2025_2_0/misc/whatisnew.html
+C4D_VERSION_2025_2 = 2025200
+
 
 def get_format_info(format_id: int) -> tuple[str, int]:
     """Return (extension, save_filter) for a C4D render format ID."""
@@ -177,8 +183,13 @@ def setup_tile_render(
 
     # OCIO: for 8-bit output during tile renders, disable the render-time OCIO view
     # transform bake so we can bake it manually after rendering.
+    # BakeOcioViewToBitmap and RDATA_BAKE_OCIO_VIEW_TRANSFORM_RENDER were introduced
+    # in Cinema 4D 2025.2 — skip OCIO baking on older versions.
     rd = render_data.GetDataInstance()
-    requires_baking = rd[c4d.RDATA_FORMATDEPTH] == c4d.RDATA_FORMATDEPTH_8
+    _has_ocio_bake = hasattr(c4d, "RDATA_BAKE_OCIO_VIEW_TRANSFORM_RENDER") and hasattr(
+        c4d.documents, "BakeOcioViewToBitmap"
+    )
+    requires_baking = _has_ocio_bake and rd[c4d.RDATA_FORMATDEPTH] == c4d.RDATA_FORMATDEPTH_8
     orig_bake_flag = None
     if requires_baking:
         orig_bake_flag = rd.GetBool(c4d.RDATA_BAKE_OCIO_VIEW_TRANSFORM_RENDER)
@@ -225,12 +236,18 @@ def finalize_tile_render(
         baked = c4d.documents.BakeOcioViewToBitmap(bm, rd, c4d.SAVEBIT_NONE)
         bm = baked or bm
 
-    bm.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_DISPLAYSPACE)
-    bm.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_VIEW_TRANSFORM)
+    if c4d.GetC4DVersion() >= C4D_VERSION_2025_2:
+        bm.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_DISPLAYSPACE)
+        bm.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_VIEW_TRANSFORM)
+    else:
+        print(
+            f"Tile ({ctx.tile_col}, {ctx.tile_row}): Skipping OCIO color profile reset (pre-2025.2)"
+        )
 
     # Crop the tile region from the full bitmap using GetClonePart to preserve
     # bit depth and float data (GetPixel/SetPixel truncates to 8-bit integers).
     tile_bmp = bm.GetClonePart(ctx.region_left, ctx.region_top, ctx.tile_w, ctx.tile_h)
+
     if tile_bmp is None:
         raise RuntimeError(
             f"Failed to crop tile ({ctx.tile_col}, {ctx.tile_row}) from rendered bitmap"
@@ -288,8 +305,15 @@ def _apply_color_profile(final_bmp: Any, source_bmp: Any, is_multipass: bool) ->
     if profile is not None:
         final_bmp.SetColorProfile(profile)
     elif not is_multipass:
-        final_bmp.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_DISPLAYSPACE)
-        final_bmp.SetColorProfile(c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_VIEW_TRANSFORM)
+        if c4d.GetC4DVersion() >= C4D_VERSION_2025_2:
+            final_bmp.SetColorProfile(
+                c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_DISPLAYSPACE
+            )
+            final_bmp.SetColorProfile(
+                c4d.bitmaps.ColorProfile(), c4d.COLORPROFILE_INDEX_VIEW_TRANSFORM
+            )
+        else:
+            print("Assembly: Skipping OCIO color profile reset (pre-2025.2)")
 
 
 def _tile_path(base: str, ext: str, frame_str: str, col: int, row: int, is_multipass: bool) -> str:


### PR DESCRIPTION

Fixes: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/409

### What was the problem/requirement? (What/Why)
Tile rendering fails on Cinema 4D 2024 with AttributeError: module 'c4d.documents' has no attribute 'BakeOcioViewToBitmap'. The tile rendering code uses OCIO APIs (BakeOcioViewToBitmap, SetColorProfile with index argument) that were introduced in Cinema 4D 2025.2. On C4D 2024, these APIs don't exist or are non-functional, causing crashes, hangs, and segfaults. 

### What was the solution? (How)

- Added version guards (c4d.GetC4DVersion() >= 2025200) around the 2025.2-only OCIO APIs in tile_rendering.py:

- - setup_tile_render: Guard the OCIO bake flag disable logic with hasattr checks for RDATA_BAKE_OCIO_VIEW_TRANSFORM_RENDER and BakeOcioViewToBitmap. On C4D 2024, requires_baking is False, so the bake flag is not disabled — C4D handles OCIO view transform baking during render as normal.

- - finalize_tile_render: Guard SetColorProfile with index argument behind a version check. On C4D 2024, the OCIO profile metadata stripping is skipped since we didn't manually bake the view transform (no metadata mismatch to fix).

- - _apply_color_profile: Same version guard for SetColorProfile with index argument during tile assembly.

Note: hasattr alone was insufficient for SetColorProfile — C4D 2024.5 has the COLORPROFILE_INDEX_DISPLAYSPACE constant but SetColorProfile doesn't properly support the index argument, causing hangs and segfaults. An explicit version check is used instead.

Also updated the FAQ in docs/user_guide/faq-and-glossary.md to reflect that tile rendering now works on C4D 2024.


### What is the impact of this change?
- Tile rendering now works on Cinema 4D 2024 instead of crashing
- On C4D 2024, OCIO view transform baking is skipped during tile rendering 
No behavior change on C4D 2025.2+ — the existing OCIO bake path runs as before

### How was this change tested?

- Submitted a job with C4D 2024 parameters, and verified the output 
<img width="1061" height="788" alt="Screenshot 2026-04-16 at 2 32 45 PM" src="https://github.com/user-attachments/assets/d7e19714-f473-4e61-adda-f011cc3db0c2" />

- Have you run the unit tests?
yes 

- Have you run the integration tests? (Add your integration test report below)
- 
```
=============================================== short test summary info ===============================================
FAILED test/integ/test_cinema4d.py::test_integ[redshift_textured_with_nonascii_characters] - AssertionError
====================================== 1 failed, 10 passed in 1250.63s (0:20:50) ======================================
```

- Have you made changes to the submitter?
no 

### Was this change documented?

updated the document 

### Is this a breaking change?

no 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*