### PR TITLE
chore: Run xa11y integration tests on release.

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -34,6 +34,38 @@ jobs:
     with:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
+  Xa11yWindows:
+    needs: [TagRelease, UnitTests]
+    name: xa11y Integration Tests (Windows)
+    uses: ./.github/workflows/integ_windows.yml
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      RLM_PORT: ${{ secrets.RLM_PORT }}
+      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
+      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
+      LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
+      BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
+    permissions:
+      id-token: write
+      contents: read
+
+  Xa11yMacOS:
+    needs: [TagRelease, UnitTests]
+    name: xa11y Integration Tests (macOS)
+    uses: ./.github/workflows/integ_macos.yml
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      RLM_PORT: ${{ secrets.RLM_PORT }}
+      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
+      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
+      LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
+      BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
+    permissions:
+      id-token: write
+      contents: read
+
   ManualTestGate:
     needs: [TagRelease, BuildInstaller]
     runs-on: ubuntu-latest
@@ -42,7 +74,7 @@ jobs:
       - run: echo "Manual testing approved for ${{ needs.TagRelease.outputs.tag }}"
 
   PreRelease:
-      needs: [TagRelease, UnitTests]
+      needs: [TagRelease, UnitTests, Xa11yWindows, Xa11yMacOS]
       uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
       permissions:
         id-token: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Our current Github release did not run integration tests. 

### What was the solution? (How)

Run the integration tests. 


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*