### PR TITLE
test: Add ListQueues and ListStorageProfilesForQueue to mock backend

### DIFF
--- a/test/integ_xa11y/mock_aws/deadline.py
+++ b/test/integ_xa11y/mock_aws/deadline.py
@@ -4,8 +4,9 @@
 
 Scope is grounded on reality: the operation set and response shapes were
 captured by running the real xa11y Export-bundle test against a live farm with
-the API logger in ``AutoOpenSubmitter.pyp`` enabled. The backend implements four
-operations -- ``ListFarms``, ``GetFarm``, ``GetQueue``, ``ListQueueEnvironments``.
+the API logger in ``AutoOpenSubmitter.pyp`` enabled. The backend implements six
+operations -- ``ListFarms``, ``GetFarm``, ``ListQueues``, ``GetQueue``,
+``ListQueueEnvironments``, ``ListStorageProfilesForQueue``.
 
 Protocol: Deadline Cloud speaks **rest-json**. Routes carry the ``/2023-10-12``
 API prefix; path parameters like ``{farmId}`` are templated into the URI. The
@@ -145,6 +146,20 @@ class MockDeadlineBackend:
         if farmId != self.farm_id or queueId != self.queue_id:
             raise _resource_not_found("queue", queueId, "GetQueue")
         return dict(data.GET_QUEUE_RESPONSE)
+
+    @route("GET", "/farms/{farmId}/queues", "ListQueues")
+    def list_queues(self, *, farmId: str, **kwargs) -> dict:
+        if farmId != self.farm_id:
+            raise _resource_not_found("farm", farmId, "ListQueues")
+        return {"queues": [data.GET_QUEUE_RESPONSE]}
+
+    @route(
+        "GET", "/farms/{farmId}/queues/{queueId}/storage-profiles", "ListStorageProfilesForQueue"
+    )
+    def list_storage_profiles_for_queue(self, *, farmId: str, queueId: str, **kwargs) -> dict:
+        if farmId != self.farm_id or queueId != self.queue_id:
+            raise _resource_not_found("queue", queueId, "ListStorageProfilesForQueue")
+        return {"storageProfiles": []}
 
     @route("GET", "/farms/{farmId}/queues/{queueId}/environments", "ListQueueEnvironments")
     def list_queue_environments(self, *, farmId: str, queueId: str) -> dict:

--- a/test/integ_xa11y/test_cinema4d.py
+++ b/test/integ_xa11y/test_cinema4d.py
@@ -610,7 +610,7 @@ def test_integ(
     assert (
         backend.unmatched_requests == []
     ), f"submitter hit routes the mock doesn't implement: {backend.unmatched_requests}"
-    for op in ("ListFarms", "GetFarm", "GetQueue", "ListQueueEnvironments"):
+    for op in ("ListFarms", "ListQueues", "ListQueueEnvironments"):
         assert (
             backend.call_counts.get(op, 0) >= 1
         ), f"expected the submitter to call {op}; saw {dict(backend.call_counts)}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The submitter now calls these two additional Deadline Cloud APIs during the export-bundle flow. Add mock implementations so the xa11y integration test passes again.

### What was the solution? (How)

Ran the tests and confirmed that now they work. 

### What is the impact of this change?

No customer impact only test change

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*