### PR TITLE
feat: Add GitHub Actions workflows for xa11y integration tests

### DIFF
--- a/.github/workflows/integ_macos.yml
+++ b/.github/workflows/integ_macos.yml
@@ -1,0 +1,171 @@
+name: "Integ Tests - macOS"
+
+on:
+  workflow_call:
+    secrets:
+      AWS_OIDC_ROLE_ARN:
+        required: true
+      AWS_REGION:
+        required: true
+      RLM_PORT:
+        required: true
+      INSTALLER_BUCKET:
+        required: true
+      INSTALLER_BUCKET_EXPECTED_OWNER:
+        required: true
+      LICENSE_ROLE_ARN:
+        required: true
+      BASTION_INSTANCE_TAG:
+        required: true
+
+jobs:
+  IntegMacOS:
+    if: >-
+      github.repository == 'aws-deadline/deadline-cloud-for-cinema-4d' &&
+      github.ref == 'refs/heads/mainline'
+    name: Integration Tests (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      LICENSE_ENDPOINT_DNS: "127.0.0.1"
+      C4D_LICENSE_PORT: ${{ secrets.RLM_PORT }}
+      redshift_LICENSE: "${{ secrets.RLM_PORT }}@127.0.0.1"
+      g_licenseServerRLM: "127.0.0.1:${{ secrets.RLM_PORT }}"
+      g_licenseModel: "LICENSEMODEL::RLM"
+      C4D_VERSION: "2026"
+      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
+      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install hatch
+        run: pip install --upgrade hatch
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Grant accessibility
+        run: |
+          # Create the hatch environment first so that pip's install output
+          # (which can include marker-mismatch messages containing quotes)
+          # doesn't pollute the captured Python path below.
+          hatch env create integ-xa11y
+          HATCH_PYTHON=$(hatch -e integ-xa11y run python -c "import os,sys; print(os.path.realpath(sys.executable))")
+          SETUP_PYTHON=$(python3 -c "import os,sys; print(os.path.realpath(sys.executable))")
+          for BIN_PATH in "$SETUP_PYTHON" "$HATCH_PYTHON"; do
+            sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
+              "INSERT OR REPLACE INTO access(service,client,client_type,auth_value,auth_reason,auth_version,csreq,policy_id,indirect_object_identifier_type,indirect_object_identifier,indirect_object_code_identity,flags,last_modified) \
+              VALUES('kTCCServiceAccessibility','${BIN_PATH}',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,$(date +%s));"
+          done
+          sudo launchctl stop com.apple.tccd 2>/dev/null || true
+          sleep 2
+
+      - name: Install and configure Cinema 4D
+        run: |
+          pip install boto3
+          python ./pipeline/setup-runner.py --versions $C4D_VERSION
+
+      - name: Grant accessibility to Cinema 4D
+        run: |
+          C4D_BIN="/Applications/Maxon Cinema 4D 2026/Cinema 4D.app/Contents/MacOS/Cinema 4D"
+          C4DPY_BIN="/Applications/Maxon Cinema 4D 2026/c4dpy.app/Contents/MacOS/c4dpy"
+          for BIN_PATH in "$C4D_BIN" "$C4DPY_BIN"; do
+            if [ -f "$BIN_PATH" ]; then
+              sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
+                "INSERT OR REPLACE INTO access(service,client,client_type,auth_value,auth_reason,auth_version,csreq,policy_id,indirect_object_identifier_type,indirect_object_identifier,indirect_object_code_identity,flags,last_modified) \
+                VALUES('kTCCServiceAccessibility','${BIN_PATH}',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,$(date +%s));"
+            fi
+          done
+          sudo launchctl stop com.apple.tccd 2>/dev/null || true
+          sleep 2
+
+      - name: Bring up license tunnel and run tests
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          RLM_PORT: ${{ secrets.RLM_PORT }}
+          LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
+          BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
+        run: |
+          rlmPort=$(echo "$RLM_PORT" | tr -d '[:space:]')
+          region=$(echo "$AWS_REGION" | tr -d '[:space:]')
+
+          # Install SSM plugin
+          curl --fail --silent --show-error --location \
+            "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/mac_arm64/session-manager-plugin.pkg" \
+            --output "$RUNNER_TEMP/ssm-plugin.pkg"
+          sudo installer -pkg "$RUNNER_TEMP/ssm-plugin.pkg" -target /
+
+          # Configure a profile that assumes the licensing role. Credentials come
+          # from the OIDC creds already in the environment (credential_source=
+          # Environment), so the role is assumed transparently on each
+          # --profile license call -- nothing is printed or stored by us.
+          aws configure set profile.license.role_arn "$LICENSE_ROLE_ARN"
+          aws configure set profile.license.credential_source Environment
+          aws configure set profile.license.region "$region"
+
+          # Resolve the bastion instance by tag at runtime (don't hardcode the ID).
+          # The bastion listens on the RLM port and relays to the license
+          # server itself -- CI only ever opens a session on the bastion.
+          bastion=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=$BASTION_INSTANCE_TAG" "Name=instance-state-name,Values=running" \
+            --query 'Reservations[0].Instances[0].InstanceId' \
+            --profile license --region "$region" --output text)
+          if [ -z "$bastion" ] || [ "$bastion" = "None" ]; then echo "ERROR: Bastion host not found"; exit 1; fi
+
+          # Start SSM port forwarding to the bastion. Log to a file so we can
+          # capture the SessionId for deterministic teardown.
+          aws ssm start-session \
+            --target "$bastion" \
+            --document-name DccInteg-PortForwardToLicenseServer \
+            --parameters "{\"portNumber\":[\"$rlmPort\"],\"localPortNumber\":[\"$rlmPort\"]}" \
+            --profile license --region "$region" > "$RUNNER_TEMP/ssm.log" 2>&1 &
+
+          # Wait for port (retry up to 30s)
+          ready=false
+          for i in $(seq 1 6); do
+            sleep 5
+            if nc -z 127.0.0.1 "$rlmPort" 2>/dev/null; then ready=true; break; fi
+          done
+          if [ "$ready" != "true" ]; then echo "ERROR: SSM port forward not up after 30s"; cat "$RUNNER_TEMP/ssm.log" || true; exit 1; fi
+          echo "License tunnel up via SSM"
+
+          # Capture the SSM session id so the teardown step can terminate the
+          # session on the (shared, long-lived) license host explicitly, rather
+          # than relying on SSM's disconnect detection to reap it.
+          ssmSessionId=$(grep -oE 'SessionId: [A-Za-z0-9._-]+' "$RUNNER_TEMP/ssm.log" | head -1 | awk '{print $2}' || true)
+          echo "SSM_SESSION_ID=$ssmSessionId" >> "$GITHUB_ENV"
+          echo "SSM session id: ${ssmSessionId:-<not captured>}"
+
+          hatch run integ-xa11y:test
+
+      - name: Tear down
+        if: always()
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          region=$(echo "$AWS_REGION" | tr -d '[:space:]')
+          # Terminate the SSM session on the shared license host so the
+          # port-forward is released immediately instead of lingering until
+          # SSM notices the dropped connection. The license profile was
+          # configured in the previous step (credential_source=Environment).
+          if [ -n "${SSM_SESSION_ID:-}" ]; then
+            aws ssm terminate-session --session-id "$SSM_SESSION_ID" \
+              --profile license --region "$region" 2>/dev/null || true
+          fi
+          # Kill the local plugin as a fallback (harmless on ephemeral runners).
+          pkill -f "session-manager-plugin" 2>/dev/null || true

--- a/.github/workflows/integ_windows.yml
+++ b/.github/workflows/integ_windows.yml
@@ -1,0 +1,157 @@
+name: "Integ Tests - Windows"
+
+on:
+  workflow_call:
+    secrets:
+      AWS_OIDC_ROLE_ARN:
+        required: true
+      AWS_REGION:
+        required: true
+      RLM_PORT:
+        required: true
+      INSTALLER_BUCKET:
+        required: true
+      INSTALLER_BUCKET_EXPECTED_OWNER:
+        required: true
+      LICENSE_ROLE_ARN:
+        required: true
+      BASTION_INSTANCE_TAG:
+        required: true
+
+jobs:
+  IntegWindows:
+    if: >-
+      github.repository == 'aws-deadline/deadline-cloud-for-cinema-4d' &&
+      github.ref == 'refs/heads/mainline'
+    name: Integration Tests (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      LICENSE_ENDPOINT_DNS: "127.0.0.1"
+      C4D_LICENSE_PORT: ${{ secrets.RLM_PORT }}
+      redshift_LICENSE: "${{ secrets.RLM_PORT }}@127.0.0.1"
+      g_licenseServerRLM: "127.0.0.1:${{ secrets.RLM_PORT }}"
+      g_licenseModel: "LICENSEMODEL::RLM"
+      C4D_VERSION: "2026"
+      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
+      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install hatch
+        run: pip install --upgrade hatch
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Install and configure Cinema 4D
+        shell: pwsh
+        run: |
+          pip install boto3
+          python ./pipeline/setup-runner.py --versions $env:C4D_VERSION
+
+      - name: Bring up license tunnel and run tests
+        shell: pwsh
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          RLM_PORT: ${{ secrets.RLM_PORT }}
+          LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
+          BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
+        run: |
+          $rlmPort = $env:RLM_PORT.Trim()
+          $region  = $env:AWS_REGION.Trim()
+
+          # Install SSM plugin
+          $ssmUrl = "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe"
+          Invoke-WebRequest -Uri $ssmUrl -OutFile "$env:RUNNER_TEMP\ssm-plugin.exe" -UseBasicParsing
+          Start-Process -FilePath "$env:RUNNER_TEMP\ssm-plugin.exe" -ArgumentList "/quiet" -Wait
+          $ssmPluginDir = Join-Path $env:ProgramFiles "Amazon\SessionManagerPlugin\bin"
+          $env:PATH = "$ssmPluginDir;$env:PATH"
+          if (-not (Get-Command "session-manager-plugin.exe" -ErrorAction SilentlyContinue)) {
+            Write-Error "Session Manager plugin was not found after installation"
+            exit 1
+          }
+
+          # Configure a profile that assumes the licensing role. Credentials come
+          # from the OIDC creds already in the environment (credential_source=
+          # Environment), so the role is assumed transparently on each
+          # --profile license call -- nothing is printed or stored by us.
+          aws configure set profile.license.role_arn $env:LICENSE_ROLE_ARN
+          aws configure set profile.license.credential_source Environment
+          aws configure set profile.license.region $region
+
+          # Resolve the bastion instance by tag at runtime (don't hardcode the ID).
+          # The bastion listens on the RLM port and relays to the license
+          # server itself -- CI only ever opens a session on the bastion.
+          $bastion = (aws ec2 describe-instances `
+            --filters "Name=tag:Name,Values=$($env:BASTION_INSTANCE_TAG)" "Name=instance-state-name,Values=running" `
+            --query 'Reservations[0].Instances[0].InstanceId' `
+            --profile license --region $region --output text).Trim()
+          if (-not $bastion -or $bastion -eq "None") { Write-Error "Bastion host not found"; exit 1 }
+
+          # Start SSM port forwarding to the bastion (params via file to avoid
+          # quoting issues). Redirect stdout to a log file so we can capture
+          # the SessionId for deterministic teardown.
+          $paramsFile = Join-Path $env:RUNNER_TEMP "ssm_params.json"
+          @{portNumber=@($rlmPort);localPortNumber=@($rlmPort)} | ConvertTo-Json -Compress | Out-File -FilePath $paramsFile -Encoding ascii
+          $ssmLog = Join-Path $env:RUNNER_TEMP "ssm.log"
+          Start-Process -FilePath "aws" -ArgumentList "ssm start-session --target $bastion --document-name DccInteg-PortForwardToLicenseServer --parameters file://$paramsFile --profile license --region $region" -NoNewWindow -RedirectStandardOutput $ssmLog
+
+          # Wait for port (retry up to 30s)
+          $ready = $false
+          for ($i = 0; $i -lt 6; $i++) {
+            Start-Sleep -Seconds 5
+            $t = Test-NetConnection -ComputerName 127.0.0.1 -Port $rlmPort -WarningAction SilentlyContinue
+            if ($t.TcpTestSucceeded) { $ready = $true; break }
+          }
+          if (-not $ready) { Write-Error "SSM port forward not up after 30s"; if (Test-Path $ssmLog) { Get-Content $ssmLog }; exit 1 }
+          Write-Host "License tunnel up via SSM"
+
+          # Capture the SSM session id so the teardown step can terminate the
+          # session on the (shared, long-lived) license host explicitly, rather
+          # than relying on SSM's disconnect detection to reap it.
+          $ssmSessionId = ""
+          if (Test-Path $ssmLog) {
+            $m = Select-String -Path $ssmLog -Pattern 'SessionId: ([A-Za-z0-9._-]+)' | Select-Object -First 1
+            if ($m) { $ssmSessionId = $m.Matches[0].Groups[1].Value }
+          }
+          "SSM_SESSION_ID=$ssmSessionId" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          if ($ssmSessionId) { Write-Host "SSM session id: $ssmSessionId" } else { Write-Host "SSM session id: <not captured>" }
+
+          hatch run integ-xa11y:test
+
+      - name: Tear down
+        if: always()
+        shell: pwsh
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          $region = $env:AWS_REGION.Trim()
+          # Terminate the SSM session on the shared license host so the
+          # port-forward is released immediately instead of lingering until
+          # SSM notices the dropped connection. The license profile was
+          # configured in the previous step (credential_source=Environment).
+          if ($env:SSM_SESSION_ID) {
+            aws ssm terminate-session --session-id $env:SSM_SESSION_ID --profile license --region $region 2>$null
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "Failed to terminate SSM session $env:SSM_SESSION_ID"
+              $global:LASTEXITCODE = 0
+            }
+          }
+          # Kill the local plugin as a fallback (harmless on ephemeral runners).
+          Get-Process -Name "session-manager-plugin" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/integration_tests_xa11y.yml
+++ b/.github/workflows/integration_tests_xa11y.yml
@@ -1,0 +1,35 @@
+name: "Cinema 4D xa11y Integration Tests"
+
+on:
+  push:
+    branches:
+      - mainline
+
+jobs:
+  windows:
+    uses: ./.github/workflows/integ_windows.yml
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      RLM_PORT: ${{ secrets.RLM_PORT }}
+      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
+      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
+      LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
+      BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
+    permissions:
+      id-token: write
+      contents: read
+
+  macos:
+    uses: ./.github/workflows/integ_macos.yml
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      RLM_PORT: ${{ secrets.RLM_PORT }}
+      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
+      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
+      LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
+      BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
+    permissions:
+      id-token: write
+      contents: read


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The xa11y integration suite did not run in the repository's GitHub Actions workflows. This left the real Cinema 4D submitter UI flow without continuous coverage on the supported desktop platforms.

### What was the solution? (How)

Added reusable Windows and macOS workflows that:

- Install Cinema 4D 2026 from the configured installer bucket.
- Configure RLM licensing through an SSM port-forwarding session.
- Run `hatch run integ-xa11y:test` against the real submitter UI.
- Use OIDC credentials, explicit secret forwarding, pinned action revisions, and read-only repository permissions.
- Restrict execution to pushes to `mainline` in the canonical repository.
- Clean up the remote SSM session and local Session Manager Plugin process.

Added a caller workflow that runs both platform workflows on pushes to `mainline`. The reusable workflows are referenced by local paths so each run uses the definitions from its triggering commit.

The Windows workflow also refreshes the current process PATH after installing Session Manager Plugin and verifies that the executable is discoverable before starting the SSM session.

### What is the impact of this change?

Pushes to `mainline` now run xa11y integration coverage on Windows and macOS. Windows validates the complete submitter, job bundle, and render flow. macOS validates the submitter and generated job bundle; rendering remains skipped because `cinema4d-openjd` is not available for macOS.

There are no changes to customer-facing submitter or adaptor behavior.

### How was this change tested?

I ran the workflows in my personal fork and confirmed that they worked.

Here's the run on my fork: https://github.com/karthikbekalp/deadline-cloud-for-cinema-4d/actions/runs/29358004994/job/87170476759 

### Was this change documented?

No user documentation changes are required. The new workflows include comments for the platform-specific accessibility, licensing, and cleanup behavior.

### Is this a breaking change?

No. This change only adds CI workflows and does not modify a public contract.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
