### PR TITLE
fix: Fix xa11y integration tests to work on macOS with Github runners

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-"""Setup runner for Cinema 4D integration tests in CodeBuild."""
+"""Setup runner for Cinema 4D integration tests."""
 
 import argparse
 import hashlib
@@ -20,10 +20,10 @@ C4D_INSTALLERS = {
             "sha256": "fcf0ea40af73727f1bc1fb1a47ea0c2f3476f0652824d3b740181dc1a6123e09",
             "type": "zip",
         },
-        "linux": {
-            "s3_key": "cinema4d/2025/Cinema4D_2025_2025.3.1_Linux.zip",
-            "sha256": "40b4a85d38dcdf5fa19fa19b03efde6494fe3e482b96836d5b736956133ff98f",
-            "type": "zip",
+        "macos": {
+            "s3_key": "cinema4d/2025/Cinema4D_2025_2025.3.3_Mac.dmg",
+            "sha256": "ff06ebae0ba37720049dfff044b75a5e9090dd94ba4f6f286f8889629e783ad8",
+            "type": "dmg",
         },
     },
     "2026": {
@@ -32,10 +32,10 @@ C4D_INSTALLERS = {
             "sha256": "412b069a00b39564aaaa7c1ccfa080d9e154669028e3521b96282c4dfcfd4024",
             "type": "exe",
         },
-        "linux": {
-            "s3_key": "cinema4d/2025/Cinema4D_2025_2025.3.1_Linux.zip",
-            "sha256": "40b4a85d38dcdf5fa19fa19b03efde6494fe3e482b96836d5b736956133ff98f",
-            "type": "zip",
+        "macos": {
+            "s3_key": "cinema4d/2026/Cinema4D_2026_2026.3_Mac.dmg",
+            "sha256": "8759463ca17aa94c527cbdd12c2289cc60b3c937729a9b7304af6ff8ef493557",
+            "type": "dmg",
         },
     },
 }
@@ -43,11 +43,11 @@ C4D_INSTALLERS = {
 C4D_INSTALL_PATHS = {
     "2025": {
         "windows": Path("C:/Program Files/Maxon Cinema 4D 2025"),
-        "linux": Path("/opt/maxon/cinema4d-2025"),
+        "macos": Path("/Applications/Maxon Cinema 4D 2025"),
     },
     "2026": {
         "windows": Path("C:/Program Files/Maxon Cinema 4D 2026"),
-        "linux": Path("/opt/maxon/cinema4d-2026"),
+        "macos": Path("/Applications/Maxon Cinema 4D 2026"),
     },
 }
 
@@ -126,7 +126,6 @@ def setup_windows(versions):
                     f"Expand-Archive -Path '{local_installer}' -DestinationPath '{extract_dir}' -Force",
                 ]
             )
-            # The zip contains a cinema4d subfolder — move it to install path
             extracted_c4d = next(extract_dir.glob("*/"), None)
             if extracted_c4d:
                 install_dir.parent.mkdir(parents=True, exist_ok=True)
@@ -177,10 +176,110 @@ def setup_windows(versions):
             )
             sys.exit(1)
 
-    _configure_rlm_licensing(versions)
+    _configure_rlm_licensing(versions, "windows")
 
 
-def _configure_rlm_licensing(versions):
+def setup_macos(versions):
+    """Install Cinema 4D on macOS for each version."""
+    for version in versions:
+        install_dir = C4D_INSTALL_PATHS[version]["macos"]
+        marker = install_dir / ".installed"
+
+        if marker.exists():
+            print(f"Cinema 4D {version} already installed at {install_dir}")
+            continue
+
+        if "macos" not in C4D_INSTALLERS.get(version, {}):
+            print(f"ERROR: No macOS installer configured for version {version}")
+            sys.exit(1)
+
+        print(f"Installing Cinema 4D {version}...")
+        installer_info = C4D_INSTALLERS[version]["macos"]
+        local_installer = Path(f"/tmp/{Path(installer_info['s3_key']).name}")
+
+        download_from_s3(installer_info["s3_key"], local_installer)
+        verify_checksum(local_installer, installer_info["sha256"])
+
+        # Mount the DMG
+        mount_point = Path("/tmp/c4d_mount")
+        mount_point.mkdir(exist_ok=True)
+        run(
+            [
+                "hdiutil",
+                "attach",
+                str(local_installer),
+                "-mountpoint",
+                str(mount_point),
+                "-nobrowse",
+            ]
+        )
+
+        # Find the installer .app inside the DMG
+        installer_app = None
+        for item in mount_point.iterdir():
+            if item.suffix == ".app":
+                installer_app = item
+                break
+
+        if not installer_app:
+            print(f"ERROR: No .app found in DMG. Contents: {list(mount_point.iterdir())}")
+            run(["hdiutil", "detach", str(mount_point)], check=False)
+            sys.exit(1)
+
+        # Per Maxon docs: copy the .app out of the DMG before running it
+        local_app = Path(f"/tmp/{installer_app.name}")
+        run(["cp", "-R", str(installer_app), str(local_app)])
+
+        # The InstallBuilder executable is at Contents/macOS/installbuilder.sh
+        installer_bin = local_app / "Contents" / "macOS" / "installbuilder.sh"
+        if not installer_bin.exists():
+            # Fallback: try Contents/MacOS/installbuilder.sh (case variation)
+            installer_bin = local_app / "Contents" / "MacOS" / "installbuilder.sh"
+        if not installer_bin.exists():
+            macos_dir = local_app / "Contents" / "MacOS"
+            if not macos_dir.exists():
+                macos_dir = local_app / "Contents" / "macOS"
+            print(
+                f"ERROR: installbuilder.sh not found. Contents of {macos_dir}: {list(macos_dir.iterdir()) if macos_dir.exists() else 'dir missing'}"
+            )
+            run(["hdiutil", "detach", str(mount_point)], check=False)
+            sys.exit(1)
+
+        print(f"Running installer: {installer_bin}")
+        result = subprocess.run(
+            [
+                "sudo",
+                str(installer_bin),
+                "--mode",
+                "unattended",
+                "--unattendedmodeui",
+                "none",
+                "--prefix",
+                str(install_dir),
+            ],
+            stdin=subprocess.DEVNULL,
+            timeout=600,
+        )
+        print(f"Installer exit code: {result.returncode}")
+
+        # Clean up the copied installer app
+        run(["rm", "-rf", str(local_app)], check=False)
+
+        run(["hdiutil", "detach", str(mount_point)], check=False)
+        local_installer.unlink(missing_ok=True)
+
+        if install_dir.exists():
+            print(f"SUCCESS: Cinema 4D {version} installed at {install_dir}")
+            run(["sudo", "touch", str(marker)])
+        else:
+            print(f"ERROR: Cinema 4D {version} not found at {install_dir}")
+            run(["ls", "-la", "/Applications/"], check=False)
+            sys.exit(1)
+
+    _configure_rlm_licensing(versions, "macos")
+
+
+def _configure_rlm_licensing(versions, platform_key):
     """Configure Cinema 4D to use RLM licensing without interactive GUI login."""
     license_dns = os.environ.get("LICENSE_ENDPOINT_DNS", "")
     if not license_dns:
@@ -196,7 +295,7 @@ def _configure_rlm_licensing(versions):
 
     rlm_config = f"{license_dns}:{license_port}"
     for version in versions:
-        install_dir = C4D_INSTALL_PATHS[version]["windows"]
+        install_dir = C4D_INSTALL_PATHS[version][platform_key]
         config_txt = install_dir / "resource" / "config.txt"
         if not config_txt.exists():
             print(f"WARNING: config.txt not found at {config_txt}")
@@ -212,7 +311,19 @@ def _configure_rlm_licensing(versions):
         lines.append(f"g_licenseServerRLM={rlm_config}")
         lines.append(f"g_licenseServerURL={rlm_config}")
         lines.append("g_licenseModel=LICENSEMODEL::RLM")
-        config_txt.write_text("\n".join(lines) + "\n")
+        new_content = "\n".join(lines) + "\n"
+        if platform_key == "macos":
+            # The macOS install dir is owned by root (installed via sudo), so we
+            # write to a temp file first then sudo cp it into place.
+            import tempfile
+
+            tmp = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt")
+            tmp.write(new_content)
+            tmp.close()
+            run(["sudo", "cp", tmp.name, str(config_txt)])
+            os.unlink(tmp.name)
+        else:
+            config_txt.write_text(new_content)
         print(f"Configured RLM licensing ({rlm_config}) in {config_txt}")
 
 
@@ -236,6 +347,8 @@ if __name__ == "__main__":
 
     if system == "Windows":
         setup_windows(args.versions)
+    elif system == "Darwin":
+        setup_macos(args.versions)
     else:
         print(f"Unsupported platform: {system}")
         sys.exit(1)

--- a/test/integ_xa11y/mock_aws/_run_server.py
+++ b/test/integ_xa11y/mock_aws/_run_server.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#!/usr/bin/env python3
+"""Standalone script to run the mock Deadline backend server.
+
+Launched by MockServerProcess via subprocess.Popen. Prints the base_url to
+stdout once the server is ready, then serves until terminated.
+"""
+
+import sys
+from pathlib import Path
+
+# This script lives at test/integ_xa11y/mock_aws/_run_server.py.
+# Add the repo src/ and the integ_xa11y/ dir so imports resolve.
+_repo_root = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_repo_root / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mock_aws.deadline import MockDeadlineBackend, start_server  # noqa: E402
+
+
+def main():
+    response_delay_s = float(sys.argv[1]) if len(sys.argv) > 1 else 0.3
+
+    backend = MockDeadlineBackend(response_delay_s=response_delay_s)
+    backend.log_callback = lambda msg: print(f"[mock-deadline] {msg}", file=sys.stderr, flush=True)
+    server, base_url, _thread = start_server(backend)
+
+    # Signal the parent that we're ready.
+    print(base_url, flush=True)
+
+    # Serve until shutdown.
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integ_xa11y/mock_aws/deadline.py
+++ b/test/integ_xa11y/mock_aws/deadline.py
@@ -364,8 +364,6 @@ def start_server(backend: MockDeadlineBackend, port: int = 0):
     routes = _discover_routes(backend)
     validator = _ResponseValidator()
     handler_cls = _make_handler(routes, validator, backend)
-    # Threading server so the artificial per-response delay represents genuine
-    # per-request latency rather than serializing concurrent submitter calls.
     server = _ThreadingHTTPServer(("127.0.0.1", port), handler_cls)
     actual_port = server.server_address[1]
     thread = _threading.Thread(target=server.serve_forever, daemon=True)

--- a/test/integ_xa11y/mock_aws/server_process.py
+++ b/test/integ_xa11y/mock_aws/server_process.py
@@ -2,72 +2,30 @@
 
 """Run the mock Deadline backend in a separate process.
 
-Why a separate process (not a thread)
---------------------------------------
-The xa11y accessibility library is a native extension (``_native.abi3.so``)
-whose ``wait_visible`` / ``wait_hidden`` poll loops hold the CPython GIL for the
-large majority of their duration (measured: ~13 background-thread ticks during a
-6.4s wait, vs ~64 expected if the GIL were free). The submitter integ test calls
-``wait_hidden(timeout=60s)`` while the queue environments load.
-
-If the mock server runs as a daemon *thread* in the pytest process, that 60s
-native wait starves the server thread: it can barely accept connections, so the
-Cinema 4D subprocess's HTTP calls pile up past the listen backlog and time out,
-the queue-env load never completes, the "Loading Queue Environments..." caption
-never clears, and the wait rides its full 60s. (Tell-tale sign: the server logs
-a served request the instant ``wait_hidden`` returns.)
-
-Running the server in its own process gives it an independent GIL, so it keeps
-serving at full speed no matter what xa11y does on the test side.
-
-Observability across the process boundary
-------------------------------------------
-``call_counts`` / ``request_log`` / ``unmatched_requests`` live in the child
-process now, so the test can't read the backend object directly. The server
-exposes them at ``GET /__admin__/calls``; :class:`RemoteBackend` fetches that
-endpoint on attribute access, so existing assertions
-(``backend.call_counts``, ``backend.unmatched_requests``) keep working.
+Running the server in its own process gives it an independent GIL.
 """
 
 from __future__ import annotations
 
 import json
-import multiprocessing
+import subprocess
+import sys
 import time
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
 from . import fixtures_data as data
 from .deadline import _ADMIN_CALLS_PATH
 
-
-def _serve(response_delay_s: float, port_queue) -> None:
-    """Child-process entrypoint: start the server, report the port, serve forever."""
-    # Imported inside the child so the server module initializes in this process.
-    from .deadline import MockDeadlineBackend, start_server
-
-    backend = MockDeadlineBackend(response_delay_s=response_delay_s)
-    # In-child logging goes to stderr (inherited by the test's captured output).
-    backend.log_callback = lambda msg: print(f"[mock-deadline] {msg}", flush=True)
-    server, base_url, _thread = start_server(backend)
-    port_queue.put(base_url)
-    # Serve until the parent terminates this process.
-    server.serve_forever()
+_SERVER_SCRIPT = Path(__file__).parent / "_run_server.py"
 
 
 class RemoteBackend:
-    """Test-side view of the out-of-process backend.
-
-    Exposes the same attributes the in-process backend did -- ``farm_id``,
-    ``queue_id``, ``call_counts``, ``request_log``, ``unmatched_requests`` --
-    but the observability fields are fetched live from the server's admin
-    endpoint each time they're read.
-    """
+    """Test-side view of the out-of-process backend."""
 
     def __init__(self, base_url: str):
         self.base_url = base_url
-        # Static identifiers mirror the seeded fixtures, so the test can write a
-        # matching deadline config without round-tripping to the server.
         self.farm_id = data.FARM_ID
         self.queue_id = data.QUEUE_ID
 
@@ -90,55 +48,50 @@ class RemoteBackend:
 
 
 class MockServerProcess:
-    """Handle for a mock Deadline server running in a child process.
-
-    Use as a context manager. ``base_url`` is the endpoint to point
-    ``AWS_ENDPOINT_URL_DEADLINE`` at; ``backend`` is a :class:`RemoteBackend`
-    for assertions.
-    """
+    """Handle for a mock Deadline server running in a child process."""
 
     def __init__(self, response_delay_s: float = 0.3):
         self._response_delay_s = response_delay_s
-        # spawn context yields a SpawnProcess; BaseProcess is the common base.
-        self._proc: Optional[multiprocessing.process.BaseProcess] = None
+        self._proc: Optional[subprocess.Popen] = None
         self.base_url: Optional[str] = None
         self.backend: Optional[RemoteBackend] = None
 
     def start(self) -> "MockServerProcess":
-        # 'spawn' so the child is a clean interpreter (no inherited C4D/Qt/xa11y
-        # state, no fork-after-threads hazards) on every platform.
-        ctx = multiprocessing.get_context("spawn")
-        port_queue = ctx.Queue()
-        self._proc = ctx.Process(
-            target=_serve,
-            args=(self._response_delay_s, port_queue),
-            daemon=True,
+        self._proc = subprocess.Popen(
+            [sys.executable, str(_SERVER_SCRIPT), str(self._response_delay_s)],
+            stdout=subprocess.PIPE,
+            stderr=None,
         )
-        self._proc.start()
-        # Wait for the child to bind and report its URL.
-        self.base_url = port_queue.get(timeout=30)
+        # The child prints its base_url on stdout once ready.
+        # NOTE: This readline() has no timeout. Attempts to add one (via
+        # threading.Thread + join(timeout)) caused macOS GitHub runners to hang.
+        assert self._proc.stdout is not None
+        line = self._proc.stdout.readline().decode().strip()
+        if not line or not line.startswith("http"):
+            rc = self._proc.poll()
+            raise RuntimeError(f"Mock server failed to start (got: {line!r}, exitcode={rc})")
+        self.base_url = line
         self.backend = RemoteBackend(self.base_url)
         self._wait_ready()
         return self
 
     def _wait_ready(self, timeout: float = 10.0) -> None:
-        """Block until the admin endpoint answers, so the test never races the
-        server's startup."""
+        assert self.backend is not None
         deadline_t = time.monotonic() + timeout
         last_err: Optional[Exception] = None
         while time.monotonic() < deadline_t:
             try:
-                self.backend._fetch()  # type: ignore[union-attr]
+                self.backend._fetch()
                 return
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 last_err = e
                 time.sleep(0.1)
         raise RuntimeError(f"mock server did not become ready: {last_err!r}")
 
     def stop(self) -> None:
-        if self._proc is not None and self._proc.is_alive():
+        if self._proc is not None and self._proc.poll() is None:
             self._proc.terminate()
-            self._proc.join(timeout=5)
+            self._proc.wait(timeout=5)
         self._proc = None
 
     def __enter__(self) -> "MockServerProcess":

--- a/test/integ_xa11y/utils.py
+++ b/test/integ_xa11y/utils.py
@@ -282,9 +282,11 @@ def assert_expected_job_bundle_and_generated_job_bundle_are_equal(
     # doesn't produce a doubled separator ("Github Repos//deadline-..."). On
     # Windows the doubled separator was masked because replace_backslashes
     # collapses "\\+" to a single "/", but on POSIX the doubled "/" survived.
+    # Use rsplit to handle GitHub Actions paths where the repo name appears
+    # twice (e.g. D:/a/deadline-cloud-for-cinema-4d/deadline-cloud-for-cinema-4d/).
     prefix_path = (
         os.path.abspath(expected_job_bundle_dir_path)
-        .split("deadline-cloud-for-cinema-4d")[0]
+        .rsplit("deadline-cloud-for-cinema-4d", 1)[0]
         .rstrip("/\\")
     )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Running integration tests on Mac Github runners used to hang. 

### What was the solution? (How)

Run the mock Deadline server via subprocess.Popen instead of multiprocessing.spawn: macOS Apple Silicon GitHub runners hang during spawn (botocore service-model loading triggers Gatekeeper scanning in the fresh spawn context). The server still runs in its own process so it has an independent GIL and keeps serving while xa11y native waits hold the GIL on the test side.

### What is the impact of this change?

We can run on Mac Github runners. 

### How was this change tested?

Ran the tests locally in my fork. 

### Was this change documented?

Test changes, no customer impact. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*