### PR TITLE
chore: Skip running Redshift xa11y tests

### DIFF
--- a/test/integ_xa11y/test_cinema4d.py
+++ b/test/integ_xa11y/test_cinema4d.py
@@ -624,6 +624,15 @@ def _run_integ_case(
     rmtree(actual_dir, ignore_errors=True)
 
 
+# Redshift render cases fail on GitHub-hosted Windows runners; the root cause
+# is currently under investigation. macOS CI is unaffected because the render
+# step doesn't run on darwin. Run these locally against a reachable license
+# server for coverage.
+_SKIP_REDSHIFT_IN_CI = pytest.mark.skipif(
+    sys.platform == "win32" and os.environ.get("CI") == "true",
+    reason="Redshift render cases fail on GitHub-hosted Windows runners",
+)
+
 # Standard test cases. Each entry is a folder name under test_cases/ with an
 # input/scene.py (required) and an optional input/configure.py (loaded as the
 # dialog configurator). Parametrized case-specific coverage is registered
@@ -644,10 +653,10 @@ _CASES = [
     "physical_multi_takes",
     "physical_tiles_multi_takes",
     "phy_apos_path",
-    "redshift",
-    "redshift_textured",
-    "redshift_textured_nonascii",
-    "redshift_tiles",
+    pytest.param("redshift", marks=_SKIP_REDSHIFT_IN_CI),
+    pytest.param("redshift_textured", marks=_SKIP_REDSHIFT_IN_CI),
+    pytest.param("redshift_textured_nonascii", marks=_SKIP_REDSHIFT_IN_CI),
+    pytest.param("redshift_tiles", marks=_SKIP_REDSHIFT_IN_CI),
 ]
 
 _TAKE_SELECTIONS = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Currently, the Redshift tests are failing in CI. 

### What was the solution? (How)

Add a temporary skip while we investigate the root cause. (We do have older integration tests that run these Redshift tests now so we are covered). 

The current theory is licensing because it needs to checkout both Redshift and Cinema 4D licenses which I think our current licensing infra is not able to run. I'll keep investigating this on my end. 

### What is the impact of this change?

The tests will continue to pass so that any PRs don't get unnecessarily blocked. 

### How was this change tested?

Just skipping the tests. 

### Was this change documented?

Only test and CI change, no documentation updates necessary. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*