### PR TITLE
chore: Add skills to accelerate development using LLMs.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md — deadline-cloud-for-cinema-4d
+
+Python package providing a Cinema 4D submitter extension and adaptor for AWS Deadline Cloud rendering.
+
+> **New to this repo?** Start with the `c4d-dev-setup` skill to automate your dev environment setup (install hatch, build the package, install the submitter into Cinema 4D). Ask: *"use c4d-dev-setup to set up this computer"*.
+
+## Working in Specific Areas
+
+When working in these areas, read the AGENTS.md in that folder first — it contains the detailed context you need:
+
+- **Submitter code** (`src/deadline/cinema4d_submitter/`) → [`src/deadline/cinema4d_submitter/AGENTS.md`](src/deadline/cinema4d_submitter/AGENTS.md)
+- **Adaptor code** (`src/deadline/cinema4d_adaptor/`) → [`src/deadline/cinema4d_adaptor/AGENTS.md`](src/deadline/cinema4d_adaptor/AGENTS.md)
+- **Tests** (`test/`) → [`test/AGENTS.md`](test/AGENTS.md)
+
+## High-Level Architecture
+
+```
+  SUBMITTER WORKSTATION                         WORKER NODE
+ ┌──────────────────────┐                     ┌──────────────────────────┐
+ │  Cinema 4D           │                     │  cinema4d-openjd CLI     │
+ │  ├─ DeadlineCloud.pyp│   OpenJD Job Bundle │  ├─ Cinema4DAdaptor/     │
+ │  └─ cinema4d_submitter│ ──────────────────►│  │    (manages C4D proc) │
+ │       (job bundle)   │                     │  └─ Cinema4DClient/      │
+ └──────────────────────┘                     │       (runs in C4D)      │
+                                              └──────────────────────────┘
+```
+
+- **Submitter** runs inside Cinema 4D on the artist's workstation; creates job bundles
+- **Cinema4DAdaptor** runs on workers as `cinema4d-openjd` CLI; manages the Cinema 4D process lifecycle
+- **Cinema4DClient** runs inside Cinema 4D on workers; executes actions from the adaptor over named pipes
+
+For architecture details, see `docs/software_arch.md` and the area-specific AGENTS.md files above.
+
+## Build
+
+```bash
+hatch build
+```
+
+For quick submitter iteration during development, see [`src/deadline/cinema4d_submitter/AGENTS.md`](src/deadline/cinema4d_submitter/AGENTS.md). For adaptor changes, build a patched [cinema4d-openjd conda package](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-openjd) and deploy to workers.
+
+## Tests
+
+Use `hatch run test` to run unit tests — do NOT use `pytest` directly.
+
+```bash
+hatch run test                                    # All unit tests
+hatch run test test/unit/<path>                   # One test file or directory
+hatch run test -k "test_name"                     # One test by name
+hatch run all:test                                # All supported Python versions
+```
+
+**Integration Tests (Windows Only):** See [`test/AGENTS.md`](test/AGENTS.md).
+
+## Linting
+
+```bash
+hatch run lint     # ruff + black + mypy
+hatch run fmt      # black + ruff auto-format
+hatch run typing   # mypy only
+```
+
+## Python Version
+
+- Cinema 4D 2026 uses Python 3.11
+- Cinema 4D 2024–2025 uses Python 3.10
+- System Python 3.10+ is sufficient for unit tests
+- Integration tests use Cinema 4D's bundled Python
+
+## Commit Messages
+
+Use conventional commits:
+- `feat:` — new features
+- `fix:` — bug fixes
+- `docs:` — documentation
+- `test:` — tests only
+- `refactor:` — code refactoring
+- `perf:` — performance improvements
+- `feat!:` or `fix!:` — breaking changes
+
+## Design Docs for Major Changes
+
+For new features or major refactors, use the `c4d-design` skill to create a structured design doc. This does NOT apply to small bug fixes.
+
+## Supported Renderers
+
+| Renderer | OS Support | Notes |
+|----------|-----------|-------|
+| Redshift | Windows, Linux | Bundled with C4D 2024+, default renderer |
+| Arnold (C4DtoA) | Windows, Linux | Separate plugin |
+| V-Ray | Windows, macOS | Separate plugin |
+| Physical/Standard | Windows, macOS, Linux | Built-in |
+
+## Skills (for AI agents)
+
+This repo includes three skills in `skills/` (following the [Agent Skills standard](https://agentskills.io/)):
+
+- **c4d-dev-setup** — Automates dev environment setup. Run when onboarding.
+- **c4d-dev** — Day-to-day development: build, test, lint, debug, integration testing.
+- **c4d-design** — Structured design docs for new features and major refactors.
+
+## External References
+
+- **Cinema 4D Python SDK:** https://developers.maxon.net/docs/py/2026/
+- **User Guide:** https://aws-deadline.github.io/deadline-cloud-for-cinema-4d
+- **Public conda recipes:** https://github.com/aws-deadline/deadline-cloud-samples
+- **OpenJD Adaptor Runtime:** https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python
+- **Software architecture:** `docs/software_arch.md`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,6 +2,13 @@
 
 This documentation provides guidance on developer workflows for working with the code in this repository.
 
+> **Tip:** This repo includes three AI skills in `skills/` (following the [Agent Skills standard](https://agentskills.io/)) to accelerate development with AI coding assistants:
+> - **c4d-dev-setup** — Automates dev environment setup. Ask: *"use c4d-dev-setup to set up this computer"*
+> - **c4d-dev** — Day-to-day development: build, test, lint, debug. Ask: *"how do I run integration tests?"*
+> - **c4d-design** — Structured design docs for new features. Ask: *"help me design a new feature"*
+>
+> See [AGENTS.md](AGENTS.md) at the repo root for general agent guidance that applies across all AI tools.
+
 Table of Contents:
 
 * [Development Environment Setup](#development-environment-setup)

--- a/skills/c4d-design/SKILL.md
+++ b/skills/c4d-design/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: c4d-design
+description: AI-guided design for Cinema 4D features and major changes in Deadline Cloud integration. Use when designing new features, planning major refactors, creating design docs, or making architectural decisions for deadline-cloud-for-cinema-4d. Triggers on requests like "design a feature", "write a design doc", "plan a major change", or "architect a solution".
+tags: [skill, deadline-cloud, deadline-cloud-for-cinema-4d, deadline-cloud-for-c4d, design, architecture, feature-design]
+---
+
+# Cinema 4D Design
+
+## Overview
+
+AI-guided interactive design process for Cinema 4D features in Deadline Cloud. The agent drives the conversation — researching, proposing options, and prompting the user for decisions at each step. Progress is saved to disk after each section.
+
+## Usage
+
+Use this skill when:
+- Designing a new **major** feature for the Cinema 4D integration
+- Planning a major refactor or architectural change
+- Creating or refining a design document in `docs/designs/`
+
+Do **not** use this skill for small bug fixes, minor enhancements, or changes that can be adequately described in a PR description.
+
+## Core Concepts
+
+### Agent Role
+
+You are the design driver. The user provides goals and makes decisions. You do everything else:
+- **Research** the codebase, `AGENTS.md`, and references
+- **Draft** each section with concrete proposals
+- **Present** options with pros/cons for every design decision
+- **Prompt** the user to choose, confirm, or redirect
+- **Challenge** your own proposals — surface weaknesses and edge cases before the user asks
+- **Iterate** based on user feedback before moving to the next section
+
+You **MUST NOT** dump an entire design doc at once. Work through it section by section, getting user sign-off on each before proceeding.
+
+### Saving Progress
+
+You **MUST** write the design doc to `docs/designs/<feature-name>.md` incrementally — after each section is approved, write it to disk. This ensures:
+- Work survives context window limits
+- A new session can resume by reading the file
+- The user can review progress at any time
+
+On session start, always check `docs/designs/` for an existing draft to resume.
+
+### Design Flow
+
+The design doc follows a four-section structure. See [references/design-doc-structure.md](references/design-doc-structure.md) for the full structure and [references/design-workflow.md](references/design-workflow.md) for the step-by-step workflow.
+
+#### Step 1: Kickoff
+
+Prompt the user:
+```
+What would you like to do?
+1. Start a new design
+2. Refine an existing design (from docs/designs/)
+```
+
+**If new design:** Ask the user to describe the feature and any known constraints/specs.
+
+**If refining:** Read the existing doc, ask what needs to change.
+
+#### Step 2: Research
+
+Before drafting anything, you **MUST**:
+1. Read `AGENTS.md` at the repo root for high-level architecture
+2. Read the relevant area-specific AGENTS.md files for the components you'll touch:
+   - `src/deadline/cinema4d_submitter/AGENTS.md` for submitter work
+   - `src/deadline/cinema4d_adaptor/AGENTS.md` for adaptor/client work
+   - `test/AGENTS.md` for test structure
+3. Read `docs/software_arch.md` for additional architectural context
+4. Search the codebase for existing patterns related to the feature
+5. Read [references/research-guide.md](references/research-guide.md) for Cinema 4D API patterns
+6. Read any linked docs, tickets, or prior art the user mentions
+
+Summarize findings to the user. Ask if anything is missing.
+
+#### Step 3: Work through the four design sections
+
+Work through each section with the user, getting sign-off before moving on:
+
+1. **Data Structures to Change or Add**
+2. **UX Changes (Submitter Dialog)**
+3. **Job Template and Bundle Changes**
+4. **Adaptor and Client Changes**
+
+For each design decision:
+1. Research options — read code, check APIs, look at existing patterns
+2. Present 2-3 options with pros/cons, self-challenge weaknesses
+3. Wait for user decision
+
+Write each approved section to disk.
+
+#### Step 4: Testing Plan
+
+Define unit tests and, if applicable, integration tests (Windows only).
+
+#### Step 5: Create the Appendix
+
+Put all full code implementations in a clearly marked appendix at the end of the design document.
+
+### Prompting Patterns
+
+At every decision point, you **MUST** end with a clear question.
+
+You **MUST NOT**:
+- Proceed to the next section without user confirmation
+- Make design decisions without presenting options
+- Skip research — always check the codebase first
+
+## Code Snippet Style Guide
+
+Use **concise inline snippets** in the main sections and put **full implementations in an appendix**.
+
+### Inline Code Format
+
+Show only the relevant changes with context:
+
+```python
+def existing_function():
+    ...existing logic...
+
+    # NEW: Add feature X support
+    if feature_x_enabled:
+        self._configure_feature_x(data)
+
+    ...rest of function...
+```
+
+### Guidelines
+
+1. **Data structures are the exception**: Always show full definitions — they anchor the design
+2. **Other sections**: Show what changes and where, not full implementations
+3. **Use `...` or comments** to indicate existing/unchanged code
+4. **Flag new sections** with `<!-- REVIEW: description -->` comments in the appendix
+
+## Quick Reference
+
+| Resource | Location |
+|----------|----------|
+| Design doc structure | `references/design-doc-structure.md` |
+| Step-by-step workflow | `references/design-workflow.md` |
+| Cinema 4D API research | `references/research-guide.md` |
+| Architecture guide | `references/deadline-cloud-architecture.md` |
+| External references | `references/external-references.md` |
+| Output directory | `docs/designs/` |
+| Repo architecture | `AGENTS.md` (repo root) |

--- a/skills/c4d-design/references/deadline-cloud-architecture.md
+++ b/skills/c4d-design/references/deadline-cloud-architecture.md
@@ -1,0 +1,123 @@
+# Deadline Cloud for Cinema 4D Architecture (for design work)
+
+Quick architectural reference for design decisions. For authoritative component details, read the AGENTS.md files first — they're the source of truth:
+
+- [`AGENTS.md`](../../../AGENTS.md) — Repo-wide architecture overview
+- [`src/deadline/cinema4d_submitter/AGENTS.md`](../../../src/deadline/cinema4d_submitter/AGENTS.md) — Submitter internals
+- [`src/deadline/cinema4d_adaptor/AGENTS.md`](../../../src/deadline/cinema4d_adaptor/AGENTS.md) — Adaptor and client internals
+- [`test/AGENTS.md`](../../../test/AGENTS.md) — Test structure
+
+This file covers patterns and flows that are especially relevant when designing new features.
+
+## Data Flow: Submitter to Render
+
+Understanding the end-to-end flow is essential for design work that spans submitter and adaptor.
+
+### 1. Job Submission
+
+```
+User opens Extensions > AWS Deadline Cloud Submitter
+    → Submitter reads scene (scene.py, takes.py, assets.py)
+    → User configures settings in dialog
+    → Submitter creates job bundle:
+        +-- template.yaml (job definition with steps per take)
+        +-- parameter_values.yaml (user settings)
+        +-- asset references (scene, textures, fonts)
+    → Submit to Deadline Cloud
+```
+
+### 2. Task Execution on Worker
+
+```
+Deadline Cloud assigns task to worker
+    → Cinema4DAdaptor receives task
+    → Adaptor starts Cinema 4D with Cinema4DClient
+    → Init actions (once per job):
+        +-- Load scene file
+        +-- Configure renderer
+        +-- Set output settings
+    → Run actions (per frame/take):
+        +-- Set frame number
+        +-- Set take (if multi-take)
+        +-- Set output path
+        +-- Start render
+    → Parse stdout for progress
+    → Report completion to Deadline Cloud
+```
+
+### 3. Action Execution in Cinema4DClient
+
+```
+Cinema4DClient receives action via named pipe
+    → Route to handler method in cinema4d_handler.py
+    → Execute c4d module commands
+    → Report result back to adaptor
+```
+
+## Design Considerations
+
+### Where does your feature live?
+
+Most features touch more than one component. Map out where each piece lives:
+
+| Concern | Component | Files |
+|---------|-----------|-------|
+| User-facing UI | Submitter | `cinema4d_submitter/ui/`, `data_classes.py` |
+| Scene analysis | Submitter | `scene.py`, `takes.py`, `assets.py` |
+| Job template parameters | Submitter | `adaptor_cinema4d_job_template.yaml` |
+| Passing data to worker | Both | `schemas/init_data.schema.json`, `schemas/run_data.schema.json` |
+| Runtime logic on worker | Adaptor | `Cinema4DAdaptor/adaptor.py` |
+| Cinema 4D control on worker | Client | `Cinema4DClient/cinema4d_handler.py` |
+
+### Schema versioning
+
+If your design changes the data contract between submitter and adaptor (either schema), you **must** bump `integration_data_interface_version` in `adaptor.py`. Consider whether the change is backwards-compatible.
+
+### Take system interaction
+
+Cinema 4D's take system can affect many features. Ask: should this setting be global, per-take, or both? The submitter creates separate Steps in the job template per take, and the adaptor switches takes before rendering each Step.
+
+### Path mapping
+
+Assets may be at different paths on worker vs. artist workstation. The OpenJD adaptor runtime provides path mapping. For any feature that references file paths, ensure they go through path mapping on the worker side.
+
+### Renderer-specific handling
+
+Not all renderers are available on all platforms:
+
+| Renderer | ID | OS Support | Notes |
+|----------|-----|-----------|-------|
+| Physical | 1023342 | Win, Mac, Linux | Built-in |
+| Standard | 0 | Win, Mac, Linux | Built-in |
+| Redshift | 1036219 | Win, Linux | Bundled with C4D 2024+ |
+| Arnold (C4DtoA) | varies | Win, Linux | Separate plugin |
+| V-Ray | varies | Win, Mac | Separate plugin |
+
+If your feature is renderer-specific, design how it gracefully handles unsupported renderers.
+
+## Adding a New Feature (Design Checklist)
+
+### Submitter side
+1. Data models in `data_classes.py`
+2. UI controls in `ui/` components
+3. Parameters in job template YAML (`adaptor_cinema4d_job_template.yaml`)
+4. Scene introspection updates if needed (`scene.py`, `takes.py`, `assets.py`)
+
+### Data contract
+5. Schema updates (`init_data.schema.json`, `run_data.schema.json`)
+6. **Bump `integration_data_interface_version`** if schemas changed
+
+### Adaptor side
+7. Read parameters from job bundle in `adaptor.py`
+8. Create actions to send to Cinema4DClient
+9. Add stdout/stderr regex handlers if needed for progress parsing
+
+### Client side
+10. Add handler method in `cinema4d_handler.py`
+11. Register action in handler's `action_dict`
+12. Implement `c4d` module logic
+
+### Testing
+13. Unit tests for handler methods (mock `c4d`)
+14. Unit tests for submitter logic
+15. Consider adding integration test scene if rendering behavior changes

--- a/skills/c4d-design/references/design-doc-structure.md
+++ b/skills/c4d-design/references/design-doc-structure.md
@@ -1,0 +1,43 @@
+# Design Document Structure
+
+Every design document MUST follow this four-section structure:
+
+## 1. Data Structures to Change or Add
+
+Define all data model changes including:
+- New dataclasses or TypedDicts
+- Modifications to existing data structures (in `data_classes.py`, `enums.py`, etc.)
+- Job parameter schemas
+- Configuration objects
+- Adaptor schema changes (`init_data.schema.json`, `run_data.schema.json`)
+- Type annotations
+
+## 2. UX Changes (Submitter Dialog)
+
+Document all user-facing changes:
+- New UI controls (dropdowns, checkboxes, text fields)
+- Control placement and grouping within the submitter dialog
+- Default values and validation
+- Tooltips and help text
+- Conditional visibility logic
+- Take-specific settings
+
+## 3. Job Template and Bundle Changes
+
+Specify modifications to:
+- `adaptor_cinema4d_job_template.yaml` structure
+- `default_cinema4d_job_template.yaml` structure (if applicable)
+- New parameters and their types
+- Parameter dependencies and conditions
+- Asset references and attachments
+
+## 4. Adaptor and Client Changes
+
+Detail the runtime implementation:
+- Cinema4DAdaptor modifications (adaptor.py)
+- Cinema4DClient changes (cinema4d_client.py, cinema4d_handler.py)
+- New action handlers and commands
+- Renderer-specific handling
+- Path mapping considerations
+- Progress reporting and logging
+- stdout/stderr handler regex patterns

--- a/skills/c4d-design/references/design-workflow.md
+++ b/skills/c4d-design/references/design-workflow.md
@@ -1,0 +1,226 @@
+# Cinema 4D Design Workflow Guide
+
+This guide walks through creating a comprehensive design document for a new Cinema 4D feature.
+
+## Step 1: Understand the Feature Request
+
+Before starting the design:
+1. Clarify the user's goal and expected outcome
+2. Identify which renderers are affected (Redshift, Arnold, V-Ray, Physical, etc.)
+3. Determine if this is a submitter change, adaptor change, or both
+4. Determine if this affects Windows, macOS, Linux, or all platforms
+5. Ask clarifying questions if the scope is unclear
+
+## Step 2: Research Phase
+
+### 2.1 Search Cinema 4D Documentation
+
+Look up relevant Cinema 4D Python APIs:
+- The `c4d` module and its classes
+- Renderer-specific settings and properties
+- Scene object access patterns
+- Take system APIs
+
+Key search terms:
+- "Cinema 4D Python API [topic]"
+- "c4d module [class name]"
+- "Redshift Cinema 4D [feature]"
+- "Cinema 4D SDK [topic]"
+
+### 2.2 Check Existing Implementation
+
+Review the current codebase:
+- How does the submitter handle similar features? (`cinema4d_render_submitter.py`, `data_classes.py`)
+- How does the adaptor handle similar actions? (`cinema4d_handler.py`, `cinema4d_client.py`)
+- What patterns exist in the job templates? (`adaptor_cinema4d_job_template.yaml`)
+- How are takes handled? (`takes.py`)
+- How are assets discovered? (`assets.py`)
+
+### 2.3 Internet Research
+
+Search for:
+- Community solutions and workarounds
+- Known issues and limitations
+- Version compatibility notes (Cinema 4D 2024 vs 2025 vs 2026)
+- Renderer-specific documentation (Redshift, Arnold, V-Ray)
+
+## Step 3: Design the Data Structures
+
+Data structures anchor the design — **always include full definitions** for new types:
+
+```python
+from typing import Any, Optional
+from dataclasses import dataclass
+from enum import Enum
+
+class FeatureMode(Enum):
+    """Mode options for Feature X."""
+    OPTION_A = "option_a"
+    OPTION_B = "option_b"
+
+@dataclass
+class FeatureSettings:
+    """Settings for Feature X workflow."""
+
+    enabled: bool = False
+    mode: FeatureMode = FeatureMode.OPTION_A
+    output_path: Optional[str] = None
+```
+
+Consider:
+- What data flows from submitter to adaptor?
+- What state needs to be maintained during rendering?
+- How does this interact with the take system?
+- Does this affect asset discovery?
+
+**Note:** Data structures are the exception to the "concise snippets" rule — show them in full since they anchor the entire design.
+
+## Step 4: Design the UX
+
+Sketch out the submitter dialog changes:
+
+1. **Control Type**: Dropdown, checkbox, text field, etc.
+2. **Placement**: Which group/section does it belong to?
+3. **Default Value**: What's the sensible default?
+4. **Validation**: What values are valid?
+5. **Dependencies**: Does it depend on other settings?
+6. **Take Interaction**: Does this setting vary per take?
+
+Example:
+```
+Group: Render Settings
+├── [Checkbox] Enable Feature X (default: unchecked)
+│   └── [Dropdown] Feature X Mode (visible when enabled)
+│       ├── Option A
+│       └── Option B
+└── [Text Field] Custom Path (optional)
+```
+
+## Step 5: Design Job Template Changes
+
+Define the job bundle modifications:
+
+```yaml
+parameterDefinitions:
+  - name: FeatureXEnabled
+    type: STRING
+    default: "false"
+    allowedValues: ["true", "false"]
+
+  - name: FeatureXMode
+    type: STRING
+    default: "option_a"
+    allowedValues: ["option_a", "option_b"]
+    userInterface:
+      control: DROPDOWN
+      label: "Feature X Mode"
+```
+
+Consider:
+- Parameter types and constraints
+- Conditional parameters
+- Asset references
+- How parameters map to adaptor init_data or run_data
+
+## Step 6: Design Adaptor and Client Changes
+
+Plan the runtime implementation using **concise inline snippets**:
+
+### Adaptor Changes (Cinema4DAdaptor)
+```python
+class Cinema4DAdaptor:
+    def on_run(self, run_data: dict) -> None:
+        ...existing logic...
+
+        # NEW: Send feature X action
+        if run_data.get("feature_x_enabled"):
+            self._client.enqueue_action("feature_x", {"mode": run_data["feature_x_mode"]})
+```
+
+### Client Changes (Cinema4DClient)
+```python
+class Cinema4DHandler:
+    def __init__(self):
+        ...existing init...
+
+        # NEW: Register feature X action
+        self.action_dict["feature_x"] = self.configure_feature_x
+
+    def configure_feature_x(self, data: dict) -> None:
+        """Configure Feature X before rendering."""
+        # See Appendix A.1 for full implementation
+        ...
+```
+
+Put full implementations in the **Appendix** section with review flags.
+
+## Step 7: Plan Testing
+
+### Unit Tests
+```python
+def test_feature_x_configuration(self):
+    """Test Feature X is correctly configured."""
+    handler = Cinema4DHandler()
+    handler.configure_feature_x({"enabled": True, "mode": "option_a"})
+    # Verify expected behavior
+```
+
+### Integration Tests (Windows Only)
+Consider adding a new test scene under `test/integ/test_scenes/` if the feature affects rendering output. Integration tests currently only run on Windows.
+
+## Step 8: Document Files to Modify
+
+Create a summary table:
+
+| File | Changes |
+|------|---------|
+| `src/deadline/cinema4d_submitter/data_classes.py` | Add data models |
+| `src/deadline/cinema4d_submitter/ui/...` | Add UI controls |
+| `src/deadline/cinema4d_submitter/adaptor_cinema4d_job_template.yaml` | Add parameters |
+| `src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py` | Add adaptor logic |
+| `src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py` | Add handler method |
+| `test/unit/.../test_handler.py` | Add unit tests |
+
+## Common Pitfalls
+
+1. **Forgetting multi-renderer support**: Always consider Redshift, Arnold, V-Ray, and Physical renderer
+2. **Missing platform handling**: Cinema 4D runs on Windows, macOS, and Linux
+3. **Take system interaction**: Features may need to work differently per take
+4. **Schema versioning**: Changes to `init_data.schema.json` or `run_data.schema.json` require updating `integration_data_interface_version`
+5. **Asset discovery**: New file references need to be included in asset discovery (`assets.py`)
+6. **Path mapping**: Cross-platform path handling for worker vs. workstation paths
+
+## Step 9: Create the Appendix
+
+Put all full code implementations in a clearly marked appendix at the end of the design document.
+
+### Appendix Format
+
+```markdown
+---
+
+## Appendix: Full Code Implementations
+
+<!-- REVIEW: Brief description of what's new -->
+
+### A.1 Cinema4DHandler.configure_feature (Full Implementation)
+
+**File:** `src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py`
+
+\`\`\`python
+def configure_feature(self, data: dict) -> None:
+    """
+    Full docstring here.
+    """
+    # Complete implementation
+    ...
+\`\`\`
+```
+
+### Guidelines
+
+1. **Flag sections for review** with `<!-- REVIEW: description -->` HTML comments
+2. **Include file paths** for each code block
+3. **Number appendix sections** (A.1, A.2, etc.) for easy reference
+4. **Don't include review tags** in final generated code — they're for design review only
+5. **Reference appendix from main sections** with "See Appendix A.X for full implementation"

--- a/skills/c4d-design/references/external-references.md
+++ b/skills/c4d-design/references/external-references.md
@@ -1,0 +1,51 @@
+# External References
+
+Use these links when designing features. Only fetch URLs when the keywords match your design topic.
+
+## GitHub Issues and Discussions
+
+| Keywords | Link | Description |
+|----------|------|-------------|
+| substance, materials, linux, crash, baking | [Issue #297](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/297) | Adobe Substance Materials crash on Amazon Linux 2023 at "Baking Substance Materials" step. Works on RHEL 9/10. |
+| redshift, freeze, linux, timeout, progress | [Issue #296](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/296) | Redshift sporadic freezing on Linux. Workaround: set timeouts via submitter. |
+| arnold, c4dtoa, linux, 2026, crash, gpu driver | [Issue #386](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/386) | C4DtoA crashes on Linux 2026. Requires c4dtoa 4.8.6.2+ with GPU driver 580.127+. |
+
+## Documentation
+
+| Keywords | Link | Description |
+|----------|------|-------------|
+| openjd, session, job template, step, task, environment, action | [OpenJD Sessions](https://github.com/OpenJobDescription/openjd-sessions-for-python) | OpenJD Sessions for Python — runtime library for executing Open Job Description jobs |
+| adaptor, runtime, lifecycle, daemon, run | [OpenJD Adaptor Runtime](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python) | OpenJD Adaptor Runtime — base framework for the cinema4d-openjd CLI |
+| conda, recipes, packaging, smf | [Deadline Cloud Samples](https://github.com/aws-deadline/deadline-cloud-samples) | Public conda recipes and samples for Cinema 4D, Arnold, V-Ray, INSYDIUM |
+| user guide, setup, submitter, installation | [User Guide](https://aws-deadline.github.io/deadline-cloud-for-cinema-4d) | Official Cinema 4D for Deadline Cloud user guide |
+| software architecture, adaptor, submitter, client | [Software Architecture](../../../docs/software_arch.md) | Architecture overview of submitter and adaptor components |
+
+## Plugin Documentation
+
+| Plugin | Keywords | Link | Description |
+|--------|----------|------|-------------|
+| Redshift | redshift, gpu, render, aov | [Redshift for C4D](https://help.maxon.net/r3d/cinema/en-us/) | Redshift render settings, AOVs, materials. Bundled with C4D 2024+. |
+| Arnold | arnold, c4dtoa, shader, aov | [Arnold for C4D](https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d) | Arnold render settings, shaders, installation |
+| V-Ray | vray, chaos, render elements | [V-Ray for C4D](https://docs.chaos.com/display/VC4D/) | V-Ray render settings, materials, render elements |
+| INSYDIUM | xparticles, insydium, particles | [INSYDIUM](https://insydium.ltd/help/) | X-Particles and INSYDIUM Fused documentation |
+| Cargo | cargo, kitbash, assets | [Cargo](https://kit-bash.myshopify.com/pages/cargo) | No special fleet config needed. Use File > Save Project with Assets. |
+
+## Conda Recipes (External)
+
+| Recipe | Link | Description |
+|--------|------|-------------|
+| Cinema 4D 2024 | [cinema4d-2024](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-2024) | Cinema 4D 2024 conda recipe |
+| Cinema 4D 2025 | [cinema4d-2025](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-2025) | Cinema 4D 2025 conda recipe |
+| Cinema 4D OpenJD | [cinema4d-openjd](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-openjd) | Adaptor conda recipe (Windows and Linux) |
+| Arnold (C4DtoA) | [cinema4d-c4dtoa-2025](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-c4dtoa-2025) | Arnold plugin conda recipe |
+| V-Ray | [cinema4d-vray-2025](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-vray-2025) | V-Ray plugin conda recipe |
+| INSYDIUM | [cinema4d-insydium-2025](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-insydium-2025) | X-Particles conda recipe |
+| Red Giant | [Host Config Script](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/host_configuration_scripts/cinema4d/cinema4d_redgiant) | Red Giant host configuration (not conda) |
+
+## Cinema 4D SDK
+
+| Keywords | Link | Description |
+|----------|------|-------------|
+| python, sdk, api, c4d module | [Python SDK](https://developers.maxon.net/docs/py/2026/) | Cinema 4D Python SDK documentation |
+| c++, sdk, plugin | [C++ SDK](https://developers.maxon.net/docs/cpp/2026/) | Cinema 4D C++ SDK documentation |
+| forum, developer, support | [Developer Forum](https://developers.maxon.net/forum/) | Maxon developer forum |

--- a/skills/c4d-design/references/research-guide.md
+++ b/skills/c4d-design/references/research-guide.md
@@ -1,0 +1,242 @@
+# Research Guide for Cinema 4D Designs
+
+This guide covers how to research and validate design decisions for Cinema 4D features.
+
+## Cinema 4D Documentation Sources
+
+### Official Maxon Documentation
+
+1. **Cinema 4D Python SDK**
+   - URL: https://developers.maxon.net/docs/py/2026/
+   - Covers: c4d module, scene objects, materials, rendering, takes
+
+2. **Cinema 4D C++ SDK**
+   - URL: https://developers.maxon.net/docs/cpp/2026/
+   - Covers: Lower-level APIs, plugin development
+
+3. **Maxon Developer Forum**
+   - URL: https://developers.maxon.net/forum/
+   - Covers: Community solutions, Maxon developer responses
+
+### Renderer Documentation
+
+1. **Redshift for Cinema 4D**
+   - URL: https://help.maxon.net/r3d/cinema/en-us/
+   - Covers: Redshift render settings, AOVs, materials
+   - Note: Redshift is bundled with Cinema 4D 2024+
+
+2. **Arnold for Cinema 4D (C4DtoA)**
+   - URL: https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d
+   - Covers: Arnold render settings, shaders, AOVs
+
+3. **V-Ray for Cinema 4D**
+   - URL: https://docs.chaos.com/display/VC4D/
+   - Covers: V-Ray render settings, materials, render elements
+
+## Key Cinema 4D Python API Patterns
+
+### Accessing the Active Document
+
+```python
+import c4d
+
+doc = c4d.documents.GetActiveDocument()
+```
+
+### Accessing Render Settings
+
+```python
+# Get active render data
+rd = doc.GetActiveRenderData()
+
+# Get renderer ID
+renderer_id = rd[c4d.RDATA_RENDERENGINE]
+
+# Common renderer IDs
+PHYSICAL_RENDERER = 1023342
+STANDARD_RENDERER = 0
+REDSHIFT_RENDERER = 1036219
+```
+
+### Accessing Takes
+
+```python
+take_data = doc.GetTakeData()
+main_take = take_data.GetMainTake()
+current_take = take_data.GetCurrentTake()
+
+# Iterate takes
+def iterate_takes(take):
+    while take:
+        print(take.GetName())
+        child = take.GetDown()
+        if child:
+            iterate_takes(child)
+        take = take.GetNext()
+
+iterate_takes(main_take.GetDown())
+```
+
+### Scene Object Access
+
+```python
+# Get first object
+obj = doc.GetFirstObject()
+
+# Iterate all objects
+def iterate_objects(obj):
+    while obj:
+        print(obj.GetName(), obj.GetType())
+        child = obj.GetDown()
+        if child:
+            iterate_objects(child)
+        obj = obj.GetNext()
+
+iterate_objects(obj)
+
+# Find object by name
+obj = doc.SearchObject("ObjectName")
+```
+
+### Renderer Detection Pattern
+
+The Cinema 4D adaptor detects renderers via the render engine ID in render settings:
+
+```python
+renderer_id = rd[c4d.RDATA_RENDERENGINE]
+
+if renderer_id == 1036219:  # Redshift
+    # Handle Redshift-specific settings
+    pass
+elif renderer_id == 1023342:  # Physical
+    # Handle Physical renderer settings
+    pass
+elif renderer_id == 0:  # Standard
+    # Handle Standard renderer settings
+    pass
+```
+
+### Output Settings
+
+```python
+# Output path
+rd[c4d.RDATA_PATH] = "/path/to/output/"
+
+# Output format
+rd[c4d.RDATA_FORMAT] = c4d.FILTER_PNG
+
+# Frame range
+rd[c4d.RDATA_FRAMEFROM] = c4d.BaseTime(0, doc.GetFps())
+rd[c4d.RDATA_FRAMETO] = c4d.BaseTime(100, doc.GetFps())
+
+# Resolution
+rd[c4d.RDATA_XRES] = 1920
+rd[c4d.RDATA_YRES] = 1080
+```
+
+## Adaptor Communication Model
+
+The Cinema 4D adaptor uses an action-based communication model:
+
+### Action Flow
+```
+Adaptor (cinema4d-openjd)
+    → enqueue_action(action_name, data)
+    → Cinema4DClient receives action via named pipe
+    → Cinema4DClient routes to handler method
+    → Handler executes c4d API calls
+    → Result sent back to adaptor
+```
+
+### Registering New Actions
+
+In `cinema4d_handler.py`:
+```python
+class Cinema4DHandler:
+    def __init__(self):
+        self.action_dict = {
+            "scene_file": self.set_scene_file,
+            "render": self.start_render,
+            # NEW: Add your action here
+            "my_action": self.handle_my_action,
+        }
+
+    def handle_my_action(self, data: dict) -> None:
+        """Handle my custom action."""
+        # Implementation using c4d module
+        pass
+```
+
+### Progress Reporting
+
+The adaptor uses stdout/stderr regex handlers to parse Cinema 4D output:
+
+```python
+# In adaptor.py - regex handlers for progress reporting
+self._stdout_handlers = [
+    RegexHandler(
+        regex=r"Rendering frame (\d+)/(\d+)",
+        callback=self._handle_progress,
+    ),
+]
+```
+
+## Submitter Data Flow
+
+```
+Cinema 4D Scene
+    → Submitter reads scene properties (scene.py, takes.py, assets.py)
+    → User configures settings in dialog (ui/)
+    → Settings stored in data classes (data_classes.py)
+    → Job template generated (adaptor_cinema4d_job_template.yaml)
+    → Job bundle created (template.yaml + parameter_values.yaml + assets)
+    → Submitted to Deadline Cloud
+```
+
+## Schema Files
+
+The adaptor uses JSON schemas to define the contract between submitter and adaptor:
+
+- `Cinema4DAdaptor/schemas/init_data.schema.json` — Initialization data (once per job)
+- `Cinema4DAdaptor/schemas/run_data.schema.json` — Per-task data (per frame/take)
+
+**Important:** When modifying schemas, update `integration_data_interface_version` in `adaptor.py`.
+
+## Knowledge Gap Protocol
+
+When you encounter a knowledge gap:
+
+1. **Document what you know**
+   - What API/feature is involved?
+   - What have you found so far?
+   - What specific information is missing?
+
+2. **Ask the user clearly**
+   > "I need clarification on [topic]. Specifically:
+   > - [Question 1]
+   > - [Question 2]
+   >
+   > Do you have documentation or code examples for this?"
+
+3. **Propose alternatives if possible**
+   > "I'm not certain about [X], but based on [Y], I believe we could:
+   > - Option A: [description]
+   > - Option B: [description]
+   >
+   > Which approach would you prefer, or do you have more information?"
+
+## Internet Research Guidelines
+
+### When to Search
+
+1. Documentation is unclear or incomplete
+2. Looking for version-specific behavior (C4D 2024 vs 2025 vs 2026)
+3. Finding community workarounds
+4. Verifying renderer-specific API behavior
+
+### Effective Search Queries
+
+- `"Cinema 4D" "Python" "[topic]" site:developers.maxon.net`
+- `"Redshift" "Cinema 4D" "[feature]" site:help.maxon.net`
+- `"c4d" "[module]" site:stackoverflow.com`
+- `"Cinema 4D" "[error message]"`

--- a/skills/c4d-dev-setup/SKILL.md
+++ b/skills/c4d-dev-setup/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: c4d-dev-setup
+description: Automated dev environment setup for deadline-cloud-for-cinema-4d. Use when onboarding, setting up the Cinema 4D integration repo, building the package, or installing the submitter. The agent automates all steps and only prompts when user input is required.
+tags: [skill, deadline-cloud, deadline-cloud-for-cinema-4d, deadline-cloud-for-c4d, dev-setup, onboarding, submitter-install]
+---
+
+# Cinema 4D Dev Setup
+
+## Overview
+
+AI-guided automated setup for the `deadline-cloud-for-cinema-4d` project. The agent executes all steps, validates results, and only prompts the user when manual intervention is truly required.
+
+## Usage
+
+Use this skill when:
+- Setting up a new dev environment for the Cinema 4D integration
+- Onboarding to the `deadline-cloud-for-cinema-4d` repo
+- Installing the submitter into Cinema 4D for the first time
+
+## Core Concepts
+
+**Platforms:**
+- Windows: full support (submitter + adaptor development, integration tests)
+- macOS: submitter development only
+- Linux: adaptor development only (no submitter UI)
+
+**Python:** Cinema 4D 2026 uses Python 3.11; Cinema 4D 2024–2025 uses Python 3.10.
+
+**Build system:** Hatch.
+
+## Agent Behavior
+
+You **MUST** automate all possible steps by running commands directly.
+You **MUST** only prompt the user when their input is required (Cinema 4D version, custom paths).
+You **MUST** validate each step's output before proceeding to the next.
+You **MUST** inform the user clearly when manual intervention is needed.
+You **SHOULD** report progress at each step.
+
+## Setup Workflow
+
+Follow the detailed step-by-step workflow in [references/setup-guide.md](references/setup-guide.md).
+
+Summary of steps:
+1. Detect OS and warn about platform limitations
+2. Prompt for Cinema 4D version (default: 2026)
+3. Verify Cinema 4D installation
+4. Verify Python 3.10+
+5. Read project documentation (`README.md`, `DEVELOPMENT.md`, `docs/software_arch.md`)
+6. Install Hatch
+7. Build the package (`hatch build`)
+8. Build the installer (optional, requires InstallBuilder)
+9. Install the submitter into Cinema 4D
+10. Set up integration test environment (Windows only)
+11. Display summary
+
+## Troubleshooting
+
+Refer to [references/troubleshooting.md](references/troubleshooting.md) for common issues and solutions.
+
+## Quick Reference
+
+| Resource | Location |
+|----------|----------|
+| Setup workflow | `references/setup-guide.md` |
+| Troubleshooting | `references/troubleshooting.md` |
+| Architecture context | `AGENTS.md` (repo root) |
+| Project docs | `README.md`, `DEVELOPMENT.md`, `docs/software_arch.md` |

--- a/skills/c4d-dev-setup/references/setup-guide.md
+++ b/skills/c4d-dev-setup/references/setup-guide.md
@@ -1,0 +1,191 @@
+# Cinema 4D Dev Setup — Agent Workflow
+
+Step-by-step workflow the agent follows to automate environment setup. Execute each step, validate, and only prompt the user when required.
+
+> **Source of truth:** The canonical setup instructions live in [DEVELOPMENT.md](../../../DEVELOPMENT.md) and [README.md](../../../README.md). This guide tells the agent *how to automate* those steps — refer to the source docs for full details.
+
+## Step 1: Detect Operating System
+
+Check the current OS and warn about platform limitations:
+- **Windows**: Full support (submitter + adaptor development)
+- **macOS**: Submitter development only
+- **Linux**: Adaptor development only (no submitter UI)
+
+If the OS doesn't support the user's intended workflow, inform them of limitations.
+
+## Step 2: Prompt for Cinema 4D Version
+
+Ask the user which version of Cinema 4D to set up for:
+- Default: 2026
+- Supported: 2024, 2025, 2026
+
+Example prompt:
+```
+Which version of Cinema 4D would you like to set up for? (default: 2026)
+```
+
+## Step 3: Verify Cinema 4D Installation
+
+**Windows:**
+```powershell
+Test-Path "C:\Program Files\Maxon Cinema 4D {VERSION}"
+Test-Path "C:\Program Files\Maxon Cinema 4D {VERSION}\Commandline.exe"
+Test-Path "C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\python.exe"
+```
+
+**macOS:**
+```bash
+test -d "/Applications/Maxon Cinema 4D {VERSION}"
+test -f "/Applications/Maxon Cinema 4D {VERSION}/Cinema 4D.app/Contents/MacOS/Cinema 4D"
+```
+
+**If Cinema 4D is NOT found:** Abort and instruct the user to install Cinema 4D from the [Maxon website](https://www.maxon.net/en/cinema-4d).
+
+**If Cinema 4D IS found:** Display confirmation and continue.
+
+## Step 4: Verify Python 3.10+
+
+```bash
+python3 --version
+```
+
+If not installed or version < 3.10, instruct user to install Python 3.10+.
+
+## Step 5: Read Project Documentation
+
+Read and summarize key information from:
+1. `README.md` — Project overview, compatibility, requirements
+2. `DEVELOPMENT.md` — Development workflow, build instructions
+3. `docs/software_arch.md` — Architecture overview
+
+## Step 6: Install Hatch
+
+```bash
+hatch --version
+```
+
+If not installed:
+```bash
+pip install hatch
+```
+
+## Step 7: Build the Package
+
+```bash
+hatch build
+```
+
+Expected output:
+- `dist/deadline_cloud_for_cinema_4d-{VERSION}-py3-none-any.whl`
+- `dist/deadline_cloud_for_cinema_4d-{VERSION}.tar.gz`
+
+Verify build artifacts exist.
+
+## Step 8: Build the Installer (Optional)
+
+If InstallBuilder is available:
+
+```bash
+hatch run installer:build-installer --local-dev --platform <windows|macos>
+```
+
+If InstallBuilder is not found, skip this step and note it in the summary.
+
+## Step 9: Install the Submitter
+
+### Using the Installer (if built in Step 8)
+Run the installer to set up Cinema 4D automatically.
+
+### Manual Installation (Windows)
+
+```cmd
+set SUBMITTER_LOCATION=%APPDATA%\DeadlineCloudSubmitter
+
+"C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\python.exe" -m ensurepip
+"C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\python.exe" -m pip install "deadline-cloud-for-cinema-4d[gui]" -t %SUBMITTER_LOCATION%
+
+md %SUBMITTER_LOCATION%\cinema_4d_plugins
+curl https://raw.githubusercontent.com/aws-deadline/deadline-cloud-for-cinema-4d/refs/heads/mainline/deadline_cloud_extension/DeadlineCloud.pyp -o %SUBMITTER_LOCATION%\cinema_4d_plugins\DeadlineCloud.pyp
+```
+
+Set environment variables:
+```cmd
+setx C4DPYTHONPATH311 %SUBMITTER_LOCATION%
+setx g_additionalModulePath %SUBMITTER_LOCATION%\cinema_4d_plugins
+```
+
+### Manual Installation (macOS)
+
+```bash
+export SUBMITTER_LOCATION="/Users/$USER/DeadlineCloudSubmitter"
+mkdir -p $SUBMITTER_LOCATION/cinema_4d_plugins
+
+python3 -m ensurepip
+python3 -m pip install "deadline-cloud-for-cinema-4d[gui]" -t $SUBMITTER_LOCATION
+
+curl https://raw.githubusercontent.com/aws-deadline/deadline-cloud-for-cinema-4d/refs/heads/mainline/deadline_cloud_extension/DeadlineCloud.pyp -o $SUBMITTER_LOCATION/cinema_4d_plugins/DeadlineCloud.pyp
+```
+
+Create a launch script on the desktop:
+```bash
+echo '#!/bin/zsh' > ~/Desktop/Cinema4D.command
+echo "export C4DPYTHONPATH311=$SUBMITTER_LOCATION" >> ~/Desktop/Cinema4D.command
+echo "export g_additionalModulePath=$SUBMITTER_LOCATION/cinema_4d_plugins" >> ~/Desktop/Cinema4D.command
+echo '"/Applications/Maxon Cinema 4D {VERSION}/Cinema 4D.app/Contents/MacOS/Cinema 4D"' >> ~/Desktop/Cinema4D.command
+chmod +x ~/Desktop/Cinema4D.command
+```
+
+## Step 10: Set Up Integration Test Environment (Windows Only)
+
+Integration tests are currently only supported on Windows.
+
+Install pywin32 to Cinema 4D's Python:
+```powershell
+pip install pywin32==308 -t "C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\lib\site-packages"
+```
+
+Copy PyWin32 DLLs:
+```powershell
+Copy-Item "C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\Lib\site-packages\pywin32_system32\pythoncom311.dll" "C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\dlls\"
+Copy-Item "C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\Lib\site-packages\pywin32_system32\pywintypes311.dll" "C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\dlls\"
+```
+
+Set environment variables:
+```powershell
+$env:C4D_LOCATION = "C:\Program Files\Maxon Cinema 4D {VERSION}\"
+$env:PYTHONIOENCODING = "utf-8"
+$env:g_licenseServerURL = "<your-license-server>:<port>"
+$env:redshift_LICENSE = "<port>@<your-license-server>"
+```
+
+## Step 11: Display Setup Summary
+
+```
+=== Cinema 4D {VERSION} Dev Setup Complete ===
+
+✅ Python verified
+✅ Hatch installed
+✅ Package built
+✅ Submitter installed to Cinema 4D
+✅ Environment variables set
+
+Quick Commands:
+- Build:          hatch build
+- Unit tests:     hatch run test
+- Lint:           hatch run lint
+- Format:         hatch run fmt
+- Integ tests:    hatch run integ:test (Windows only)
+
+Next Steps:
+1. Configure Cinema 4D licensing for your environment
+2. Launch Cinema 4D
+3. Verify submitter: Extensions > AWS Deadline Cloud Submitter
+4. Run unit tests: hatch run test
+```
+
+## Important Notes
+
+- Always verify Cinema 4D installation before proceeding
+- macOS requires launching Cinema 4D via the generated script (for env vars)
+- pywin32 is only needed on Windows for adaptor integration tests
+- InstallBuilder is optional — setup continues without it

--- a/skills/c4d-dev-setup/references/troubleshooting.md
+++ b/skills/c4d-dev-setup/references/troubleshooting.md
@@ -1,0 +1,161 @@
+# Troubleshooting Guide
+
+Common issues and solutions for Cinema 4D dev setup.
+
+## Cinema 4D Not Found
+
+**Problem:** Setup aborts with "Cinema 4D {VERSION} is not installed"
+
+**Solutions:**
+1. Verify Cinema 4D is installed at the standard location:
+   - Windows: `C:\Program Files\Maxon Cinema 4D {VERSION}`
+   - macOS: `/Applications/Maxon Cinema 4D {VERSION}`
+2. Install Cinema 4D from the [Maxon website](https://www.maxon.net/en/cinema-4d)
+3. Check if you have the correct version installed (2024, 2025, or 2026)
+
+## Hatch Installation Issues
+
+**Problem:** `hatch: command not found`
+
+**Solutions:**
+1. Verify hatch is installed:
+   ```bash
+   pip list | grep hatch
+   ```
+2. Restart terminal after installation
+3. Install explicitly:
+   ```bash
+   pip install hatch
+   ```
+
+## Build Failures
+
+**Problem:** `hatch build` fails
+
+**Solutions:**
+1. Ensure you're in the repository root directory
+2. Check if git is initialized (hatch-vcs requires git):
+   ```bash
+   git status
+   ```
+3. Verify Python version:
+   ```bash
+   python3 --version  # Should be 3.10+
+   ```
+4. Clean build artifacts and retry:
+   ```bash
+   rm -rf dist build *.egg-info
+   hatch build
+   ```
+5. Prune hatch environments:
+   ```bash
+   hatch env prune
+   ```
+
+## Submitter Installation Issues
+
+**Problem:** Submitter not visible in Cinema 4D
+
+**Solutions:**
+1. Verify environment variables are set:
+   - `C4DPYTHONPATH311` → Points to submitter installation
+   - `g_additionalModulePath` → Points to cinema_4d_plugins directory
+2. Restart Cinema 4D completely after setting env vars
+3. On macOS, launch Cinema 4D via the generated `Cinema4D.command` script
+4. Check Cinema 4D console (`Extensions > Console`) for import errors
+
+## PySide6 Import Errors
+
+**Problem:** `PySide6/__init__.py: Unable to import Shiboken from ...`
+
+**Solutions:**
+1. Update to Cinema 4D 2024.4.0+ (resolves missing libraries)
+2. Manually install missing module:
+   ```
+   # Windows
+   "C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\python.exe" -m pip install MISSING_MODULE
+   ```
+
+## Licensing Issues
+
+### Cinema 4D License Not Found
+
+**Problem:** Cinema 4D shows license error on startup
+
+**Solutions:**
+1. Verify your license server is accessible
+2. Configure Cinema 4D license settings appropriately for your environment
+3. Check that the license server environment variable is set:
+   ```powershell
+   $env:g_licenseServerURL = "<your-license-server>:<port>"
+   ```
+
+### Redshift License Not Found
+
+**Problem:** Redshift renders fail with license error
+
+**Solutions:**
+1. Set the Redshift license environment variable:
+   ```bash
+   # Windows PowerShell
+   $env:redshift_LICENSE = "<port>@<your-license-server>"
+
+   # macOS/Linux
+   export redshift_LICENSE="<port>@<your-license-server>"
+   ```
+2. Verify your license server is accessible
+
+## Integration Test Issues
+
+### pywin32 Errors (Windows)
+
+**Problem:** Integration tests fail with pywin32 DLL errors
+
+**Solutions:**
+1. Install pywin32 version 308:
+   ```powershell
+   pip install pywin32==308 -t "C:\Program Files\Maxon Cinema 4D {VERSION}\resource\modules\python\libs\win64\lib\site-packages"
+   ```
+2. Copy DLLs manually:
+   - Copy `pythoncom311.dll` and `pywintypes311.dll`
+   - From: `...\pywin32_system32\`
+   - To: `...\dlls\`
+
+### Tests Hang
+
+**Problem:** Integration tests hang indefinitely
+
+**Solutions:**
+1. Cinema 4D may be waiting for license input. Kill stuck processes:
+   ```powershell
+   Get-Process *Cinema* | Stop-Process -Force
+   Get-Process *Commandline* | Stop-Process -Force
+   ```
+2. Verify licensing is configured correctly
+
+### Non-ASCII Path Errors
+
+**Problem:** Tests with non-ASCII characters fail
+
+**Solutions:**
+1. Set encoding:
+   ```powershell
+   $env:PYTHONIOENCODING = "utf-8"
+   ```
+
+## Python Version Mismatch
+
+**Problem:** Wrong Python version being used
+
+**Solutions:**
+1. Cinema 4D 2026 uses Python 3.11, Cinema 4D 2024-2025 uses Python 3.10
+2. For unit tests, your system Python 3.10+ is fine
+3. For integration tests, Cinema 4D's bundled Python is used automatically
+
+## Getting Help
+
+If issues persist:
+1. Check project documentation: `README.md`, `DEVELOPMENT.md`, `docs/software_arch.md`
+2. Check Cinema 4D console: `Extensions > Console`
+3. Review Cinema 4D logs for detailed error messages
+4. Try a clean setup: `hatch env prune`, rebuild, reinstall

--- a/skills/c4d-dev/SKILL.md
+++ b/skills/c4d-dev/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: c4d-dev
+description: Day-to-day development for deadline-cloud-for-cinema-4d. Use when building, testing, linting, debugging, or running integration tests with Cinema 4D, Redshift, Arnold, or V-Ray. Covers submitter iteration, adaptor debugging, and project structure.
+tags: [skill, deadline-cloud, deadline-cloud-for-cinema-4d, deadline-cloud-for-c4d, build, test, lint, integration, redshift, arnold, vray, adaptor, submitter]
+---
+
+# Cinema 4D Dev
+
+## Overview
+
+Development companion for building, testing, and debugging the `deadline-cloud-for-cinema-4d` project.
+
+This project provides:
+- **Cinema 4D Adaptor**: Runs Cinema 4D renders on Deadline Cloud workers (`cinema4d-openjd` CLI)
+- **Cinema 4D Submitter**: Extension for submitting jobs from Cinema 4D to Deadline Cloud
+- **Cinema4DClient**: Runs inside Cinema 4D, facilitating communication between the adaptor and Cinema 4D process
+
+For project structure and component details, see:
+- [`AGENTS.md`](../../AGENTS.md) — High-level architecture and build commands
+- [`src/deadline/cinema4d_submitter/AGENTS.md`](../../src/deadline/cinema4d_submitter/AGENTS.md) — Submitter internals
+- [`src/deadline/cinema4d_adaptor/AGENTS.md`](../../src/deadline/cinema4d_adaptor/AGENTS.md) — Adaptor and client internals
+- [`test/AGENTS.md`](../../test/AGENTS.md) — Test structure and scenes
+
+## Usage
+
+Use this skill when:
+- Building, testing, or linting the project
+- Iterating on submitter or adaptor code
+- Running integration tests
+- Debugging renderer-specific issues (Redshift, Arnold, V-Ray)
+
+## Prerequisites
+
+- Python 3.10+ (Cinema 4D 2026 uses Python 3.11; 2024–2025 uses Python 3.10)
+- Cinema 4D 2024, 2025, or 2026 installed
+- Hatch: `pip install hatch`
+- Windows or macOS for submitter development
+- Windows or Linux for adaptor development
+- Windows for integration tests
+
+## Quick Commands
+
+### Build
+```bash
+hatch build
+```
+
+### Lint & Format
+```bash
+hatch run fmt    # Format code (black + ruff)
+hatch run lint   # Run linter + type checker
+hatch run typing # Type checking only (mypy)
+```
+
+### Unit Tests
+```bash
+hatch run test                                    # All unit tests
+hatch run test test/unit/path/to/test.py          # Specific file
+hatch run test -k "test_redshift"                 # Pattern match
+hatch run all:test                                # All supported Python versions
+```
+
+### Integration Tests (Windows Only)
+
+Integration tests require Cinema 4D installed with licensing configured.
+
+```powershell
+$env:C4D_LOCATION = "C:\Program Files\Maxon Cinema 4D 2026\"
+hatch run integ:test
+```
+
+See [references/integration-testing.md](references/integration-testing.md) for setup details and [`test/AGENTS.md`](../../test/AGENTS.md) for test structure.
+
+### Build Installer
+```bash
+hatch run installer:build-installer --local-dev --platform <windows|macos>
+```
+
+## Detailed Guides
+
+- [references/build-and-test.md](references/build-and-test.md) — Complete build and test workflow
+- [references/dev-guide.md](references/dev-guide.md) — Development conventions and workflows
+- [references/integration-testing.md](references/integration-testing.md) — Running integration tests (Windows only)
+- [references/troubleshooting.md](references/troubleshooting.md) — Common issues and solutions
+
+## Supported Renderers
+
+| Renderer | OS Support | Notes |
+|----------|-----------|-------|
+| Redshift | Windows, Linux | Bundled with Cinema 4D 2024+, default renderer |
+| Arnold (C4DtoA) | Windows, Linux | Requires separate plugin install |
+| V-Ray | Windows, macOS | Requires separate plugin install |
+| Physical/Standard | Windows, Linux, macOS | Built-in Cinema 4D renderer |
+| Cargo | Windows, macOS | No special fleet config needed |
+| X-Particles (INSYDIUM) | Windows, macOS | Requires queue environment |
+| Red Giant | Windows | Requires host config scripts |
+
+## Known Issues
+
+- **Linux Adobe Substance Materials**: Crash at "Baking Substance Materials" step on Amazon Linux 2023. Works on RHEL 9/10.
+- **Linux Redshift Freezing**: Sporadic freezes during rendering. Workaround: set timeouts via submitter.
+- **C4DtoA Linux 2026**: Crashes due to GPU driver version mismatch. Requires c4dtoa 4.8.6.2+ with driver 580.127+.

--- a/skills/c4d-dev/references/build-and-test.md
+++ b/skills/c4d-dev/references/build-and-test.md
@@ -1,0 +1,130 @@
+# Build and Test Workflow
+
+Complete build and test workflow for deadline-cloud-for-cinema-4d.
+
+## Step 1: Apply Code Changes
+
+### Quick iteration (Recommended for submitter changes)
+
+For fast iteration on submitter code, copy the source files directly from the repo into your Cinema 4D submitter installation. This avoids rebuilding wheels each time.
+
+**Windows (PowerShell):**
+```powershell
+Copy-Item -Path "src\deadline\cinema4d_submitter\*" -Destination "$env:APPDATA\DeadlineCloudSubmitter\deadline\cinema4d_submitter\" -Recurse -Force
+```
+
+**macOS:**
+```bash
+cp -R src/deadline/cinema4d_submitter/* ~/DeadlineCloudSubmitter/deadline/cinema4d_submitter/
+```
+
+Restart Cinema 4D after copying to pick up the changes.
+
+For adaptor changes, you'll need to build a new conda package and deploy it to your workers. Follow the public [cinema4d-openjd conda recipe](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-openjd) to create a patched package with your changes.
+
+### Full build (for releases, installers, or farm testing)
+
+```bash
+hatch build
+```
+
+## Step 2: Run Linting and Formatting
+
+Before committing, ensure code passes all checks:
+
+```bash
+# Format code (black + ruff)
+hatch run fmt
+
+# Run linter (ruff check + black check + mypy)
+hatch run lint
+
+# Type checking only
+hatch run typing
+```
+
+## Step 3: Run Unit Tests
+
+Run the full unit test suite:
+
+```bash
+hatch run test
+```
+
+For faster iteration, run specific tests:
+
+```bash
+# Run tests for a specific module
+hatch run test test/unit/deadline_adaptor_for_cinema4d/
+
+# Run a single test file
+hatch run test test/unit/deadline_submitter_for_cinema4d/test_scene.py
+
+# Run tests matching a pattern
+hatch run test -k "test_redshift"
+```
+
+Run against all supported Python versions:
+
+```bash
+hatch run all:test
+```
+
+## Step 4: Run Integration Tests (Windows Only)
+
+Integration tests are currently only supported on Windows. They require Cinema 4D installed with proper licensing. See `integration-testing.md` for full setup.
+
+### Set Cinema 4D location
+
+```powershell
+$env:C4D_LOCATION = "C:\Program Files\Maxon Cinema 4D 2026\"
+```
+
+If `C4D_LOCATION` is not set, the default Windows path `C:\Program Files\Maxon Cinema 4D 2026\` is used automatically.
+
+### Run all integration tests
+
+```bash
+hatch run integ:test
+```
+
+## Step 5: Build the Installer
+
+Build a local submitter installer (requires InstallBuilder):
+
+```bash
+# Windows
+hatch run installer:build-installer --local-dev --platform windows
+
+# macOS
+hatch run installer:build-installer --local-dev --platform macos
+```
+
+### Test the installer
+
+```bash
+hatch run test-installer
+```
+
+## Common Issues
+
+### Wrong Python Version
+Cinema 4D 2026 uses Python 3.11, Cinema 4D 2024-2025 uses Python 3.10. Ensure your hatch environment matches.
+
+### Wheel Not Found
+Only needed for full builds. Run `hatch build` if you need wheel packages for installers or farm testing.
+
+### Hatch Environment Issues
+If builds or tests behave unexpectedly, prune all environments:
+```bash
+hatch env prune
+```
+
+### Coverage Threshold
+The project requires minimum 23% code coverage. If tests fail on coverage, check `pyproject.toml` `[tool.coverage.report]` settings.
+
+### Import Errors in Tests
+Install test dependencies:
+```bash
+pip install -r requirements-testing.txt
+```

--- a/skills/c4d-dev/references/dev-guide.md
+++ b/skills/c4d-dev/references/dev-guide.md
@@ -1,0 +1,163 @@
+# Dev Guide
+
+Day-to-day development workflows. For architecture details, see the relevant AGENTS.md:
+- [`AGENTS.md`](../../../AGENTS.md) — Repo overview
+- [`src/deadline/cinema4d_submitter/AGENTS.md`](../../../src/deadline/cinema4d_submitter/AGENTS.md) — Submitter
+- [`src/deadline/cinema4d_adaptor/AGENTS.md`](../../../src/deadline/cinema4d_adaptor/AGENTS.md) — Adaptor and client
+
+## Python Environment
+
+**IMPORTANT**: Use the correct Python version for your Cinema 4D version:
+- Cinema 4D 2026: Python 3.11
+- Cinema 4D 2024-2025: Python 3.10
+
+For development, Python 3.10+ on your system is sufficient for unit tests. Integration tests require Windows and Cinema 4D's bundled Python.
+
+## Build & Install Workflow
+
+### Build
+
+```bash
+hatch build
+```
+
+### Code Quality
+
+```bash
+hatch run fmt      # Format code (black + ruff)
+hatch run lint     # Lint + type check
+hatch run typing   # Type checking only (mypy)
+```
+
+### Unit Tests
+
+```bash
+hatch run test                                    # All tests
+hatch run test test/unit/path/to/test.py          # Specific file
+hatch run test -k "test_redshift"                 # Pattern match
+hatch run all:test                                # All Python versions
+```
+
+## Submitter Development Workflow
+
+### Quick iteration (Recommended)
+
+Copy source files directly over the installed submitter:
+
+**Windows (PowerShell):**
+```powershell
+Copy-Item -Path "src\deadline\cinema4d_submitter\*" -Destination "$env:APPDATA\DeadlineCloudSubmitter\deadline\cinema4d_submitter\" -Recurse -Force
+```
+
+**macOS:**
+```bash
+cp -R src/deadline/cinema4d_submitter/* ~/DeadlineCloudSubmitter/deadline/cinema4d_submitter/
+```
+
+Restart Cinema 4D to pick up the changes.
+
+### Using the Installer
+
+1. Build the package: `hatch build`
+2. Build the installer: `hatch run installer:build-installer --local-dev --platform <windows|macos>`
+3. Run the installer to set up Cinema 4D
+4. Restart Cinema 4D after installation
+
+### Manual Installation (Windows)
+
+```cmd
+set SUBMITTER_LOCATION=%APPDATA%\DeadlineCloudSubmitter
+"C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\python.exe" -m ensurepip
+"C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\python.exe" -m pip install "deadline-cloud-for-cinema-4d[gui]" -t %SUBMITTER_LOCATION%
+md %SUBMITTER_LOCATION%\cinema_4d_plugins
+curl https://raw.githubusercontent.com/aws-deadline/deadline-cloud-for-cinema-4d/refs/heads/mainline/deadline_cloud_extension/DeadlineCloud.pyp -o %SUBMITTER_LOCATION%\cinema_4d_plugins\DeadlineCloud.pyp
+```
+
+Set environment variables:
+- `C4DPYTHONPATH311` → `%SUBMITTER_LOCATION%`
+- `g_additionalModulePath` → `%SUBMITTER_LOCATION%\cinema_4d_plugins`
+
+### Manual Installation (macOS)
+
+```bash
+export SUBMITTER_LOCATION="/Users/$USER/DeadlineCloudSubmitter"
+mkdir -p $SUBMITTER_LOCATION/cinema_4d_plugins
+python3 -m pip install "deadline-cloud-for-cinema-4d[gui]" -t $SUBMITTER_LOCATION
+curl https://raw.githubusercontent.com/aws-deadline/deadline-cloud-for-cinema-4d/refs/heads/mainline/deadline_cloud_extension/DeadlineCloud.pyp -o $SUBMITTER_LOCATION/cinema_4d_plugins/DeadlineCloud.pyp
+```
+
+On macOS, launch Cinema 4D via a script that sets `C4DPYTHONPATH311` and `g_additionalModulePath`.
+
+## Adaptor Development Workflow
+
+For adaptor architecture, action model, and schema versioning, see [`src/deadline/cinema4d_adaptor/AGENTS.md`](../../../src/deadline/cinema4d_adaptor/AGENTS.md).
+
+### Running the Adaptor Locally
+
+Create two files:
+1. `init-data.yaml` — Schema at `src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/init_data.schema.json`
+2. `run-data.yaml` — Schema at `src/deadline/cinema4d_adaptor/Cinema4DAdaptor/schemas/run_data.schema.json`
+
+Ensure Cinema 4D's command-line executable is on your PATH.
+
+**Direct run mode** (simpler, for rapid iteration):
+```bash
+cinema4d-openjd run \
+  --init-data file://<path-to-init-data.yaml> \
+  --run-data file://<path-to-run-data.yaml>
+```
+
+**Daemon mode** (for testing sticky rendering):
+```bash
+cinema4d-openjd daemon start \
+  --init-data file://<path-to-init-data.yaml> \
+  --connection-file file://connection-info.json
+
+cinema4d-openjd daemon run \
+  --run-data file://<path-to-run-data.yaml> \
+  --connection-file file://connection-info.json
+
+cinema4d-openjd daemon stop \
+  --connection-file file://connection-info.json
+```
+
+When testing daemon mode, do multiple `daemon run` commands with different inputs before `daemon stop` to catch data carryover issues.
+
+### Running the Adaptor on a Farm
+
+For testing on a live Deadline Cloud farm with Service Managed Fleets:
+
+1. Create a patch for the `cinema4d-openjd` conda recipe following [these instructions](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes#create-a-patch-for-a-recipe)
+2. Build a new conda package using the patch
+3. Submit jobs and verify renders
+
+## Job Template Files
+
+Two job template variants:
+- `adaptor_cinema4d_job_template.yaml` — Used when submitting with the adaptor (default)
+- `default_cinema4d_job_template.yaml` — Used for direct Cinema 4D command-line rendering
+
+## Key Data Flow
+
+```
+User fills submitter dialog
+    → Submitter creates job bundle (template.yaml + parameter_values.yaml + assets)
+    → Submit to Deadline Cloud
+    → Worker receives task
+    → Adaptor starts Cinema 4D with Cinema4DClient
+    → Adaptor sends actions to Cinema4DClient via named pipes
+    → Cinema4DClient executes actions (load scene, set frame, render)
+    → Results reported back to Deadline Cloud
+```
+
+## Troubleshooting Quick Reference
+
+| Issue | Fix |
+|-------|-----|
+| No wheel found | `hatch build` |
+| Hatch not found | `pip install hatch` |
+| Import errors | `pip install -r requirements-testing.txt` |
+| Hatch env issues | `hatch env prune` |
+| Submitter not visible | Check `C4DPYTHONPATH311` and `g_additionalModulePath` env vars |
+| Adaptor not found | Ensure `cinema4d-openjd` is on PATH |
+| License issues | Verify Cinema 4D and renderer licensing is configured |

--- a/skills/c4d-dev/references/integration-testing.md
+++ b/skills/c4d-dev/references/integration-testing.md
@@ -1,0 +1,120 @@
+# Integration Testing Guide
+
+How to set up and run integration tests for the Cinema 4D adaptor and submitter. **Integration tests are currently only supported on Windows.**
+
+> For test structure, test scenes, and adding new tests, see [`test/AGENTS.md`](../../../test/AGENTS.md).
+
+## Prerequisites
+
+1. **Windows operating system** (integration tests are not yet supported on macOS or Linux)
+2. Cinema 4D 2024, 2025, or 2026 installed
+3. Redshift licensing configured (for Redshift tests)
+4. Cinema 4D licensing configured
+5. Python 3.10+ on system
+6. Hatch installed: `pip install hatch`
+
+## Licensing Setup
+
+### Cinema 4D License
+Set the license server environment variable:
+
+**Windows (PowerShell):**
+```powershell
+$env:g_licenseServerURL = "<your-license-server-host>:<port>"
+```
+
+### Redshift License
+**Windows (PowerShell):**
+```powershell
+$env:redshift_LICENSE = "<port>@<your-license-server-host>"
+```
+
+### Alternative: Manual License Configuration
+Run `c4dpy` and `Commandline.exe` separately and set the license information through the Cinema 4D UI.
+
+## Environment Setup
+
+### Set Cinema 4D Location
+
+**Windows (PowerShell):**
+```powershell
+$env:C4D_LOCATION = "C:\Program Files\Maxon Cinema 4D 2026\"
+```
+
+If not set, the default Windows path `C:\Program Files\Maxon Cinema 4D 2026\` is used automatically.
+
+### Set Python Encoding
+Required for non-ASCII character tests:
+```powershell
+$env:PYTHONIOENCODING = "utf-8"
+```
+
+### Install pywin32 (for adaptor tests)
+
+pywin32 is required for adaptor tests on Windows:
+
+```powershell
+pip install pywin32==308 -t "C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\lib\site-packages"
+```
+
+Copy PyWin32 DLLs (post-install requirement):
+```powershell
+# Copy pythoncom311.dll and pywintypes311.dll
+# From: C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\Lib\site-packages\pywin32_system32
+# To:   C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\dlls
+```
+
+## Running Tests
+
+### Run all integration tests (recommended)
+
+```bash
+hatch run integ:test
+```
+
+This uses Cinema 4D's `c4dpy` for submitter tests and `Commandline.exe` for adaptor tests.
+
+### Run with verbose output
+
+```bash
+hatch run integ:test -vvv
+```
+
+### Run a specific test scene
+
+```bash
+hatch run integ:test -k "physical"
+hatch run integ:test -k "redshift"
+hatch run integ:test -k "redshift_tiles"
+```
+
+For the full list of test scenes and how to add new ones, see [`test/AGENTS.md`](../../../test/AGENTS.md).
+
+## Common Issues
+
+### License Not Found
+Verify environment variables are set for Cinema 4D and Redshift licensing.
+
+### pywin32 Issues
+On Windows, pywin32 version 308 is required. Register DLLs if needed:
+```powershell
+python -m pywin32_postinstall -install
+```
+
+### Scene Generation Fails
+- Verify Cinema 4D is properly installed and licensed
+- Check that `c4dpy` is accessible from the Cinema 4D installation
+- Ensure `PYTHONIOENCODING=utf-8` is set for non-ASCII tests
+
+### Render Output Mismatch
+- Small pixel differences may occur across GPU types
+- Check that the correct renderer and version are installed
+- Verify licensing is active for the renderer being tested
+
+### Tests Hang
+Cinema 4D may be waiting for license input or a dialog. Kill stuck processes:
+
+```powershell
+Get-Process *Cinema* | Stop-Process -Force
+Get-Process *Commandline* | Stop-Process -Force
+```

--- a/skills/c4d-dev/references/troubleshooting.md
+++ b/skills/c4d-dev/references/troubleshooting.md
@@ -1,0 +1,166 @@
+# Troubleshooting Guide
+
+Common issues and solutions when developing deadline-cloud-for-cinema-4d.
+
+## Build Issues
+
+### "No wheel files found in dist directory"
+```bash
+hatch build
+```
+
+### Hatch not found
+```bash
+pip install hatch
+```
+
+### Build fails with version error
+Hatch-vcs requires a git repository. Ensure you cloned the repo (not downloaded a zip):
+```bash
+git status
+```
+
+If the `.git` folder is missing, re-clone:
+```bash
+git clone https://github.com/aws-deadline/deadline-cloud-for-cinema-4d.git
+```
+
+### Hatch environment issues
+If builds or tests behave unexpectedly, prune all environments:
+```bash
+hatch env prune
+```
+
+## Test Issues
+
+### Unit tests fail with import errors
+```bash
+pip install -r requirements-testing.txt
+# Or use hatch environment (handles deps automatically)
+hatch run test
+```
+
+### Coverage below threshold
+The project requires minimum 23% coverage. If adding new code without tests, the coverage check may fail. Add unit tests or adjust the threshold in `pyproject.toml` under `[tool.coverage.report]`.
+
+### Integration tests hang
+Cinema 4D may be waiting for license input or a dialog. Kill stuck processes:
+
+```powershell
+Get-Process *Cinema* | Stop-Process -Force
+Get-Process *Commandline* | Stop-Process -Force
+```
+
+### Integration tests fail with license errors
+Verify licensing environment variables are set:
+```powershell
+# Cinema 4D
+$env:g_licenseServerURL = "<your-license-server>:<port>"
+
+# Redshift
+$env:redshift_LICENSE = "<port>@<your-license-server>"
+```
+
+## Submitter Issues
+
+### Submitter not visible in Cinema 4D
+Check that environment variables are set:
+- `C4DPYTHONPATH311` — Points to the submitter installation location
+- `g_additionalModulePath` — Points to the cinema_4d_plugins directory containing `DeadlineCloud.pyp`
+
+Restart Cinema 4D after setting environment variables.
+
+### PySide6 import errors
+Some Cinema 4D versions (e.g., 2024.1.0) are missing libraries. Errors look like:
+```
+PySide6/__init__.py: Unable to import Shiboken from ...
+```
+
+**Solutions:**
+1. Update to a later Cinema 4D version (e.g., 2024.4.0+)
+2. Manually install the missing module:
+   ```
+   "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe" -m ensurepip
+   "C:\Program Files\Maxon Cinema 4D 2024\resource\modules\python\libs\win64\python.exe" -m pip install MISSING_MODULE
+   ```
+
+### Submitter changes not taking effect
+After modifying submitter code:
+1. Copy the updated source over the installed submitter (quick iteration)
+2. Or reinstall the package (rebuild wheel and reinstall)
+3. Restart Cinema 4D completely
+
+## Adaptor Issues
+
+### cinema4d-openjd command not found
+Ensure the adaptor is installed and on PATH:
+```bash
+pip install deadline-cloud-for-cinema-4d
+cinema4d-openjd --help
+```
+
+### Cinema 4D executable not found
+Set the `C4D_COMMANDLINE_EXECUTABLE` environment variable:
+```powershell
+$env:C4D_COMMANDLINE_EXECUTABLE = "C:\Program Files\Maxon Cinema 4D 2026\Commandline.exe"
+```
+
+Or add Cinema 4D to PATH.
+
+### Adaptor schema changes
+When modifying `init_data.schema.json` or `run_data.schema.json`, you **must** also update the `integration_data_interface_version` in `adaptor.py` following semantic versioning.
+
+## Renderer Issues
+
+### Redshift render produces black image
+- Verify Redshift licensing is active
+- Check GPU drivers: NVIDIA GRID driver 551.78+ required
+- Ensure sufficient RAM (at least 2x VRAM)
+
+### Redshift freezing on Linux
+Known sporadic issue. Workaround: set timeouts via the submitter's job-specific settings.
+
+### Arnold (C4DtoA) crashes on Linux 2026
+Known issue. Requires c4dtoa 4.8.6.2+ with GPU driver 580.127+. See [GitHub issue #386](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/386).
+
+### Adobe Substance Materials crash on Linux
+Known issue on Amazon Linux 2023. Scenes crash at "Baking Substance Materials" step. Works on RHEL 9/10. See [GitHub issue #297](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/297).
+
+### V-Ray render issues
+- V-Ray is supported on Windows and macOS only
+- Ensure V-Ray is installed and licensed
+
+## Path and Encoding Issues
+
+### Non-ASCII characters in paths
+Set the encoding environment variable:
+```powershell
+$env:PYTHONIOENCODING = "utf-8"
+```
+
+### Scene file not found
+- Verify the file exists at the specified path
+- Use forward slashes in YAML/JSON configuration
+- Check `parameter_values.yaml` paths match actual file locations
+
+## pywin32 Issues (Windows)
+
+### pywin32 DLL errors during integration tests
+Install pywin32 version 308 to Cinema 4D's Python:
+```powershell
+pip install pywin32==308 -t "C:\Program Files\Maxon Cinema 4D 2026\resource\modules\python\libs\win64\lib\site-packages"
+```
+
+Copy DLLs manually:
+- Copy `pythoncom311.dll` and `pywintypes311.dll`
+- From: `...\pywin32_system32\`
+- To: `...\dlls\`
+
+## Getting Help
+
+If issues persist:
+1. Check project documentation: `README.md`, `DEVELOPMENT.md`, `docs/software_arch.md`
+2. Check Cinema 4D console: `Extensions > Console` in Cinema 4D
+3. Review Cinema 4D logs for detailed error messages
+4. Verify all prerequisites: Python 3.10+, Cinema 4D 2024-2026, proper licensing
+5. Try a clean setup: `hatch env prune`, rebuild, reinstall

--- a/src/deadline/cinema4d_adaptor/AGENTS.md
+++ b/src/deadline/cinema4d_adaptor/AGENTS.md
@@ -1,0 +1,111 @@
+# AGENTS.md — cinema4d_adaptor
+
+Worker-side component that runs Cinema 4D renders on Deadline Cloud. Exposed as the `cinema4d-openjd` CLI.
+
+## Two-Part Architecture
+
+### Cinema4DAdaptor (`Cinema4DAdaptor/`)
+
+The adaptor server — a command-line app that manages the Cinema 4D process lifecycle on workers. Built on the [OpenJD Adaptor Runtime](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python).
+
+**Key files:**
+- `adaptor.py` — Main adaptor class, lifecycle management (`on_start`, `on_run`, `on_end`)
+- `schemas/init_data.schema.json` — Schema for initialization data (once per job)
+- `schemas/run_data.schema.json` — Schema for per-task data (per frame/take)
+
+**Responsibilities:**
+- Start/stop Cinema 4D process with Cinema4DClient
+- Send initialization actions (scene file, renderer settings)
+- Send per-task actions (frame number, output path, take)
+- Parse stdout/stderr for progress reporting via regex handlers
+- Handle errors and logging
+
+### Cinema4DClient (`Cinema4DClient/`)
+
+Runs inside the Cinema 4D process. Acts as a secure web server over named pipes, receiving commands from the adaptor to control Cinema 4D.
+
+**Key files:**
+- `cinema4d_client.py` — Main client class, action routing, named pipe server
+- `cinema4d_handler.py` — Action handlers for scene loading, rendering, etc.
+- `tile_rendering.py` — Tile rendering support
+- `plugin/` — Cinema 4D plugin files for client integration
+
+**Responsibilities:**
+- Receive actions from adaptor via named pipes
+- Route actions to appropriate handler methods in `cinema4d_handler.py`
+- Execute `c4d` module commands to control Cinema 4D
+- Report progress and errors back to adaptor
+
+## Action-Based Communication Model
+
+```
+Adaptor (cinema4d-openjd)
+    → enqueue_action(action_name, data)
+    → Cinema4DClient receives action via named pipe
+    → Cinema4DClient routes to handler method in cinema4d_handler.py
+    → Handler executes c4d API calls
+    → Result sent back to adaptor
+```
+
+### Registering a new action
+
+In `Cinema4DClient/cinema4d_handler.py`:
+
+```python
+class Cinema4DHandler:
+    def __init__(self):
+        self.action_dict = {
+            "scene_file": self.set_scene_file,
+            "render": self.start_render,
+            # NEW: Add your action here
+            "my_action": self.handle_my_action,
+        }
+
+    def handle_my_action(self, data: dict) -> None:
+        """Handle my custom action."""
+        # Implementation using c4d module
+        pass
+```
+
+### Progress reporting
+
+The adaptor parses Cinema 4D stdout/stderr via regex handlers registered in `adaptor.py`:
+
+```python
+self._stdout_handlers = [
+    RegexHandler(
+        regex=r"Rendering frame (\d+)/(\d+)",
+        callback=self._handle_progress,
+    ),
+]
+```
+
+## Schema Versioning — IMPORTANT
+
+When modifying `Cinema4DAdaptor/schemas/init_data.schema.json` or `run_data.schema.json`, you **must** also update `integration_data_interface_version` in `adaptor.py` following semantic versioning. The submitter checks this version to ensure compatibility.
+
+## Path Mapping
+
+Assets may be at different paths on worker vs. artist workstation. The OpenJD adaptor runtime provides path mapping support that translates paths between platforms. Use the runtime's path mapping utilities rather than hardcoding paths.
+
+## Adaptor Modes
+
+Two modes of operation:
+
+**Direct run** — simpler, for rapid iteration:
+```bash
+cinema4d-openjd run --init-data file://<init.yaml> --run-data file://<run.yaml>
+```
+
+**Daemon mode** — for testing sticky rendering across multiple runs:
+```bash
+cinema4d-openjd daemon start --init-data file://<init.yaml> --connection-file file://connection-info.json
+cinema4d-openjd daemon run --run-data file://<run.yaml> --connection-file file://connection-info.json
+cinema4d-openjd daemon stop --connection-file file://connection-info.json
+```
+
+When testing daemon mode, run multiple `daemon run` commands with different inputs before `daemon stop` to catch data carryover issues.
+
+## Testing the Adaptor
+
+For testing adaptor changes on a live Deadline Cloud farm, build a patched conda package from the public [cinema4d-openjd conda recipe](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/cinema4d-openjd).

--- a/src/deadline/cinema4d_submitter/AGENTS.md
+++ b/src/deadline/cinema4d_submitter/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md — cinema4d_submitter
+
+The Cinema 4D submitter extension. Runs inside Cinema 4D on the artist's workstation, creates job bundles, and submits them to AWS Deadline Cloud.
+
+## Entry Point
+
+The Cinema 4D extension is in `deadline_cloud_extension/DeadlineCloud.pyp` (repo root). It's a bare-bones plugin file that delegates all business logic to this package. The submitter is accessible in Cinema 4D via `Extensions > AWS Deadline Cloud Submitter`.
+
+## Key Files
+
+- `cinema4d_render_submitter.py` — Main submitter logic and entry point
+- `data_classes.py` — Data models for settings and configuration
+- `scene.py` — Scene introspection (renderers, output settings, cameras)
+- `takes.py` — Take system handling
+- `assets.py` — Asset discovery (textures, references, fonts)
+- `enums.py` — Enumerations for renderers, formats, etc.
+- `tile_utils.py` — Tile rendering utilities
+- `font_utils.py` — Font handling and discovery
+- `font_installer.py` — Font installation on workers
+- `ui/` — Submitter dialog UI components (PySide6)
+- `adaptor_cinema4d_job_template.yaml` — Job template used when submitting via the adaptor (default)
+- `default_cinema4d_job_template.yaml` — Job template used for direct Cinema 4D command-line rendering
+
+## Responsibilities
+
+- Display job submission dialog
+- Collect user settings (renderer, frame range, takes, output)
+- Analyze scene (cameras, renderers, takes, assets)
+- Create job bundle with template and assets
+- Submit to Deadline Cloud
+
+## Job Bundle
+
+The submitter's output is a job bundle directory containing:
+- `template.yaml` — Job template with parameters and steps (dynamically generated)
+- `parameter_values.yaml` — User-provided parameter values
+- Asset references (scene file, textures, fonts, etc.)
+
+The template is generated dynamically from scene properties. For example, it may contain a Step for each take to render.
+
+## Take System
+
+Cinema 4D's take system allows multiple render configurations within a single scene. The submitter:
+1. Discovers all takes in the scene (`takes.py`)
+2. Allows users to select which takes to render via the UI
+3. Creates separate steps in the job template for each selected take
+4. The adaptor switches takes before rendering each step (see `../cinema4d_adaptor/AGENTS.md`)
+
+## Tile Rendering
+
+Tile rendering support for high-resolution output:
+- `tile_utils.py` — Calculates tile regions on the submitter side
+- `../cinema4d_adaptor/Cinema4DClient/tile_rendering.py` — Executes tile renders on workers
+- Tiles are rendered as separate tasks and composited
+
+## Adding a New Feature
+
+When adding a new feature to the submitter:
+
+1. Add data models to `data_classes.py`
+2. Add UI controls to `ui/` components
+3. Add parameters to the job template YAML (`adaptor_cinema4d_job_template.yaml`)
+4. Update scene introspection if needed (`scene.py`, `takes.py`, `assets.py`)
+5. Write parameter values to the bundle
+
+If the feature requires worker-side handling, you'll also need to update the adaptor — see `../cinema4d_adaptor/AGENTS.md`. Changes to the data contract between submitter and adaptor require bumping `integration_data_interface_version`.
+
+## Quick Iteration
+
+For fast iteration on submitter code, copy source files directly over the installed submitter rather than rebuilding:
+
+**Windows (PowerShell):**
+```powershell
+Copy-Item -Path "src\deadline\cinema4d_submitter\*" -Destination "$env:APPDATA\DeadlineCloudSubmitter\deadline\cinema4d_submitter\" -Recurse -Force
+```
+
+**macOS:**
+```bash
+cp -R src/deadline/cinema4d_submitter/* ~/DeadlineCloudSubmitter/deadline/cinema4d_submitter/
+```
+
+Restart Cinema 4D to pick up the changes.
+
+## Error Handling
+
+- Validate inputs before submission
+- Collect warnings via `warning_collector.py`
+- Surface issues to the user through the dialog before they submit

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md — test/
+
+Test suite for deadline-cloud-for-cinema-4d. Three categories of tests.
+
+## Directory Layout
+
+```
+test/
+├── unit/                    # Unit tests (always runnable, no Cinema 4D required)
+│   ├── deadline_adaptor_for_cinema4d/
+│   └── deadline_submitter_for_cinema4d/
+├── integ/                   # Integration tests (Windows only, requires Cinema 4D)
+│   ├── test_scenes/         # Test scene definitions
+│   ├── test_cinema4d.py     # Parametrized test runner
+│   ├── conftest.py          # Test fixtures
+│   └── utils.py             # Test utilities
+└── installer/               # Installer tests
+```
+
+## Running Tests
+
+Always use `hatch run` — do NOT invoke `pytest` directly.
+
+```bash
+hatch run test                                    # All unit tests
+hatch run test test/unit/<path>                   # One test file or directory
+hatch run test -k "test_name"                     # One test by name
+hatch run all:test                                # All supported Python versions
+hatch run integ:test                              # Integration tests (Windows only)
+hatch run test-installer                          # Installer tests
+```
+
+## Unit Tests
+
+Unit tests do NOT require Cinema 4D installed. They should use mocks for the `c4d` module and other external dependencies. These are the primary tests run in CI and during development.
+
+When adding new features or fixing bugs, always add unit tests.
+
+## Integration Tests (Windows Only)
+
+Integration tests are currently only supported on Windows. They require Cinema 4D installed with licensing configured.
+
+### Test flow
+
+1. **Scene generation**: Each test case uses scene generation scripts (`scene.py`) to create test scenes with specific configurations
+2. **Job bundle generation**: Generated scenes are processed through the submitter code, exporting job bundles to a temporary location
+3. **Job bundle validation**: Exported bundles are compared against expected bundles in `expected_job_bundle/`
+4. **Scene rendering**: Job bundles are run using OpenJD `run` command with Cinema 4D Commandline
+5. **Output validation**: Generated output files are compared with expected output files
+
+### Test scene structure
+
+```
+test/integ/test_scenes/<scene_name>/
+├── expected_job_bundle/      # Reference job bundle for validation
+│   ├── asset_references.yaml
+│   ├── parameter_values.yaml
+│   └── template.yaml
+├── expected_job_output/      # Expected render output
+│   └── renders/
+└── scene/
+    └── scene.py              # Scene generation script
+```
+
+### Existing test scenes
+
+| Scene | Renderer | Description |
+|-------|----------|-------------|
+| `physical` | Physical | Basic physical renderer test |
+| `physical_apostrophe_path` | Physical | Path with special characters (apostrophes) |
+| `physical_chunking` | Physical | Frame chunking across tasks |
+| `physical_multi_takes` | Physical | Multiple takes rendering |
+| `physical_textured` | Physical | Scene with textures |
+| `physical_tiles` | Physical | Tile rendering |
+| `redshift` | Redshift | Basic Redshift render |
+| `redshift_takes` | Redshift | Redshift with multiple takes |
+| `redshift_textured` | Redshift | Redshift with textures |
+| `redshift_textured_with_nonascii_characters` | Redshift | Non-ASCII path handling |
+| `redshift_tiles` | Redshift | Redshift tile rendering |
+
+### Adding a new test scene
+
+1. Create a new directory under `test/integ/test_scenes/<scene_name>/`
+2. Add a `scene/scene.py` script that generates the test scene programmatically
+3. Add `expected_job_bundle/` with the expected template, parameter values, and asset references
+4. Add `expected_job_output/` with expected render output files
+5. The parametrized test runner (`test_cinema4d.py`) will automatically pick up the new scene
+
+### Running specific integration tests
+
+```bash
+hatch run integ:test -k "physical"
+hatch run integ:test -k "redshift"
+hatch run integ:test -k "redshift_tiles"
+```
+
+## Installer Tests
+
+Test the built installer. Requires having run `hatch run installer:build-installer` first.
+
+```bash
+hatch run test-installer
+```
+
+## Coverage
+
+The project requires minimum 23% code coverage. Coverage settings are in `pyproject.toml` under `[tool.coverage.report]`.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

To accelerate development for new contributors, we need to add few tools.

### What was the solution? (How)

Add 3 skills that can be useful for contributing using LLMs. 

- c4d-dev— Your daily driver. Use it when you're actively working on the codebase: building, running tests, debugging integration tests, understanding the project structure. It has steering files for build workflows, dev conventions, integration testing, and troubleshooting. This is the one you'd activate most often.

- c4d-design— For planning before coding. Use it when you're designing a new feature or major change and want a structured design doc. It walks through a four-section format (data structures, UX changes, job template changes, adaptor/client changes) and includes Cinema 4D API patterns, architecture guides, and external references. Think of it as the "think first" power.

- c4d-dev-setup — One-time onboarding. Use it when someone new joins the team and needs to get their machine set up from scratch: install hatch, build the package, install the submitter into Cinema 4D, configure environment variables. Once setup is done, you wouldn't use this again.

In practice, most people would use dev-setup once, then live in c4d-dev day-to-day, and pull in c4d-design occasionally for bigger features.

### What is the impact of this change?

Hopefully, faster development cycles. 

### Was this change documented?

Added to DEVELOPMENT.md. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*