### PR TITLE
fix: raise error when set_take receives nonexistent take name

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -378,13 +378,16 @@ class Cinema4DHandler:
         main_take = take_data.GetCurrentTake()
         all_takes = [main_take] + get_child_takes(main_take)
 
-        take = None
+        matched_take = None
         for take in all_takes:
             if take.GetName() == take_name:
+                matched_take = take
                 break
-        if take is None:
-            print("Error: take not found: %s" % take_name)
-        take_data.SetCurrentTake(take)
+
+        if matched_take is None:
+            raise RuntimeError("Take not found: %s" % take_name)
+
+        take_data.SetCurrentTake(matched_take)
 
     def use_cached_text(self, data: dict) -> None:
         """

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -65,6 +65,60 @@ class TestCinema4DHandler:
         with pytest.raises(RuntimeError, match="Failed to load the scene file"):
             handler.set_scene_file({"scene_file": "file.c4d"})
 
+    @patch(
+        "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.GetActiveDocument"
+    )
+    def test_set_take_not_found_raises_error(self, mock_get_doc: Mock):
+        """Verify that set_take raises RuntimeError when the take name doesn't exist."""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Set up mock takes: "Main" and "A"
+        mock_main_take = Mock()
+        mock_main_take.GetName.return_value = "Main"
+        mock_main_take.GetChildren.return_value = []
+
+        mock_take_a = Mock()
+        mock_take_a.GetName.return_value = "A"
+        mock_take_a.GetChildren.return_value = []
+
+        mock_take_data = Mock()
+        mock_take_data.GetCurrentTake.return_value = mock_main_take
+        mock_main_take.GetChildren.return_value = [mock_take_a]
+
+        mock_doc = Mock()
+        mock_doc.GetTakeData.return_value = mock_take_data
+        mock_get_doc.return_value = mock_doc
+
+        with pytest.raises(RuntimeError, match="Take not found: NonExistentTake"):
+            handler.set_take({"take": "NonExistentTake"})
+
+    @patch(
+        "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.GetActiveDocument"
+    )
+    def test_set_take_found_sets_take(self, mock_get_doc: Mock):
+        """Verify that set_take correctly sets the take when it exists."""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Set up mock takes: "Main" and "A"
+        mock_main_take = Mock()
+        mock_main_take.GetName.return_value = "Main"
+        mock_main_take.GetChildren.return_value = []
+
+        mock_take_a = Mock()
+        mock_take_a.GetName.return_value = "A"
+        mock_take_a.GetChildren.return_value = []
+
+        mock_take_data = Mock()
+        mock_take_data.GetCurrentTake.return_value = mock_main_take
+        mock_main_take.GetChildren.return_value = [mock_take_a]
+
+        mock_doc = Mock()
+        mock_doc.GetTakeData.return_value = mock_take_data
+        mock_get_doc.return_value = mock_doc
+
+        handler.set_take({"take": "A"})
+        mock_take_data.SetCurrentTake.assert_called_once_with(mock_take_a)
+
 
 class TestShouldCacheText:
     """Tests for the use_cached_text method"""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The set_take() method in cinema4d_handler.py had a broken for/break pattern. If a nonexistent take name was passed, instead of raising an error, the loop variable would be set to the last take in the list and SetCurrentTake would silently render the wrong take. While unreachable through the GUI submitter (which validates take names before submission), this could cause silent incorrect renders when running the adaptor manually via CLI with a typo in the take name.

### What was the solution? (How)
Fixed the for/break pattern by using a separate matched_take variable. After iterating through all takes, if no match is found, a RuntimeError is raised with a clear message. SetCurrentTake is only called with a valid matched take.

### What is the impact of this change?
If set_take() receives a nonexistent take name, it now raises a RuntimeError instead of silently rendering the wrong take. No behavior change for valid take names. This is a defensive fix — unreachable through normal GUI submission but protects against incorrect renders when the adaptor is run manually.

### How was this change tested?
- Have you run the unit tests?
Yes. Added two unit tests: one verifying RuntimeError is raised for a nonexistent take, and one verifying a valid take is correctly set. ========= 323 passed, 6 skipped in 6.42s ====

- Have you run the integration tests?
Yes. ===== 10 passed, 1 xfailed in 1049.72s (0:17:29) ====

- Have you made changes to the submitter?
No.

### Was this change documented?
No documentation changes needed. The fix is internal to the adaptor handler and does not change any public interface, schema, or user-facing behavior.

### Is this a breaking change?
No. The fix only affects the error case (nonexistent take name), which previously produced silent incorrect behavior. Valid take names continue to work identically.