### PR TITLE
fix: migrate C4D integ test licensing to license endpoint

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -47,7 +47,6 @@ build-installer = "python {root}/scripts/build_installer_cli.py --installer-sour
 pre-install-commands = [
   "pip install -r requirements-testing.txt"
 ]
-features = ["gui"]
 
 [[envs.integ-ci.matrix]]
 cinema4d = ["2025", "2026"]

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -181,35 +181,38 @@ def setup_windows(versions):
 
 
 def _configure_rlm_licensing(versions):
-    """Configure Cinema 4D to use RLM licensing without interactive GUI login.
-
-    Cinema 4D normally requires a user to select a license method via a GUI dialog on first launch.
-    For headless CI, we append 'g_licenseServerRLM=host:port' to Cinema 4D's resource/config.txt,
-    which is the official Maxon-documented way to enable automatic RLM licensing:
-    https://support.maxon.net/hc/en-us/articles/1500006333301
-
-    The RLM server address is read from the redshift_LICENSE env var (format: "port@host"),
-    which is set by the CodeBuild project and tunneled via SSH to the dev license server.
-    """
-    rlm_server = os.environ.get("redshift_LICENSE", "")
-    if not rlm_server:
+    """Configure Cinema 4D to use RLM licensing without interactive GUI login."""
+    license_dns = os.environ.get("LICENSE_ENDPOINT_DNS", "")
+    if not license_dns:
+        print(
+            "WARNING: LICENSE_ENDPOINT_DNS is not set. Skipping licensing config. The test will likely fail."
+        )
         return
 
-    # Convert "port@host" to "host:port" for config.txt
-    parts = rlm_server.split("@")
-    rlm_config = f"{parts[1]}:{parts[0]}" if len(parts) == 2 else rlm_server
+    license_port = os.environ.get("C4D_LICENSE_PORT")
+    if not license_port:
+        print("WARNING: C4D_LICENSE_PORT is not set. Skipping licensing config.")
+        return
 
+    rlm_config = f"{license_dns}:{license_port}"
     for version in versions:
         install_dir = C4D_INSTALL_PATHS[version]["windows"]
         config_txt = install_dir / "resource" / "config.txt"
         if not config_txt.exists():
             print(f"WARNING: config.txt not found at {config_txt}")
             continue
-        if "g_licenseServerRLM" in config_txt.read_text():
-            print(f"RLM licensing already configured in {config_txt}")
-            continue
-        with open(config_txt, "a") as f:
-            f.write(f"\ng_licenseServerRLM={rlm_config}\n")
+        content = config_txt.read_text()
+        lines = [
+            line
+            for line in content.splitlines()
+            if "g_licenseServerRLM" not in line
+            and "g_licenseServerURL" not in line
+            and "g_licenseModel" not in line
+        ]
+        lines.append(f"g_licenseServerRLM={rlm_config}")
+        lines.append(f"g_licenseServerURL={rlm_config}")
+        lines.append("g_licenseModel=LICENSEMODEL::RLM")
+        config_txt.write_text("\n".join(lines) + "\n")
         print(f"Configured RLM licensing ({rlm_config}) in {config_txt}")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gui = [
-    "deadline[gui] >= 0.51.1,< 0.55",
+    "deadline[gui] >= 0.55.1,< 0.56",
     "PySide6-Essentials == 6.8.3",  # Use 6.8 to align with VFXP 2026: https://vfxplatform.com/#reference-platform
 ]
 

--- a/test/integ/utils.py
+++ b/test/integ/utils.py
@@ -21,7 +21,7 @@ def run_command(args: list[str]) -> subprocess.CompletedProcess[bytes]:
     """
 
     print(f"Args list: {args}")
-    output = subprocess.run(args, capture_output=True)
+    output = subprocess.run(args, capture_output=True, stdin=subprocess.DEVNULL)
 
     print(f"\nstdout:\n\n{output.stdout.decode('utf-8', errors='replace')}")
     print(f"\nstderr:\n\n{output.stderr.decode('utf-8', errors='replace')}")


### PR DESCRIPTION
Migrate Cinema 4D integration tests from SSH bastion to the license endpoint, eliminating manual SSH key rotation every 60 days.

- Configure RLM licensing via config.txt using LICENSE_ENDPOINT_DNS and C4D_LICENSE_PORT environment variables
- Add g_licenseModel=LICENSEMODEL::RLM to force RLM mode on headless servers
- Add stdin=DEVNULL to subprocess calls to prevent interactive prompt hang
- Fix gui extra dependency version pin to match base (>= 0.55.1, < 0.56)
- Remove unused features=[gui] from integ-ci hatch env

### What was the problem/requirement? (What/Why)
Cinema 4D integration tests used an SSH tunnel to a bastion host for licensing, which requires manual key rotation every 60 days. Other DCC integrations (Houdini, 3ds Max) have already migrated to the license endpoint.

### What was the solution? (How)
- Configure RLM licensing via config.txt using LICENSE_ENDPOINT_DNS and C4D_LICENSE_PORT
environment variables (set by CDK)
- Add g_licenseModel=LICENSEMODEL::RLM to force RLM mode — without this, Cinema 4D prompts
interactively for a license server, which hangs on headless servers
- Add stdin=DEVNULL to subprocess calls as a safety net against interactive prompts
- Fix [gui] extra dependency version pin to match base (>= 0.55.1, < 0.56)
- Remove unused features=["gui"] from integ-ci hatch env

### What is the impact of this change?
No customer impact. Internal CI only. Eliminates the need for manual SSH key rotation every 60
days for Cinema 4D integration tests.

### How was this change tested?

*delete text starting here*
See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/DEVELOPMENT.md) for information on running tests.

- Have you run the unit tests?
```
=============================== 321 passed, 6 skipped in 5.42s ===============================
```
- Have you run the integration tests? (Add your integration test report below)
```

scheduling tests via LoadScheduling
--
 
test/integ/test_cinema4d.py::test_integ[physical]
[gw0] [  9%] PASSED test/integ/test_cinema4d.py::test_integ[physical]
test/integ/test_cinema4d.py::test_integ[physical_textured]
[gw0] [ 18%] PASSED test/integ/test_cinema4d.py::test_integ[physical_textured]
test/integ/test_cinema4d.py::test_integ[redshift]
[gw0] [ 27%] PASSED test/integ/test_cinema4d.py::test_integ[redshift]
test/integ/test_cinema4d.py::test_integ[redshift_takes]
[gw0] [ 36%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_takes]
test/integ/test_cinema4d.py::test_integ[redshift_textured]
[gw0] [ 45%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_textured]
test/integ/test_cinema4d.py::test_integ[redshift_textured_nonascii]
[gw0] [ 54%] XFAIL test/integ/test_cinema4d.py::test_integ[redshift_textured_nonascii]
test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
[gw0] [ 63%] PASSED test/integ/test_cinema4d.py::test_integ[physical_multi_takes]
test/integ/test_cinema4d.py::test_integ[physical_tiles]
[gw0] [ 72%] PASSED test/integ/test_cinema4d.py::test_integ[physical_tiles]
test/integ/test_cinema4d.py::test_integ[redshift_tiles]
[gw0] [ 81%] PASSED test/integ/test_cinema4d.py::test_integ[redshift_tiles]
test/integ/test_cinema4d.py::test_integ[physical_apostrophe_path]
[gw0] [ 90%] PASSED test/integ/test_cinema4d.py::test_integ[physical_apostrophe_path]
test/integ/test_cinema4d.py::test_integ[physical_chunking]
[gw0] [100%] PASSED test/integ/test_cinema4d.py::test_integ[physical_chunking]
 ```

- Have you made changes to the submitter?
no 
### Was this change documented?
no 
### Is this a breaking change?
no 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*