### PR TITLE
Revert "chore(release): 0.11.2 (#454)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.11.2 (2026-06-05)
-
-### Bug Fixes
-* The submitter window now stays in the foreground when the parent Cinema 4D window is clicked, preventing it from getting lost behind other windows. (#452)
-* Fixed an issue where jobs with long file paths containing apostrophes could fail on Windows due to exceeding the 260 character path limit. (#443)
 
 ## 0.11.1 (2026-04-22)
 


### PR DESCRIPTION
We found an issue with 0.11.2 release and hence we are reverting it. https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/454

This reverts commit 9693b19ad2e3ad8a0baba6dbec7e74296c90e022.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*