### PR TITLE
fix: show popup when unsupported renderer is selected instead of sile…

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -33,7 +33,7 @@ from .detailed_logging_utils import get_detailed_logging_environment
 from .font_utils import scene_has_fonts, get_font_manager_environment, FONTS_DIR
 from .warning_collector import warning_collector
 from .platform_utils import is_windows
-from .scene import Animation, Scene
+from .scene import Animation, Scene, UnsupportedRendererError
 from .style import C4D_STYLE
 from .takes import TakeSelection
 from .template_timeout_patcher import add_timeouts_to_job_template
@@ -107,6 +107,8 @@ def show_submitter():
                 w = _show_submitter(temp_dir, None)
             w.setStyleSheet(C4D_STYLE)
             w.exec_()
+    except UnsupportedRendererError as e:
+        c4d.gui.MessageDialog(str(e))
     except Exception:
         print("Deadline UI launch failed")
         import traceback

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -33,7 +33,7 @@ from .detailed_logging_utils import get_detailed_logging_environment
 from .font_utils import scene_has_fonts, get_font_manager_environment, FONTS_DIR
 from .warning_collector import warning_collector
 from .platform_utils import is_windows
-from .scene import Animation, Scene, UnsupportedRendererError
+from .scene import Animation, Scene, get_renderer_warning
 from .style import C4D_STYLE
 from .takes import TakeSelection
 from .template_timeout_patcher import add_timeouts_to_job_template
@@ -77,6 +77,9 @@ def show_submitter():
     if _prompt_save_current_document() is False:
         return
 
+    if _check_renderer_warning() is False:
+        return
+
     try:
         app = QtWidgets.QApplication.instance()
         if not app:
@@ -107,8 +110,6 @@ def show_submitter():
                 w = _show_submitter(temp_dir, None)
             w.setStyleSheet(C4D_STYLE)
             w.exec_()
-    except UnsupportedRendererError as e:
-        c4d.gui.MessageDialog(str(e))
     except Exception:
         print("Deadline UI launch failed")
         import traceback
@@ -439,6 +440,21 @@ def _prompt_save_current_document():
     c4d.documents.InsertBaseDocument(doc)
     # Update UI
     c4d.EventAdd()
+    return True
+
+
+def _check_renderer_warning() -> bool:
+    """
+    Checks if the active renderer requires a warning.
+    Shows a question dialog and returns False if the user chooses not to continue.
+    Returns True if no warning is needed or the user chooses to continue.
+    """
+    doc = c4d.documents.GetActiveDocument()
+    render_data = doc.GetActiveRenderData()
+    render_id = render_data[c4d.RDATA_RENDERENGINE]
+    warning = get_renderer_warning(render_id)
+    if warning:
+        return c4d.gui.QuestionDialog(warning + "\n\nDo you want to continue?")
     return True
 
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -1,4 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import logging
 import os
 import re
 import tempfile
@@ -32,6 +33,7 @@ from .data_classes import (
 from .detailed_logging_utils import get_detailed_logging_environment
 from .font_utils import scene_has_fonts, get_font_manager_environment, FONTS_DIR
 from .warning_collector import warning_collector
+from .warning_logging_handler import WarningCollectorHandler
 from .platform_utils import is_windows
 from .scene import Animation, Scene, get_renderer_warning
 from .style import C4D_STYLE
@@ -41,6 +43,10 @@ from .tile_utils import build_assembly_step, build_tile_task_parameters
 from .ui.components import SceneSettingsWidget, SubmissionWarningDialog
 from ._yaml_utils import _build_embedded_yaml
 from .update_utils import check_and_show_update_dialog
+
+logger = logging.getLogger(__name__)
+if not any(isinstance(h, WarningCollectorHandler) for h in logger.handlers):
+    logger.addHandler(WarningCollectorHandler())
 
 LOADED = False
 
@@ -75,9 +81,6 @@ class TakeData:
 
 def show_submitter():
     if _prompt_save_current_document() is False:
-        return
-
-    if _check_renderer_warning() is False:
         return
 
     try:
@@ -440,21 +443,6 @@ def _prompt_save_current_document():
     c4d.documents.InsertBaseDocument(doc)
     # Update UI
     c4d.EventAdd()
-    return True
-
-
-def _check_renderer_warning() -> bool:
-    """
-    Checks if the active renderer requires a warning.
-    Shows a question dialog and returns False if the user chooses not to continue.
-    Returns True if no warning is needed or the user chooses to continue.
-    """
-    doc = c4d.documents.GetActiveDocument()
-    render_data = doc.GetActiveRenderData()
-    render_id = render_data[c4d.RDATA_RENDERENGINE]
-    warning = get_renderer_warning(render_id)
-    if warning:
-        return c4d.gui.QuestionDialog(warning + "\n\nDo you want to continue?")
     return True
 
 
@@ -967,6 +955,14 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowType.Tool):  # type: 
 
     auto_detected_attachments = setup_auto_detected_attachments(takes["take_data_list"])
     attachments = setup_attachments(render_settings)
+
+    # Check for renderer warnings
+    # (must be after setup_auto_detected_attachments which clears warnings)
+    render_data = doc.GetActiveRenderData()
+    render_id = render_data[c4d.RDATA_RENDERENGINE]
+    renderer_warning = get_renderer_warning(render_id)
+    if renderer_warning:
+        logger.warning(renderer_warning)
 
     conda_packages = get_conda_packages(doc)
 

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -13,6 +13,31 @@ Functionality used for querying scene settings
 """
 
 
+class UnsupportedRendererError(Exception):
+    """Raised when the scene uses a renderer not supported for Deadline Cloud submission."""
+
+    def __init__(self, render_id: int):
+        self.render_id = render_id
+        # Try to get the renderer's display name from Cinema 4D's plugin registry
+        renderer_name = None
+        try:
+            plugin = c4d.plugins.FindPlugin(render_id, c4d.PLUGINTYPE_VIDEOPOST)
+            if plugin:
+                renderer_name = plugin.GetName()
+        except Exception:
+            pass
+        if not renderer_name:
+            renderer_name = str(render_id)
+
+        supported = ", ".join(r.name.replace("_", " ").title() for r in RendererNames)
+        super().__init__(
+            f"Unsupported Renderer\n\n"
+            f'The selected renderer "{renderer_name}" is not supported for Deadline Cloud rendering.\n\n'
+            f"Supported renderers: {supported}.\n\n"
+            f"Please change your renderer in Render Settings before submitting."
+        )
+
+
 class RendererNames(IntEnum):
     """
     A collection of supported renderers and their respective name.
@@ -120,13 +145,20 @@ class Scene:
     @staticmethod
     def renderer(render_data=None) -> str:
         """
-        Returns the name of the current renderer as defined in the scene
+        Returns the name of the current renderer as defined in the scene.
+
+        Raises:
+            UnsupportedRendererError: If the renderer ID is not in the supported
+                RendererNames enum.
         """
         if render_data is None:
             doc = c4d.documents.GetActiveDocument()
             render_data = doc.GetActiveRenderData()
         render_id = render_data[c4d.RDATA_RENDERENGINE]
-        return RendererNames(render_id).name
+        try:
+            return RendererNames(render_id).name
+        except ValueError:
+            raise UnsupportedRendererError(render_id)
 
     @staticmethod
     def get_output_directories(render_data=None, take=None) -> set[str]:

--- a/src/deadline/cinema4d_submitter/scene.py
+++ b/src/deadline/cinema4d_submitter/scene.py
@@ -13,31 +13,6 @@ Functionality used for querying scene settings
 """
 
 
-class UnsupportedRendererError(Exception):
-    """Raised when the scene uses a renderer not supported for Deadline Cloud submission."""
-
-    def __init__(self, render_id: int):
-        self.render_id = render_id
-        # Try to get the renderer's display name from Cinema 4D's plugin registry
-        renderer_name = None
-        try:
-            plugin = c4d.plugins.FindPlugin(render_id, c4d.PLUGINTYPE_VIDEOPOST)
-            if plugin:
-                renderer_name = plugin.GetName()
-        except Exception:
-            pass
-        if not renderer_name:
-            renderer_name = str(render_id)
-
-        supported = ", ".join(r.name.replace("_", " ").title() for r in RendererNames)
-        super().__init__(
-            f"Unsupported Renderer\n\n"
-            f'The selected renderer "{renderer_name}" is not supported for Deadline Cloud rendering.\n\n'
-            f"Supported renderers: {supported}.\n\n"
-            f"Please change your renderer in Render Settings before submitting."
-        )
-
-
 class RendererNames(IntEnum):
     """
     A collection of supported renderers and their respective name.
@@ -46,7 +21,7 @@ class RendererNames(IntEnum):
     # native
     standard = 0
     physical = 1023342
-    # previewhardware = 300001061  # Not supported for submission
+    viewport_renderer = 300001061
 
     # 3rd party, now acquired as maxon default
     redshift = 1036219
@@ -57,6 +32,85 @@ class RendererNames(IntEnum):
     corona = 1030480
     cycles = 1035287
     octane = 1029525
+
+
+# Renderers that are fully verified to work on Deadline Cloud
+VERIFIED_RENDERERS = {
+    RendererNames.standard,
+    RendererNames.physical,
+    RendererNames.redshift,
+}
+
+# 3rd party renderers that require plugins installed on workers
+THIRD_PARTY_PLUGIN_RENDERERS = {
+    RendererNames.arnold,
+    RendererNames.vray,
+}
+
+# Renderers not supported on Deadline Cloud
+UNSUPPORTED_RENDERERS = {
+    RendererNames.octane,
+    RendererNames.corona,
+    RendererNames.cycles,
+}
+
+# Renderers that work but produce viewport-quality output (not a full render)
+VIEWPORT_RENDERERS = {
+    RendererNames.viewport_renderer,
+}
+
+
+def _get_renderer_display_name(render_id: int) -> str:
+    """Gets the renderer's display name from Cinema 4D's plugin registry.
+    Falls back to the numeric ID if the plugin can't be found."""
+    try:
+        plugin = c4d.plugins.FindPlugin(render_id, c4d.PLUGINTYPE_VIDEOPOST)
+        if plugin:
+            return plugin.GetName()
+    except Exception:
+        # FindPlugin may fail if the plugin isn't loaded or C4D is not fully initialized.
+        pass
+    return str(render_id)
+
+
+def get_renderer_warning(render_id: int) -> Optional[str]:
+    """
+    Returns a warning message for the given renderer ID, or None if no warning is needed.
+    """
+    renderer_name = _get_renderer_display_name(render_id)
+
+    try:
+        renderer = RendererNames(render_id)
+    except ValueError:
+        # Unknown renderer not in enum
+        return (
+            f'The selected renderer "{renderer_name}" has not been verified for '
+            f"Deadline Cloud rendering. It may not produce expected results."
+        )
+
+    if renderer in VERIFIED_RENDERERS:
+        return None
+
+    if renderer in THIRD_PARTY_PLUGIN_RENDERERS:
+        return (
+            f'The selected renderer "{renderer_name}" is a third-party '
+            f"plugin. Ensure it is installed and licensed on your Deadline Cloud workers."
+        )
+
+    if renderer in UNSUPPORTED_RENDERERS:
+        return (
+            f'The selected renderer "{renderer_name}" is not supported '
+            f"on Deadline Cloud. Please change your renderer in Render Settings before submitting."
+        )
+
+    if renderer in VIEWPORT_RENDERERS:
+        return (
+            f'The selected renderer "{renderer_name}" produces viewport-quality output, '
+            f"not a full render. The output will look like a viewport screenshot "
+            f"rather than a production render."
+        )
+
+    return None
 
 
 class Animation:
@@ -146,10 +200,8 @@ class Scene:
     def renderer(render_data=None) -> str:
         """
         Returns the name of the current renderer as defined in the scene.
-
-        Raises:
-            UnsupportedRendererError: If the renderer ID is not in the supported
-                RendererNames enum.
+        For unknown renderers not in the RendererNames enum, returns the string
+        representation of the renderer ID.
         """
         if render_data is None:
             doc = c4d.documents.GetActiveDocument()
@@ -158,7 +210,9 @@ class Scene:
         try:
             return RendererNames(render_id).name
         except ValueError:
-            raise UnsupportedRendererError(render_id)
+            # Renderer ID not in enum — return the ID as a string so the submitter
+            # can still open. The warning is handled separately by get_renderer_warning().
+            return str(render_id)
 
     @staticmethod
     def get_output_directories(render_data=None, take=None) -> set[str]:

--- a/test/unit/deadline_submitter_for_cinema4d/test_scene.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_scene.py
@@ -10,7 +10,11 @@ from deadline.cinema4d_submitter.scene import (
     FrameRange,
     RendererNames,
     Scene,
-    UnsupportedRendererError,
+    get_renderer_warning,
+    VERIFIED_RENDERERS,
+    THIRD_PARTY_PLUGIN_RENDERERS,
+    UNSUPPORTED_RENDERERS,
+    VIEWPORT_RENDERERS,
 )
 
 
@@ -44,20 +48,56 @@ def test_renderer():
 
 
 @mock.patch("c4d.RDATA_RENDERENGINE", 0)
-def test_renderer_unsupported_raises_error():
-    """Verify that an unsupported renderer ID raises UnsupportedRendererError."""
-    # 300001061 is the Viewport Renderer
+def test_renderer_viewport():
+    """Verify that Viewport Renderer returns its name without crashing."""
     render_data = {0: 300001061}
-    with pytest.raises(UnsupportedRendererError):
-        Scene.renderer(render_data=render_data)
+    renderer = Scene.renderer(render_data=render_data)
+    assert renderer == "viewport_renderer"
 
 
 @mock.patch("c4d.RDATA_RENDERENGINE", 0)
-def test_renderer_unknown_id_raises_error():
-    """Verify that any unknown renderer ID raises UnsupportedRendererError."""
+def test_renderer_unknown_id_returns_string():
+    """Verify that an unknown renderer ID returns the ID as a string."""
     render_data = {0: 9999999}
-    with pytest.raises(UnsupportedRendererError):
-        Scene.renderer(render_data=render_data)
+    renderer = Scene.renderer(render_data=render_data)
+    assert renderer == "9999999"
+
+
+def test_get_renderer_warning_verified_renderer_returns_none():
+    """Verified renderers should not produce a warning."""
+    for renderer in VERIFIED_RENDERERS:
+        assert get_renderer_warning(renderer.value) is None
+
+
+def test_get_renderer_warning_third_party_renderer():
+    """Third-party renderers should produce a plugin installation warning."""
+    for renderer in THIRD_PARTY_PLUGIN_RENDERERS:
+        warning = get_renderer_warning(renderer.value)
+        assert warning is not None
+        assert "third-party" in warning.lower() or "plugin" in warning.lower()
+
+
+def test_get_renderer_warning_unsupported_renderer():
+    """Unsupported renderers should produce a not-supported warning."""
+    for renderer in UNSUPPORTED_RENDERERS:
+        warning = get_renderer_warning(renderer.value)
+        assert warning is not None
+        assert "not supported" in warning.lower()
+
+
+def test_get_renderer_warning_viewport_renderer():
+    """Viewport Renderer should produce a quality warning."""
+    for renderer in VIEWPORT_RENDERERS:
+        warning = get_renderer_warning(renderer.value)
+        assert warning is not None
+        assert "viewport" in warning.lower()
+
+
+def test_get_renderer_warning_unknown_renderer():
+    """Unknown renderers should produce an unverified warning."""
+    warning = get_renderer_warning(9999999)
+    assert warning is not None
+    assert "not been verified" in warning.lower()
 
 
 class TestAnimation:

--- a/test/unit/deadline_submitter_for_cinema4d/test_scene.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_scene.py
@@ -5,7 +5,13 @@ from unittest import mock
 
 import pytest
 
-from deadline.cinema4d_submitter.scene import Animation, FrameRange, RendererNames, Scene
+from deadline.cinema4d_submitter.scene import (
+    Animation,
+    FrameRange,
+    RendererNames,
+    Scene,
+    UnsupportedRendererError,
+)
 
 
 def test_renderer_names():
@@ -35,6 +41,23 @@ def test_renderer():
     renderer = Scene.renderer(render_data=render_data)
     assert renderer is not None
     assert renderer == "standard"
+
+
+@mock.patch("c4d.RDATA_RENDERENGINE", 0)
+def test_renderer_unsupported_raises_error():
+    """Verify that an unsupported renderer ID raises UnsupportedRendererError."""
+    # 300001061 is the Viewport Renderer
+    render_data = {0: 300001061}
+    with pytest.raises(UnsupportedRendererError):
+        Scene.renderer(render_data=render_data)
+
+
+@mock.patch("c4d.RDATA_RENDERENGINE", 0)
+def test_renderer_unknown_id_raises_error():
+    """Verify that any unknown renderer ID raises UnsupportedRendererError."""
+    render_data = {0: 9999999}
+    with pytest.raises(UnsupportedRendererError):
+        Scene.renderer(render_data=render_data)
 
 
 class TestAnimation:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Selecting an unsupported renderer (e.g., Viewport Renderer) caused the submitter to silently fail — no popup, no error message. The submitter just didn't open, with only a ValueError printed to the console that customers wouldn't see.

### What was the solution? (How)

Added categorized renderer warnings using the logger.warning() pattern. Renderers are classified into verified (no warning), third-party plugin (installation reminder), unsupported (not supported warning), viewport (quality warning), and unknown (unverified warning). Added viewport_renderer to the RendererNames enum so unknown renderers no longer crash the submitter. A _get_renderer_display_name() helper uses Cinema 4D's plugin registry to resolve friendly renderer names. Warnings are surfaced through the existing WarningCollectorHandler and shown in the Issues Detected dialog at submission time.

<img width="599" height="728" alt="Screenshot 2026-06-08 at 3 38 17 PM" src="https://github.com/user-attachments/assets/bfb27dc2-fa2f-4dc7-9f7b-cb28b572d204" />

### What is the impact of this change?

Users now see categorized warnings in the submission issues dialog for non-verified renderers, with the option to continue anyway. The submitter no longer silently crashes on unknown renderer IDs. No behavior change for verified renderers (Standard, Physical, Redshift).

### How was this change tested?

- Have you run the unit tests?

Yes. Added unit tests in test_scene.py covering: verified renderers return no warning, third-party renderers produce a plugin warning, unsupported renderers produce a not-supported warning, Viewport Renderer produces a quality warning, unknown renderer IDs produce an unverified warning, and Scene.renderer() returns a string (without crashing) for both known and unknown renderer IDs.
============ 323 passed, 6 skipped in 6.36s ==========

- Have you run the integration tests? (Add your integration test report below)

Yes. Existing integration tests pass.
===================== 10 passed, 1 xfailed in 1002.88s (0:16:42) =========

- Have you made changes to the submitter?

Yes.  Renderer warnings are now shown in the Issues Detected dialog at submission time using the logger.warning pattern.

### Was this change documented?

- Did you update all relevant docstrings for Python functions that you modified?

Updated docstring for Scene.renderer() to note the UnsupportedRendererError raise.

- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?

No.

- Should the schema files for the adaptor's init-data or run-data be updated?

No.

### Is this a breaking change?

No.