### PR TITLE
chore: Append Deadline Cloud V2 channel as the default for migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline[gui] >= 0.55.1,< 0.59",
+    "deadline[gui] >= 0.59, <0.60",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
     # fonttools is Windows-only due to Cinema 4D technical limitations
     "fonttools >=4.59.2, <4.64; sys_platform == 'win32'",
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gui = [
-    "deadline[gui] >= 0.55.1,< 0.59",
+    "deadline[gui] >= 0.59, <0.60",
     "PySide6-Essentials == 6.8.3",  # Use 6.8 to align with VFXP 2026: https://vfxplatform.com/#reference-platform
 ]
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -1031,6 +1031,7 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowType.Tool):  # type: 
         f=f,
         show_host_requirements_tab=True,
         submitter_info=submitter_info,
+        use_deadline_cloud_v2_channel=True,
     )
 
     return submitter_dialog


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Deadline Cloud is migrating its service-managed Conda channel from `deadline-cloud` to `deadline-cloud-v2`. The Cinema 4D submitter should adopt the v2 channel so that jobs resolve packages from `deadline-cloud-v2` (while still falling back to `deadline-cloud` for anything not yet hosted on v2). The actual channel rewrite is shared logic that belongs in the `deadline-cloud` library, not in this submitter; this change is the Cinema 4D side that opts into it.

### What was the solution? (How)

- Pass `use_deadline_cloud_v2_channel=True` when constructing `SubmitJobToDeadlineDialog` in `_show_submitter`. This is a new opt-in flag added to the `deadline-cloud` library: when enabled, the library prepends `deadline-cloud-v2` ahead of `deadline-cloud` in the `CondaChannels` queue parameter as it loads (token-level, order-preserving, idempotent). The submitter itself contains no channel-name logic.
- Bump the `deadline[gui]` dependency from `>= 0.55.1, < 0.59` to `>= 0.59, < 0.60`, since the `use_deadline_cloud_v2_channel` argument is only available in `deadline-cloud` 0.59+.

### What is the impact of this change?

- GUI submissions from the Cinema 4D submitter now prepend `deadline-cloud-v2` ahead of `deadline-cloud` in the `CondaChannels` queue parameter, with `deadline-cloud` retained as a fallback. Customized channels on the queue are left untouched.
- Requires `deadline-cloud` 0.59 or newer. The dependency bump is the only thing that gates upgrades.
- No change to the adaptor, its init-data/run-data, or the job template structure.

### How was this change tested?

- **Have you run the integration tests?** The integration tests were reviewed for impact and require no change. They build job bundles directly via `internal_create_job_bundle` (`integ_test_helpers.py`), which bypasses the GUI dialog where the v2 prepend happens, so the generated `CondaChannels` value remains `deadline-cloud` and continues to match the existing expected fixtures. The shared logic itself is unit-tested in the `deadline-cloud` repository (the rewrite helper and the widget wiring).
- **Have you made changes to the submitter?** Yes — the single `use_deadline_cloud_v2_channel=True` argument in `_show_submitter`. There is no change to `integ_test_helpers.py`: the submitter does not set `CondaChannels` itself (it is left to the queue / the `deadline-cloud` library), so the sample queue parameters used by the integration helpers are unaffected.

### Was this change documented?

No documentation changes are required. No Python function signatures in this repository changed (only a call-site argument was added), the adaptor init-data/run-data schemas are unaffected, and there are no user-facing CLI or README changes.

### Is this a breaking change?

No. This is a backward-compatible change: it adds an opt-in argument at a call site and raises the minimum `deadline-cloud` version. The adaptor interface, init-data, and run-data are unchanged, so jobs submitted by older submitter versions continue to work with the adaptor.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
