### PR TITLE
chore: Upgrade deadline cloud test fixtures to >=0.18.17

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -13,7 +13,7 @@ numpy >= 2.2.6, < 2.5; python_version < "3.12"
 pillow == 12.*
 openjd-cli == 0.7.*
 fonttools >= 4.0.0
-deadline-cloud-test-fixtures >= 0.18.16
+deadline-cloud-test-fixtures >= 0.18.17
 # Drives the real submitter dialog via the OS accessibility tree.
 # Used by test/integ_xa11y/.
 xa11y >= 0.11.0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The xa11y tests need a fix from `deadline-cloud-test-fixtures` to run correctly. 

### What was the solution? (How)

Updated the version to `0.18.17` which has the fix. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*