### PR TITLE
fix: keep submitter dialog in foreground when parent window is clicked

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -922,7 +922,7 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
     asset_references.input_filenames = temp_assets
 
 
-def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowType(0)):  # type: ignore[call-overload]
+def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowType.Tool):  # type: ignore[call-overload]
     """
     Creates and returns a submission dialog for rendering jobs.
 


### PR DESCRIPTION
## Summary
- Sets `Qt.Tool` window flag on the submitter dialog so it stays in front of the Cinema 4D window when the parent application is clicked, preventing it from being backgrounded.

## Test plan
- [x] Open Cinema 4D on macOS, launch the submitter via Extensions > AWS Deadline Cloud Submitter
- [x] Click the Cinema 4D window behind the submitter — submitter remains in foreground
- [x] macOS plays the standard "bonk" sound indicating the modal is blocking, consistent with native app behavior

## Demo


https://github.com/user-attachments/assets/d9f17c0c-9c94-4efd-925d-7b0f6434cc50



