### PR TITLE
Fix/submitter stay on top

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -99,7 +99,12 @@ def show_submitter():
             prefix="scene_with_assets_", dir=scene_dir_path
         ) as temp_dir:
             app.setStyleSheet(C4D_STYLE)  # type: ignore[attr-defined]
-            w = _show_submitter(temp_dir, None)
+            if is_windows():
+                w = _show_submitter(
+                    temp_dir, None, Qt.WindowType.Tool | Qt.WindowType.WindowStaysOnTopHint
+                )
+            else:
+                w = _show_submitter(temp_dir, None)
             w.setStyleSheet(C4D_STYLE)
             w.exec_()
     except Exception:


### PR DESCRIPTION
 ## Summary

   - Set `Qt.WindowType.Tool` flag so the submitter dialog stays above the host application window (works on macOS without further changes).
   - On Windows, use `Qt.WindowStaysOnTopHint` to keep the submitter window in front of all windows including the parent DCC. This matches [the approach we use for Blender](https://github.com/aws-deadline/deadline-cloud-for-blender/blob/3e5bc3fdbd820268267b10f0f92c23d5db565179/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py#L135)

   ## Test plan

   - [x] macOS: Open submitter from Cinema 4D, click C4D main window → submitter stays in front
   - [ ] Windows: Same test → submitter stays in front (previously it would get hidden)
   - [ ] Verify no regression when closing submitter normally
   - [ ] Verify submitter still works if `GetMainWindowHandle()` returns 0/None (guard handles this