### PR TITLE
ci: run integration tests on mainline push

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,6 +1,9 @@
 name: Cinema 4D Integration Tests
 
 on:
+  push:
+    branches:
+      - mainline
   workflow_dispatch:
     inputs:
       ref_type:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Cinema 4D integration tests only run via manual workflow_dispatch trigger as it was in development phase. Now that the integration tests are passing, would like to run integration tests when mainline is pushed, catching regressions early. 

### What was the solution? (How)
Added a push trigger on the mainline branch to the integration tests workflow, alongside the existing workflow_dispatch trigger.

### What is the impact of this change?
Integration tests now run automatically on every mainline push, matching the pattern used by other DCC repos. Manual triggering still works as before.

### How was this change tested?

- Have you run the unit tests?
yes
```
=================== 321 passed, 6 skipped in 5.17s ===================
```

- Have you run the integration tests? (Add your integration test report below)
yes - verified the integration tests succeeds

- Have you made changes to the submitter?
no 

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*