### PR TITLE
feat: Run pre-GUI hooks in the Cinema 4D render submitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline[gui] >= 0.59, < 0.61",
+    "deadline[gui] >= 0.60.1, < 0.61",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
     # fonttools is Windows-only due to Cinema 4D technical limitations
     "fonttools >=4.59.2, <4.64; sys_platform == 'win32'",
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gui = [
-    "deadline[gui] >= 0.59, < 0.61",
+    "deadline[gui] >= 0.60.1, < 0.61",
     "PySide6-Essentials == 6.8.3",  # Use 6.8 to align with VFXP 2026: https://vfxplatform.com/#reference-platform
 ]
 

--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import tempfile
+from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,14 +15,21 @@ import yaml  # type: ignore[import]
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt  # type: ignore[attr-defined]
 
+from deadline.client.config import get_setting, str2bool
 from deadline.client.dataclasses import SubmitterInfo
-from deadline.client.exceptions import DeadlineOperationError
+from deadline.client.exceptions import DeadlineOperationCanceled, DeadlineOperationError
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.parameters import JobParameter
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
     JobBundlePurpose,
     SubmitJobToDeadlineDialog,
+)
+from deadline.client.ui.pre_gui_hooks import (
+    PreGuiHookContext,
+    apply_pre_gui_output,
+    qt_hook_confirmation,
+    run_pre_gui_hooks,
 )
 
 from ._version import version_tuple as adaptor_version_tuple
@@ -110,6 +118,10 @@ def show_submitter():
                 )
             else:
                 w = _show_submitter(temp_dir, None)
+            # _show_submitter returns None when the user declines the pre-GUI hook confirmation
+            # prompt; treat that as a normal cancellation and skip showing the dialog.
+            if w is None:
+                return
             w.setStyleSheet(C4D_STYLE)
             w.exec_()
     except Exception:  # noqa: BLE001 - prevent UI failures from escaping into Cinema 4D
@@ -574,6 +586,106 @@ def save_job_bundle_files(
         deadline_yaml_dump(asset_references.to_dict(), f, indent=1)
 
 
+def _restore_pre_gui_hook_sticky_settings(
+    settings: RenderSubmitterUISettings,
+    pre_gui_hook_sticky_reset: dict[str, tuple[Any, Any]] | None,
+) -> dict[str, Any]:
+    """Restore pre-hook baseline values for sticky fields a pre-GUI hook overwrote.
+
+    ``pre_gui_hook_sticky_reset`` maps each sticky field a pre-GUI hook overwrote to
+    ``(pre_hook_value, hook_value)``. For each, restore the pre-hook value unless the user changed
+    the field in the dialog -- in that case the current value differs from what the hook applied,
+    so we keep the user's value. Hook output therefore stays scoped to the session: it never
+    persists as a stale default after the hook is disabled, nor feeds back as ``jobName`` on the
+    next launch.
+
+    Returns the ``{field_name: hook_value}`` it reset to baseline, so the caller can reapply the
+    hook values after the sticky write and avoid leaving the live ``settings`` object mutated (see
+    :func:`_pre_gui_hook_sticky_baseline`).
+    """
+    if not pre_gui_hook_sticky_reset:
+        return {}
+    restored: dict[str, Any] = {}
+    for field_name, (baseline_value, hook_value) in pre_gui_hook_sticky_reset.items():
+        if getattr(settings, field_name) == hook_value:
+            setattr(settings, field_name, baseline_value)
+            restored[field_name] = hook_value
+    return restored
+
+
+# deadline-cloud's shared-settings tab (SharedJobPropertiesWidget) writes these "deadline:*" job
+# properties onto the matching sticky RenderSubmitterUISettings fields when it gathers settings on
+# Export/Submit. A pre-GUI hook only ever puts them in the shared parameter values (not directly on
+# the settings object), so a hook emitting e.g. deadline:priority would otherwise persist into the
+# scene's sticky settings exactly as an unscoped name/description would. This maps each such shared
+# key to its sticky field so both are scoped out of the sticky write together.
+_HOOK_STICKY_SHARED_PARAM_FIELDS = {
+    "deadline:priority": "priority",
+    "deadline:targetTaskRunStatus": "initial_status",
+    "deadline:maxFailedTasksCount": "max_failed_tasks_count",
+    "deadline:maxRetriesPerTask": "max_retries_per_task",
+    "deadline:maxWorkerCount": "max_worker_count",
+}
+
+
+def _compute_pre_gui_hook_sticky_reset(
+    settings: RenderSubmitterUISettings,
+    name_description_baseline: dict[str, Any],
+    shared_before: dict[str, Any],
+    shared_after: dict[str, Any],
+) -> dict[str, tuple[Any, Any]]:
+    """Build the ``{sticky_field: (pre_hook_value, hook_value)}`` map of every sticky field a
+    pre-GUI hook changed, so create_job_bundle can keep the hook's values out of the sticky write.
+
+    Two routes a hook reaches a sticky field:
+
+    * ``name`` / ``description`` are set directly on ``settings`` by ``apply_pre_gui_output`` —
+      detected by diffing ``name_description_baseline`` (snapshotted before the hook) against the
+      current value.
+    * ``deadline:*`` job properties are routed into the shared parameter values instead; the shared
+      settings tab later writes them onto the matching sticky field (see
+      ``_HOOK_STICKY_SHARED_PARAM_FIELDS``). Each such key the hook added or changed
+      (``shared_before`` -> ``shared_after``) is recorded against its field, with the hook's value
+      so a later user edit in the dialog (current value != hook value) is still kept.
+
+    The baseline for a shared-param field is the field's current value on ``settings``, which
+    ``apply_pre_gui_output`` does not touch — so it is still the pre-hook (scene/sticky) value.
+    """
+    reset: dict[str, tuple[Any, Any]] = {}
+    for attr, baseline in name_description_baseline.items():
+        current = getattr(settings, attr)
+        if current != baseline:
+            reset[attr] = (baseline, current)
+    for shared_key, field_name in _HOOK_STICKY_SHARED_PARAM_FIELDS.items():
+        if shared_key in shared_after and shared_after[shared_key] != shared_before.get(shared_key):
+            reset[field_name] = (getattr(settings, field_name), shared_after[shared_key])
+    return reset
+
+
+@contextmanager
+def _pre_gui_hook_sticky_baseline(
+    settings: RenderSubmitterUISettings,
+    pre_gui_hook_sticky_reset: dict[str, tuple[Any, Any]] | None,
+):
+    """Scope the pre-GUI hook sticky-settings reset to the ``save_sticky_settings`` call only.
+
+    Restores pre-hook baselines for the sticky write, then reapplies the hook values so the live
+    ``settings`` object is unchanged on exit. ``on_create_job_bundle_callback`` runs once per
+    Export/Submit against the dialog's *live* settings object (not a per-call copy), so permanently
+    resetting ``name``/``description`` to baseline would make a second action in the same session
+    build its job from the scene-derived value instead of the hook's -- two different job names for
+    two identical clicks, with the dialog still showing the first. Keeping the reset scoped to the
+    sticky write leaves the in-memory settings exactly as the user saw them, while the persisted
+    sticky settings still exclude the hook output.
+    """
+    restored = _restore_pre_gui_hook_sticky_settings(settings, pre_gui_hook_sticky_reset)
+    try:
+        yield
+    finally:
+        for field_name, hook_value in restored.items():
+            setattr(settings, field_name, hook_value)
+
+
 def create_job_bundle(
     settings: RenderSubmitterUISettings,
     takes: dict[str, list[TakeData]],
@@ -583,6 +695,7 @@ def create_job_bundle(
     attachments: AssetReferences,
     temp_dir: str | None = None,
     host_requirements: dict | None = None,
+    pre_gui_hook_sticky_reset: dict[str, tuple[Any, Any]] | None = None,
 ) -> dict[str, Any]:
     """
     Creates a job bundle and saves sticky settings for rendering.
@@ -671,7 +784,11 @@ def create_job_bundle(
     settings.input_filenames = sorted(attachments.input_filenames)
     settings.input_directories = sorted(attachments.input_directories)
 
-    settings.save_sticky_settings(Scene.name())
+    # Keep pre-GUI hook output out of the persisted sticky settings (the job template above already
+    # captured the effective name/description). Scope the reset to the sticky write only, so the
+    # live settings object keeps the hook values for any later action in the same dialog session.
+    with _pre_gui_hook_sticky_baseline(settings, pre_gui_hook_sticky_reset):
+        settings.save_sticky_settings(Scene.name())
 
     return {
         "known_asset_paths": [
@@ -943,6 +1060,19 @@ def export_to_temp_folder(temp_dir: str, asset_references: AssetReferences) -> N
     asset_references.input_filenames = temp_assets
 
 
+def _pre_gui_hook_confirm_callback(parent):
+    """Choose the confirmation callback for pre-GUI hooks based on the auto_accept setting.
+
+    Returns ``None`` (run hooks without prompting) when ``settings.auto_accept`` is enabled,
+    otherwise the standard Qt confirmation dialog from ``qt_hook_confirmation``. Kept as a small
+    helper so the auto_accept branch can be unit-tested headlessly.
+    """
+    if str2bool(get_setting("settings.auto_accept")):
+        return None
+
+    return qt_hook_confirmation(parent)
+
+
 def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowType.Tool):  # type: ignore[call-overload]
     """
     Creates and returns a submission dialog for rendering jobs.
@@ -991,6 +1121,11 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowType.Tool):  # type: 
         additional_info=additional_info,
     )
 
+    # Maps each sticky field a pre-GUI hook overwrites -> (pre-hook value, hook value). Populated
+    # after the hooks run below and passed to create_job_bundle, which uses it to keep hook output
+    # out of the persisted sticky settings. See the block near apply_pre_gui_output.
+    pre_gui_hook_sticky_reset: dict[str, tuple[Any, Any]] = {}
+
     def on_create_job_bundle_callback(
         widget: SubmitJobToDeadlineDialog,
         job_bundle_dir: str,
@@ -1026,14 +1161,61 @@ def _show_submitter(temp_dir: str, parent=None, f=Qt.WindowType.Tool):  # type: 
             widget.job_attachments.attachments,
             temp_dir,
             host_requirements,
+            pre_gui_hook_sticky_reset=pre_gui_hook_sticky_reset,
         )
+
+    shared_parameter_values = {
+        "CondaPackages": conda_packages,
+    }
+
+    # Run pre-GUI hooks so studios can pre-populate dialog fields before it opens. Cinema 4D has
+    # no on-disk job bundle at this point, so hooks are sourced from DEADLINE_HOOKS_DIR only
+    # (bundle_dir=None), gated by settings.allow_environment_hooks. The confirmation prompt is
+    # skipped when auto_accept is set; otherwise the standard dialog is shown.
+    try:
+        pre_gui_output = run_pre_gui_hooks(
+            PreGuiHookContext(
+                bundle_dir=None,
+                job_name=render_settings.name,
+                submitter_name="cinema4d",
+                parameters=dict(shared_parameter_values),
+            ),
+            confirm_callback=_pre_gui_hook_confirm_callback(parent),
+        )
+    except DeadlineOperationCanceled:
+        # The user declined the hook confirmation prompt. This is a normal cancellation, not an
+        # error, so abort opening the submitter silently by returning None; show_submitter skips
+        # the dialog. Without this, the exception would surface as a spurious "Deadline UI launch
+        # failed" error for what is a deliberate "No" click.
+        return None
+    # RenderSubmitterUISettings has no `.parameters` list, so apply_pre_gui_output routes
+    # name/description onto it and every hook parameter into shared_parameter_values.
+    # run_pre_gui_hooks returns {} when no hooks run (and raises DeadlineOperationCanceled, handled
+    # above, if the user declines); `or {}` is defensive against any future contract change so the
+    # common no-hooks path can never pass a falsy value into apply_pre_gui_output.
+    #
+    # name/description (and deadline:* job properties routed through shared_parameter_values) are
+    # sticky settings (data_classes.py). Snapshot the pre-hook (scene/sticky) state first, then
+    # record what the hook actually changed so create_job_bundle can scope those to this session
+    # (keep them out of the sticky write). This stops hook output from persisting as a stale default
+    # once the hook is disabled and from feeding back on the next launch, while any edit the user
+    # makes in the dialog still persists. See _compute_pre_gui_hook_sticky_reset.
+    name_description_baseline = {
+        attr: getattr(render_settings, attr) for attr in ("name", "description")
+    }
+    shared_values_before_hook = dict(shared_parameter_values)
+    apply_pre_gui_output(pre_gui_output or {}, render_settings, shared_parameter_values)
+    pre_gui_hook_sticky_reset = _compute_pre_gui_hook_sticky_reset(
+        render_settings,
+        name_description_baseline,
+        shared_values_before_hook,
+        shared_parameter_values,
+    )
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,
         initial_job_settings=render_settings,
-        initial_shared_parameter_values={
-            "CondaPackages": conda_packages,
-        },
+        initial_shared_parameter_values=shared_parameter_values,
         auto_detected_attachments=auto_detected_attachments,
         attachments=attachments,
         on_create_job_bundle_callback=on_create_job_bundle_callback,

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -372,6 +372,28 @@ the mock logs `404 NO ROUTE`). Add a `@route`-decorated handler in
 resource data, extend `MockDeadlineScenario` there. Keep DCC-specific launch
 behavior in this repository.
 
+**Pre-GUI hook case (`test_pre_gui_hook`):** this one does *not* use the `_CASES`
+/ golden-bundle model — it's a standalone test asserting only the fields a
+pre-GUI hook owns. The hook script `fixtures/pregui_hooks/pregui_hook.py` reads
+the job metadata on stdin and emits `name` / `description` / `parameters` as JSON
+on stdout. Its `hooks.yaml` (version `"1.0"`) is *not* committed: the test
+generates it per-run (`_materialize_pregui_hooks_dir`) with `command` set to
+`sys.executable`, because deadline-cloud resolves a hook `command` via absolute
+path / hooks-dir / `shutil.which` with no env-var expansion, so a static `python`
+isn't a portable interpreter (absent on macOS; PATH-dependent everywhere) and the
+hook would silently not run. The test enables `settings.allow_environment_hooks`
+(so the submitter sources `DEADLINE_HOOKS_DIR`) and `settings.auto_accept` (so
+hooks run without the Qt confirmation prompt) in the config the `deadline_farm`
+fixture wrote, points `DEADLINE_HOOKS_DIR` at that generated dir via the launch
+env, Exports, then asserts a marker file proves the hook actually ran before
+asserting the emitted `name`/`description` reached `template.yaml` and
+`deadline:priority` reached `parameter_values.yaml` (the marker separates "hook
+never launched" from "hook ran but output wasn't wired in"). To change what the
+hook injects, edit `pregui_hook.py` and the `_HOOK_*` constants in
+`test_cinema4d.py` together (they're the paired source of truth). It has no
+`expected/job_bundle/` and never renders, so it needs no golden capture and runs
+on macOS too.
+
 ## Installer Tests
 
 Test the built installer. Requires having run `hatch run installer:build-installer` first.

--- a/test/integ/fixtures/pregui_hooks/pregui_hook.py
+++ b/test/integ/fixtures/pregui_hooks/pregui_hook.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Pre-GUI hook fixture for the Cinema 4D xa11y integ test.
+
+deadline-cloud runs this as a subprocess before the submitter dialog is built (see
+``deadline.client.ui.pre_gui_hooks.run_pre_gui_hooks``). It receives the job metadata as JSON on
+stdin and returns the merged pre-GUI output as JSON on stdout: ``name`` / ``description`` land on
+the submitter's settings object, and every key under ``parameters`` flows into the dialog's shared
+parameter values (``deadline:priority`` sets the Priority field).
+
+The test asserts the exported job bundle reflects exactly these values, proving the C4D submitter
+wires ``run_pre_gui_hooks`` + ``apply_pre_gui_output`` correctly (PR #480). This case has no
+``expected/job_bundle/`` golden dir; the assertions compare against the ``_HOOK_*`` constants in
+``test/integ/test_cinema4d.py`` instead, so keep the emitted values in sync with those constants.
+
+The test also sets ``DEADLINE_CLOUD_PREGUI_MARKER``; when present this script writes that file, so
+the test can assert the hook actually ran (separately from asserting its output was applied).
+"""
+
+import json
+import os
+import sys
+
+# Consume the metadata C4D passes on stdin (jobName, parameters, submitterName, ...). We do not
+# branch on it here — the point of the fixture is a deterministic, asserted output — but reading it
+# keeps the subprocess contract honest (a real hook would use it). A malformed/empty stdin is not a
+# failure for this fixture: it still emits the fixed output below, so we deliberately ignore a
+# decode error rather than abort.
+try:
+    json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # No usable metadata on stdin; the fixture's output does not depend on it, so continue.
+    pass
+
+# Signal that this hook actually executed. The integ test points DEADLINE_CLOUD_PREGUI_MARKER at a
+# path it checks after export, so a run that yields the wrong bundle can be told apart as "the hook
+# never launched" (discovery / interpreter resolution failure) rather than "the hook ran but its
+# output wasn't wired in". Best-effort: marker I/O must never break the hook's stdout contract.
+_marker = os.environ.get("DEADLINE_CLOUD_PREGUI_MARKER")
+if _marker:
+    try:
+        with open(_marker, "w", encoding="utf-8") as _fh:
+            _fh.write("ran")
+    except OSError:
+        # The marker is best-effort diagnostics; a filesystem error writing it must not change the
+        # hook's stdout contract, so the failure is intentionally ignored.
+        pass
+
+output = {
+    "name": "PREGUI RAN",
+    "description": "populated by pre-GUI hook",
+    "parameters": {
+        "deadline:priority": 88,
+    },
+}
+
+json.dump(output, sys.stdout)

--- a/test/integ/test_cases/pregui_hook/input/scene.py
+++ b/test/integ/test_cases/pregui_hook/input/scene.py
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Build the scene for the pre-GUI hook integ case and save it.
+
+Usage: c4dpy scene.py <scene_dir>
+
+Mirrors the ``cube`` case's scene, but this case never renders (the pre-GUI hook
+test only exports a job bundle and asserts its metadata), so it omits the
+render-data setup. The submitter still needs a saved document with a path, which
+the test's sidecar plugin loads before opening the dialog.
+"""
+
+import os
+import sys
+
+import c4d
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: c4dpy scene.py <scene_dir>", file=sys.stderr)
+        return 2
+
+    scene_dir = sys.argv[1]
+    os.makedirs(scene_dir, exist_ok=True)
+
+    doc = c4d.documents.GetActiveDocument()
+    doc.Flush()
+
+    cube = c4d.BaseObject(c4d.Ocube)
+    cube[c4d.PRIM_CUBE_LEN] = c4d.Vector(200, 200, 200)
+    cube.SetAbsPos(c4d.Vector(0, 100, 0))
+    doc.InsertObject(cube)
+
+    scene_name = "pregui_hook.c4d"
+    scene_path = os.path.join(scene_dir, scene_name)
+    doc.SetDocumentPath(scene_dir)
+    doc.SetDocumentName(scene_name)
+    c4d.documents.SaveDocument(doc, scene_path, c4d.SAVEDOCUMENTFLAGS_0, c4d.FORMAT_C4DEXPORT)
+    c4d.EventAdd()
+
+    print(f"saved: {scene_path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/integ/test_cinema4d.py
+++ b/test/integ/test_cinema4d.py
@@ -20,6 +20,7 @@ from deadline_test_fixtures.xa11y import (
     SharedSubmitterDialog,
     find_accessibility_app,
 )
+from yaml import safe_dump, safe_load
 
 from .utils import (
     assert_all_images_close,
@@ -142,6 +143,7 @@ def _build_launch_env(
     scene_path: Path,
     plugin_diag_log: Path,
     mock_env_overlay: dict,
+    extra_env: dict | None = None,
 ) -> dict:
     """Build the environment for the Cinema 4D subprocess.
 
@@ -151,8 +153,12 @@ def _build_launch_env(
     opt-out, isolated HOME, the temp deadline config path, and the mock-mode flag
     that switches on the sidecar's ``management.`` getaddrinfo redirect. So the
     submitter talks to the local mock, never real AWS.
+
+    ``extra_env`` overlays case-specific variables (e.g. ``DEADLINE_HOOKS_DIR`` for
+    the pre-GUI hook case) last, so a case can add to — or deliberately override —
+    the base launch env.
     """
-    return {
+    env = {
         **mock_env_overlay,
         # Point C4D at two plugin dirs: the real submitter plugin checked into
         # this repo, and the test-only sidecar that auto-opens the submitter.
@@ -187,6 +193,43 @@ def _build_launch_env(
         # opens.
         "DEADLINE_CLOUD_SCENE_PATH": str(scene_path),
     }
+    if extra_env:
+        env.update(extra_env)
+    return env
+
+
+def _enable_environment_hooks(env_overlay: dict) -> None:
+    """Turn on the two settings the pre-GUI hook path needs, in the deadline config
+    the ``deadline_farm`` fixture wrote.
+
+    ``run_pre_gui_hooks`` only sources ``DEADLINE_HOOKS_DIR`` when
+    ``settings.allow_environment_hooks`` is ``true``; both default to ``false``.
+    ``settings.auto_accept`` = ``true`` makes ``_pre_gui_hook_confirm_callback``
+    return ``None`` so hooks run without the Qt confirmation prompt — the prompt's
+    behaviour is covered by the unit tests, and skipping it keeps this UI test
+    focused on the export-output contract.
+
+    We write through ``deadline.client.config.set_setting`` rather than editing the
+    INI by hand: it resolves the correct (possibly profile-scoped) section for each
+    setting, validates the setting name against the installed deadline-cloud, and
+    avoids ``ConfigParser``'s default ``%`` interpolation mangling unrelated values
+    on rewrite. ``set_setting`` targets the file named by ``DEADLINE_CONFIG_FILE_PATH``,
+    so we point that at the overlay's config for the duration of the writes.
+    """
+    from deadline.client import config
+
+    config_path = env_overlay["DEADLINE_CONFIG_FILE_PATH"]
+    prev = os.environ.get("DEADLINE_CONFIG_FILE_PATH")
+    os.environ["DEADLINE_CONFIG_FILE_PATH"] = str(config_path)
+    try:
+        config.set_setting("settings.allow_environment_hooks", "true")
+        config.set_setting("settings.auto_accept", "true")
+    finally:
+        if prev is None:
+            os.environ.pop("DEADLINE_CONFIG_FILE_PATH", None)
+        else:
+            os.environ["DEADLINE_CONFIG_FILE_PATH"] = prev
+    log(f"enabled allow_environment_hooks + auto_accept in {config_path}")
 
 
 def _launch_cinema4d(cinema4d_gui_exe: Path, scene_path: Path, env: dict) -> subprocess.Popen:
@@ -472,9 +515,14 @@ def _export_job_bundle_via_submitter(
     job_bundle_generated: Path,
     deadline_farm: dict,
     configure: DialogConfigurator | None = None,
+    extra_env: dict | None = None,
 ) -> None:
     """Launch Cinema 4D, drive the real submitter UI to export a job bundle,
     and copy the bundle files flat into `job_bundle_generated`.
+
+    ``extra_env`` is overlaid onto the C4D launch environment (see
+    ``_build_launch_env``); the pre-GUI hook case uses it to set
+    ``DEADLINE_HOOKS_DIR``.
 
     The submitter exports via create_job_history_bundle_dir, which always
     writes under <history_dir>/<YYYY-mm>/<bundle-name>/. The history dir is set
@@ -492,7 +540,9 @@ def _export_job_bundle_via_submitter(
     plugin_diag_log = bundle_staging / "plugin-diag.log"
     log(f"bundle staging dir: {bundle_staging}; job history dir: {history_dir}")
     try:
-        env = _build_launch_env(scene_path, plugin_diag_log, deadline_farm["env_overlay"])
+        env = _build_launch_env(
+            scene_path, plugin_diag_log, deadline_farm["env_overlay"], extra_env=extra_env
+        )
         proc = _launch_cinema4d(cinema4d_gui_exe, scene_path, env)
         try:
             staged_bundle = _drive_submitter_ui(proc, history_dir, configure=configure)
@@ -715,3 +765,151 @@ def test_job_specific_take_selection(
         configure_kwargs={"selection": selection},
         scene_args=(expected_variant,),
     )
+
+
+# The committed pre-GUI hook script. Its hooks.yaml is NOT committed: it is generated per-run by
+# _materialize_pregui_hooks_dir so the hook's `command` can be this interpreter's absolute path
+# (see that helper for why a static `command` is not portable). DEADLINE_HOOKS_DIR points at the
+# generated dir; the run is gated by settings.allow_environment_hooks.
+_PREGUI_HOOK_SCRIPT = Path(__file__).parent / "fixtures" / "pregui_hooks" / "pregui_hook.py"
+
+# The values pregui_hook.py emits. Kept next to the test as the single source of truth for the
+# assertions; must match that script.
+_HOOK_JOB_NAME = "PREGUI RAN"
+_HOOK_DESCRIPTION = "populated by pre-GUI hook"
+_HOOK_PRIORITY = 88
+
+
+def _materialize_pregui_hooks_dir(dest: Path) -> None:
+    """Write a ``hooks.yaml`` under ``dest`` that runs the committed ``pregui_hook.py`` with the
+    interpreter currently running the tests (``sys.executable``).
+
+    The manifest cannot be a static committed file with a portable ``command``. deadline-cloud
+    resolves a hook ``command`` as an absolute path, then relative to the hooks dir, then via
+    ``shutil.which`` on PATH (``deadline.client.job_bundle._hooks._executor``) — it does not expand
+    environment variables. A bare ``python`` is not a reliable interpreter name: on macOS only
+    ``python3`` exists (the system ``python`` went away with Python 2), and on every platform
+    whether it resolves depends on the PATH Cinema 4D happened to inherit, not on this fixture. When
+    it fails to resolve, the hook silently never runs and the failure surfaces as the value
+    assertions below failing rather than a clear "hook could not be launched".
+
+    Writing ``sys.executable`` (an absolute path that exists on this machine — and ``pregui_hook.py``
+    needs only the stdlib, so any interpreter works) makes the hook resolve on every platform.
+    ``args`` references the committed script by absolute path, so only ``hooks.yaml`` lives here.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "version": "1.0",
+        "preGUI": [
+            {
+                "command": sys.executable,
+                "args": [str(_PREGUI_HOOK_SCRIPT)],
+                "timeout": 60,
+            }
+        ],
+    }
+    (dest / "hooks.yaml").write_text(safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+
+def _bundle_parameter_values(actual_dir: Path) -> dict:
+    """Read the exported bundle's parameter_values.yaml into a {name: value} dict."""
+    params_file = actual_dir / "parameter_values.yaml"
+    values = safe_load(params_file.read_text(encoding="utf-8"))["parameterValues"]
+    return {v["name"]: v["value"] for v in values}
+
+
+def test_pre_gui_hook(
+    cinema4d_location: Path,
+    test_cases_folder_location: Path,
+    deadline_farm: dict,
+) -> None:
+    """A pre-GUI hook pre-populates the submitter dialog before it opens (PR #480).
+
+    This is the GUI counterpart to the headless ``test_pre_gui_hooks`` unit tests: those check the
+    ``apply_pre_gui_output`` mapping in isolation, whereas this drives the *real* submitter end to
+    end and proves the wiring holds through an actual export. It launches Cinema 4D with
+    ``DEADLINE_HOOKS_DIR`` pointing at a per-run hooks dir (see ``_materialize_pregui_hooks_dir``)
+    and ``allow_environment_hooks`` / ``auto_accept`` enabled, so the shipped submitter runs the
+    hook (``run_pre_gui_hooks``) before building the dialog and applies its output
+    (``apply_pre_gui_output``). A marker file proves the hook actually ran. The hook emits a fixed
+    name, description, and ``deadline:priority``; the same Export path the render cases use then
+    writes a job bundle, and we assert those three values survived into it:
+
+      * ``name`` / ``description`` -> template.yaml (they land on the settings object, which the
+        submitter writes to the job template).
+      * ``deadline:priority`` -> parameter_values.yaml (hook parameters flow into the dialog's
+        shared parameter values).
+
+    Unlike the standard cases this one never renders and does no golden-bundle diff: the hook path
+    is orthogonal to render output, and asserting just the three hook-owned fields keeps the test
+    robust to unrelated bundle changes. It runs on Windows and macOS (submitter-only; no openjd).
+    """
+    case = "pregui_hook"
+    case_folder, actual_dir = _prepare_actual_dir(test_cases_folder_location, case)
+
+    scene_path = _build_cinema4d_scene(cinema4d_location, case_folder, actual_dir, case)
+
+    # Enable the env-hook path in the config the fixture wrote.
+    _enable_environment_hooks(deadline_farm["env_overlay"])
+
+    # Generate the hooks dir (so `command` is sys.executable, resolvable on every platform) and
+    # give the hook a marker path so we can prove it actually ran. The dir is temporary and always
+    # cleaned up; on failure `actual_dir` (below) is what stays behind for inspection.
+    hooks_dir = Path(tempfile.mkdtemp(prefix="c4d-pregui-hooks-"))
+    marker_path = hooks_dir / "hook_ran.marker"
+    try:
+        _materialize_pregui_hooks_dir(hooks_dir)
+
+        _export_job_bundle_via_submitter(
+            cinema4d_location=cinema4d_location,
+            scene_path=scene_path,
+            job_bundle_generated=actual_dir,
+            deadline_farm=deadline_farm,
+            configure=None,
+            extra_env={
+                "DEADLINE_HOOKS_DIR": str(hooks_dir),
+                "DEADLINE_CLOUD_PREGUI_MARKER": str(marker_path),
+            },
+        )
+
+        # The submitter reached the mock, not real AWS. The hook itself is a local subprocess that
+        # runs before any AWS call, so no new mock routes are needed; still confirm nothing hit an
+        # unmocked route (a hook misfire that changed the submit path would surface here).
+        backend = deadline_farm["backend"]
+        log(f"mock backend call_counts: {dict(backend.call_counts)}")
+        assert (
+            backend.unmatched_requests == []
+        ), f"submitter hit routes the mock doesn't implement: {backend.unmatched_requests}"
+
+        # Prove the hook subprocess ran at all before trusting the exported values. This separates
+        # "the hook never launched" (discovery / interpreter resolution failure) from "the hook ran
+        # but its output wasn't wired into the bundle" — the value assertions below can't tell those
+        # two apart on their own.
+        assert marker_path.is_file(), (
+            f"pre-GUI hook never ran: no marker at {marker_path} (DEADLINE_HOOKS_DIR={hooks_dir}). "
+            "The submitter didn't execute the hook subprocess — look at hook discovery / "
+            "interpreter resolution, not the output-mapping wiring."
+        )
+
+        # The exported bundle must carry the hook's output.
+        assert_valid_job_bundle(actual_dir / "template.yaml")
+        template = safe_load((actual_dir / "template.yaml").read_text(encoding="utf-8"))
+        params = _bundle_parameter_values(actual_dir)
+
+        assert template.get("name") == _HOOK_JOB_NAME, (
+            f"pre-GUI hook ran but its name did not reach the bundle: template name is "
+            f"{template.get('name')!r}, expected {_HOOK_JOB_NAME!r}"
+        )
+        assert template.get("description") == _HOOK_DESCRIPTION, (
+            f"pre-GUI hook ran but its description did not reach the bundle: template description is "
+            f"{template.get('description')!r}, expected {_HOOK_DESCRIPTION!r}"
+        )
+        assert params.get("deadline:priority") == _HOOK_PRIORITY, (
+            f"pre-GUI hook ran but its priority did not reach the bundle: parameter_values has "
+            f"{params.get('deadline:priority')!r}, expected {_HOOK_PRIORITY}"
+        )
+
+        # Clean up if the test was successful
+        rmtree(actual_dir, ignore_errors=True)
+    finally:
+        rmtree(hooks_dir, ignore_errors=True)

--- a/test/unit/deadline_submitter_for_cinema4d/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_pre_gui_hooks.py
@@ -1,0 +1,329 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for the Cinema 4D submitter's pre-GUI hook integration.
+
+``_show_submitter`` calls deadline-cloud's ``run_pre_gui_hooks`` (env-only, since Cinema 4D has
+no on-disk bundle at pre-GUI time) and then applies the merged output with deadline-cloud's
+generic ``apply_pre_gui_output``. The full submitter needs a running Cinema 4D, so it is
+exercised in the integration suite; here we verify the DCC-owned pieces headless:
+
+* ``apply_pre_gui_output`` routes hook output correctly against Cinema 4D's own
+  ``RenderSubmitterUISettings`` — which has no ``.parameters`` list, so every hook parameter must
+  land in the shared parameter values (name/description land on the settings object). This guards
+  against a regression where ``RenderSubmitterUISettings`` gains a ``parameters`` attribute that
+  would misroute hook params.
+* ``_pre_gui_hook_confirm_callback`` honours the ``settings.auto_accept`` setting.
+
+The c4d / Qt modules are stubbed by ``test/unit/deadline_submitter_for_cinema4d/__init__`` so
+the module imports.
+"""
+
+from unittest.mock import patch
+
+from deadline.cinema4d_submitter import cinema4d_render_submitter
+from deadline.cinema4d_submitter.data_classes import RenderSubmitterUISettings
+from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
+
+
+def _settings() -> RenderSubmitterUISettings:
+    s = RenderSubmitterUISettings()
+    s.name = "Original"
+    s.description = ""
+    return s
+
+
+def test_name_and_description_applied_to_settings():
+    """A hook's name/description overwrite the settings fields (C4D has no .parameters list,
+    so these land directly on the dataclass)."""
+    settings = _settings()
+    shared = {"CondaPackages": "cinema4d=2026.* cinema4d-openjd=0.1.*"}
+
+    apply_pre_gui_output({"name": "PREGUI RAN", "description": "from pipeline"}, settings, shared)
+
+    assert settings.name == "PREGUI RAN"
+    assert settings.description == "from pipeline"
+
+
+def test_hook_parameters_flow_to_shared_values():
+    """C4D's RenderSubmitterUISettings has no .parameters list, so every hook parameter (queue
+    params, deadline: properties) lands in the shared values the dialog is seeded with,
+    overriding the C4D-computed defaults on key collision."""
+    settings = _settings()
+    shared = {"CondaPackages": "cinema4d=2026.* cinema4d-openjd=0.1.*"}
+
+    apply_pre_gui_output(
+        {
+            "parameters": {
+                "deadline:priority": 88,
+                "CondaPackages": "cinema4d=2026.* custom_pkg",  # overrides the default
+            }
+        },
+        settings,
+        shared,
+    )
+
+    assert shared["deadline:priority"] == 88
+    assert shared["CondaPackages"] == "cinema4d=2026.* custom_pkg"
+
+
+def test_empty_output_is_a_noop():
+    """No pre-GUI hook output leaves the settings and shared values unchanged."""
+    settings = _settings()
+    shared = {"CondaPackages": "pkg"}
+
+    apply_pre_gui_output({}, settings, shared)
+
+    assert settings.name == "Original"
+    assert settings.description == ""
+    assert shared == {"CondaPackages": "pkg"}
+
+
+def test_falsy_output_is_a_noop():
+    """The submitter passes ``pre_gui_output or {}`` into apply_pre_gui_output, so the values
+    run_pre_gui_hooks can actually produce for the no-hooks path — ``{}`` today, or ``None`` if
+    the contract ever changed — must both be safe no-ops that leave settings/shared untouched."""
+    falsy_values: list[dict | None] = [{}, None]
+    for falsy in falsy_values:
+        settings = _settings()
+        shared = {"CondaPackages": "cinema4d=2026.* cinema4d-openjd=0.1.*"}
+
+        # Mirror the submitter call site: `pre_gui_output or {}`.
+        apply_pre_gui_output(falsy or {}, settings, shared)
+
+        assert settings.name == "Original"
+        assert settings.description == ""
+        assert shared == {"CondaPackages": "cinema4d=2026.* cinema4d-openjd=0.1.*"}
+
+
+def test_partial_output_only_touches_present_keys():
+    """Only the keys present in the output are applied; others keep their prior values."""
+    settings = _settings()
+    settings.description = "keep me"
+    shared: dict = {}
+
+    apply_pre_gui_output({"name": "NewName"}, settings, shared)
+
+    assert settings.name == "NewName"
+    assert settings.description == "keep me"  # not overwritten
+    assert shared == {}  # no parameters in output
+
+
+def test_hook_sticky_settings_reset_to_baseline_when_user_did_not_edit():
+    """A pre-GUI hook that overwrote name/description must not leave those values in the scene's
+    sticky settings. If the field still holds the hook's value at save time (the user left it
+    untouched), it is restored to the pre-hook baseline so hook output stays scoped to the session
+    -- otherwise it would persist after the hook is disabled and feed back as ``jobName`` next
+    launch (PR #480)."""
+    settings = _settings()
+    settings.name = "PREGUI RAN"  # what the hook applied and the user left untouched
+    settings.description = "from hook"
+
+    cinema4d_render_submitter._restore_pre_gui_hook_sticky_settings(
+        settings,
+        {"name": ("Original", "PREGUI RAN"), "description": ("", "from hook")},
+    )
+
+    assert settings.name == "Original"
+    assert settings.description == ""
+
+
+def test_hook_sticky_settings_keep_user_edits():
+    """If the user edited a hook-populated field in the dialog, that edit -- not the pre-hook
+    baseline -- persists, because its current value differs from what the hook applied."""
+    settings = _settings()
+    settings.name = "MyShot_v2"  # user overrode the hook's "PREGUI RAN"
+    settings.description = "from hook"  # left as the hook set it
+
+    cinema4d_render_submitter._restore_pre_gui_hook_sticky_settings(
+        settings,
+        {"name": ("Original", "PREGUI RAN"), "description": ("", "from hook")},
+    )
+
+    assert settings.name == "MyShot_v2"  # user edit kept
+    assert settings.description == ""  # untouched hook value scoped back out
+
+
+def test_hook_sticky_settings_noop_without_reset_map():
+    """No hook overwrote a sticky field (empty or None map) -> settings are left untouched, so the
+    common no-hooks path persists exactly what the dialog produced."""
+    reset: dict | None
+    for reset in ({}, None):
+        settings = _settings()
+        settings.name = "Whatever"
+        settings.description = "desc"
+
+        cinema4d_render_submitter._restore_pre_gui_hook_sticky_settings(settings, reset)
+
+        assert settings.name == "Whatever"
+        assert settings.description == "desc"
+
+
+def test_restore_pre_gui_hook_sticky_settings_returns_reset_fields():
+    """The restore helper reports which fields it reset to baseline, so the caller can reapply the
+    hook values afterwards. A field the user edited is not reset and so is not reported."""
+    settings = _settings()
+    settings.name = "PREGUI RAN"  # hook value, user left it
+    settings.description = "MyEdit"  # user overrode the hook's "from hook"
+
+    restored = cinema4d_render_submitter._restore_pre_gui_hook_sticky_settings(
+        settings,
+        {"name": ("Original", "PREGUI RAN"), "description": ("", "from hook")},
+    )
+
+    assert restored == {"name": "PREGUI RAN"}  # only the un-edited field was reset
+    assert settings.name == "Original"
+    assert settings.description == "MyEdit"
+
+
+def test_sticky_baseline_context_restores_for_write_then_reapplies():
+    """Inside the context the sticky-write sees the pre-hook baseline; on exit the live settings
+    object is restored to the hook values, so a second Export/Submit in the same session still
+    builds its job from what the user saw (regression guard for the in-place mutation bug)."""
+    settings = _settings()
+    settings.name = "PREGUI RAN"
+    settings.description = "from hook"
+    reset = {"name": ("Original", "PREGUI RAN"), "description": ("", "from hook")}
+
+    seen_during_write = {}
+    with cinema4d_render_submitter._pre_gui_hook_sticky_baseline(settings, reset):
+        seen_during_write["name"] = settings.name
+        seen_during_write["description"] = settings.description
+
+    assert seen_during_write == {"name": "Original", "description": ""}  # baseline for the write
+    assert settings.name == "PREGUI RAN"  # hook values put back for later actions
+    assert settings.description == "from hook"
+
+
+def test_sticky_baseline_context_keeps_user_edit_throughout():
+    """A field the user edited is neither reset for the write nor touched on exit, so the user's
+    value both persists to sticky settings and remains on the live object."""
+    settings = _settings()
+    settings.name = "MyShot_v2"  # user overrode the hook value
+    settings.description = "from hook"
+    reset = {"name": ("Original", "PREGUI RAN"), "description": ("", "from hook")}
+
+    with cinema4d_render_submitter._pre_gui_hook_sticky_baseline(settings, reset):
+        assert settings.name == "MyShot_v2"  # user edit untouched during the write
+
+    assert settings.name == "MyShot_v2"
+    assert settings.description == "from hook"  # reapplied hook value
+
+
+def test_sticky_baseline_context_reapplies_even_if_write_raises():
+    """The hook values must be restored even when save_sticky_settings raises, so a failed write
+    never leaves the live settings object stuck at the baseline."""
+    settings = _settings()
+    settings.name = "PREGUI RAN"
+    reset = {"name": ("Original", "PREGUI RAN")}
+
+    try:
+        with cinema4d_render_submitter._pre_gui_hook_sticky_baseline(settings, reset):
+            raise RuntimeError("save failed")
+    except RuntimeError:
+        pass
+
+    assert settings.name == "PREGUI RAN"
+
+
+def test_compute_sticky_reset_maps_deadline_params_to_sticky_fields():
+    """A hook that emits a deadline:* job property (routed through the shared parameter values, not
+    onto the settings object) is recorded against its sticky field with the hook's value, so it can
+    be scoped out of the sticky write just like name/description. deadline:priority is exactly what
+    the integ fixture emits."""
+    settings = _settings()  # priority defaults to 50
+    reset = cinema4d_render_submitter._compute_pre_gui_hook_sticky_reset(
+        settings,
+        {"name": settings.name, "description": settings.description},  # unchanged -> no entry
+        {"CondaPackages": "pkg"},
+        {"CondaPackages": "pkg", "deadline:priority": 88},  # hook added deadline:priority
+    )
+    assert reset == {"priority": (50, 88)}
+
+
+def test_compute_sticky_reset_covers_name_description_and_shared_together():
+    """name/description (applied directly on settings) and deadline:* fields (via shared values) are
+    both captured in one reset map."""
+    settings = _settings()
+    settings.name = "PREGUI RAN"  # post-apply state
+    settings.description = "from hook"
+    reset = cinema4d_render_submitter._compute_pre_gui_hook_sticky_reset(
+        settings,
+        {"name": "Original", "description": ""},  # pre-hook baseline
+        {"CondaPackages": "pkg"},
+        {"CondaPackages": "pkg", "deadline:priority": 88, "deadline:maxRetriesPerTask": 9},
+    )
+    assert reset["name"] == ("Original", "PREGUI RAN")
+    assert reset["description"] == ("", "from hook")
+    assert reset["priority"] == (50, 88)
+    assert reset["max_retries_per_task"] == (5, 9)
+
+
+def test_compute_sticky_reset_ignores_unchanged_and_unmapped_shared_params():
+    """Only shared keys the hook actually changed AND that map to a sticky field are recorded: an
+    unchanged deadline:* value and a non-sticky key (CondaPackages) are both ignored."""
+    settings = _settings()
+    reset = cinema4d_render_submitter._compute_pre_gui_hook_sticky_reset(
+        settings,
+        {"name": settings.name, "description": settings.description},
+        {"CondaPackages": "pkg", "deadline:priority": 50},
+        {
+            "CondaPackages": "pkg2",
+            "deadline:priority": 50,
+        },  # CondaPackages changed (unmapped); priority same
+    )
+    assert reset == {}
+
+
+def test_sticky_baseline_context_scopes_priority_out_of_write():
+    """End to end: a deadline:priority reset flows through the sticky-baseline context manager just
+    like name/description -- baseline during the write, hook value reapplied after."""
+    settings = _settings()
+    settings.priority = 88  # gathered from the shared Priority widget (the hook value)
+    reset = {"priority": (50, 88)}
+
+    seen = {}
+    with cinema4d_render_submitter._pre_gui_hook_sticky_baseline(settings, reset):
+        seen["priority"] = settings.priority
+
+    assert seen["priority"] == 50  # sticky write sees the pre-hook baseline
+    assert settings.priority == 88  # reapplied after
+
+
+def test_sticky_baseline_context_keeps_user_priority_edit():
+    """If the user changed Priority in the dialog away from the hook value, that edit persists to
+    sticky (current value != hook value, so it is not reset)."""
+    settings = _settings()
+    settings.priority = 90  # user overrode the hook's 88
+    reset = {"priority": (50, 88)}
+
+    with cinema4d_render_submitter._pre_gui_hook_sticky_baseline(settings, reset):
+        assert settings.priority == 90  # not reset during the write
+
+    assert settings.priority == 90
+
+
+@patch.object(cinema4d_render_submitter, "get_setting", return_value="true")
+def test_confirm_callback_none_when_auto_accept_enabled(mock_get_setting):
+    """With settings.auto_accept enabled, hooks run without a confirmation prompt."""
+    assert cinema4d_render_submitter._pre_gui_hook_confirm_callback(parent=None) is None
+    mock_get_setting.assert_called_once_with("settings.auto_accept")
+
+
+@patch.object(cinema4d_render_submitter, "qt_hook_confirmation")
+@patch.object(cinema4d_render_submitter, "get_setting", return_value="false")
+def test_confirm_callback_prompts_when_auto_accept_disabled(mock_get_setting, mock_qt_confirm):
+    """With settings.auto_accept disabled, the standard Qt confirmation callback is selected and
+    built against the window passed into the submitter.
+
+    We assert on the submitter's own contract — that it hands ``qt_hook_confirmation`` the parent
+    and uses its result as the ``confirm_callback`` — rather than reaching into deadline-cloud's
+    ``qt_hook_confirmation`` internals (it imports ``QMessageBox`` lazily from ``qtpy`` inside the
+    returned callback; whether the dialog itself fires is covered by deadline-cloud's own tests).
+    """
+    sentinel = object()
+    mock_qt_confirm.return_value = sentinel
+
+    result = cinema4d_render_submitter._pre_gui_hook_confirm_callback(parent="mainwin")
+
+    assert result is sentinel
+    mock_qt_confirm.assert_called_once_with("mainwin")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Cinema 4D submitter did not run pre-GUI submission hooks, so studios had no way to
pre-populate the submit dialog's fields (job name/description, queue parameters, `deadline:`
job properties) before it opens. deadline-cloud added a Qt-free pre-GUI hook entry point
(`run_pre_gui_hooks` / `PreGuiHookContext`) plus a generic `apply_pre_gui_output` helper in
[aws-deadline/deadline-cloud#1255](https://github.com/aws-deadline/deadline-cloud/pull/1255)
so DCC submitters (Maya, Nuke, and now Cinema 4D) can share one integration. This PR wires
that into Cinema 4D, matching the equivalent Maya and Nuke changes.

### What was the solution? (How)

- In `_show_submitter`, before building `SubmitJobToDeadlineDialog`, call
  `run_pre_gui_hooks(PreGuiHookContext(bundle_dir=None, submitter_name="cinema4d", ...))`.
  Cinema 4D has no on-disk job bundle at pre-GUI time, so hooks are sourced from
  `DEADLINE_HOOKS_DIR` only (`bundle_dir=None`), gated by `settings.allow_environment_hooks`.
- The confirmation prompt uses `qt_hook_confirmation(parent)`, skipped when
  `settings.auto_accept` is set.
- Apply the merged output with deadline-cloud's generic `apply_pre_gui_output`.
  `RenderSubmitterUISettings` has no `.parameters` list, so `name`/`description` land on the
  settings object and every hook parameter flows into the dialog's shared parameter values.
- Bump the `deadline` floor to `>= 0.60.1` (the release that first ships
  `deadline.client.ui.pre_gui_hooks`; the 0.60.0 tag does not contain the module).

### What is the impact of this change?

No behavior change when no pre-GUI hooks are configured: the merged output is empty, so the
dialog is seeded with the same `CondaPackages` value as before. The new path only takes effect
when `DEADLINE_HOOKS_DIR` is set and environment hooks are enabled.

### How was this change tested?

- **Unit tests:** Added `test/unit/deadline_submitter_for_cinema4d/test_pre_gui_hooks.py` —
  headless tests exercising the DCC-relevant mapping contract (name/description onto settings;
  all hook parameters flowing to shared values since C4D has no `.parameters` list; empty,
  falsy, and partial output; the `auto_accept` confirm-callback branch). These pass against the
  real merged `apply_pre_gui_output` from #1255.
- **Integration test (xa11y):** Added `test/integ_xa11y/test_cinema4d.py::test_pre_gui_hook` —
  the GUI counterpart to the unit tests. It launches a real Cinema 4D with `DEADLINE_HOOKS_DIR`
  pointing at a fixture hook (and `allow_environment_hooks` / `auto_accept` enabled), drives the
  shipped submitter dialog end to end via xa11y, exports a job bundle, and asserts the hook's
  output survived into it — proving the `run_pre_gui_hooks` + `apply_pre_gui_output` wiring holds
  through an actual export, not just in isolation. The fixture hook emits a fixed name,
  description, and `deadline:priority`; the test asserts `template.yaml` carries
  `name: PREGUI RAN` / `description: populated by pre-GUI hook` and `parameter_values.yaml`
  carries `deadline:priority: 88`.
- **Ran it on a Windows + Cinema 4D 2026 workstation: `1 passed`.** The submitter dialog was
  driven through to Export and the exported bundle contained exactly those three hook values.
- `black --check`, `ruff check`, and `py_compile` all pass.

### Was this change documented?

Docstrings/comments added at the hook call site, in the new unit-test module, and in the
integration test; `test/AGENTS.md` documents the new pre-GUI hook case (fixture layout, the two
settings it enables, and that it uses targeted asserts rather than a golden-bundle diff). No
README/adaptor schema changes are needed — this is submitter-only and does not touch
init-data/run-data.

### Is this a breaking change?

No. This is additive and backward compatible (no adaptor interface change). It does raise the
`deadline` dependency floor to `>= 0.60.1`, so this PR should only merge once deadline-cloud
0.60.1 (which ships `deadline.client.ui.pre_gui_hooks`) is available to the build — the same
dependency the equivalent Maya and Nuke pre-GUI PRs carry.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
