### PR TITLE
chore(deps): disable dependabot from updating pyside6-essentials

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    commit-message: 
+    # PySide6 is pinned to 6.8 to align with VFX Reference Platform 2026, so
+    # Dependabot must not propose bumps for it: https://vfxplatform.com/#reference-platform
+    # Omitting `versions` and `update-types` ignores every update for the
+    # dependency, which is what we want here.
+    ignore:
+      - dependency-name: "pyside6*"
+    commit-message:
       prefix: "chore(deps):"
     # Combine all minor and patch bumps into a single PR. Major bumps do not
     # match this group and so each get their own individual PR.


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

`PySide6-Essentials` is pinned to `== 6.8.3` in the `gui` extra to align with [VFX Reference Platform 2026](https://vfxplatform.com/#reference-platform). Dependabot doesn't know about that constraint, so it keeps proposing bumps that are never actionable and have to be closed by hand — most recently #503 (`6.8.3` -> `6.11.1`).

`aws-deadline/deadline-cloud` already carries an ignore rule for this dependency; this repo is the only other non-archived repo in the org that actually declares PySide6 as a dependency, so this brings the two into line.

## What was the solution? (How)

Added an `ignore` entry for `pyside6*` to the `pip` ecosystem in `.github/dependabot.yml`.

Two deliberate differences from the `deadline-cloud` rule, which is `versions: [ "6" ]`:

- **Bare `dependency-name` instead of `versions`.** For pip, Dependabot parses a bare `"6"` as the exact requirement `= 6`, so that rule only ignores version 6.0 — it would *not* have suppressed the `6.11.1` bump. Omitting both `versions` and `update-types` resolves to `ALL_VERSIONS` (`">= 0"`) in [dependabot-core](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/config/ignore_condition.rb), which ignores every update.
- **Glob rather than a literal name**, which guards against the manifest's mixed casing (`PySide6-Essentials`) and picks up any sibling `pyside6-*` package.

Worth a separate follow-up: the rule in `deadline-cloud` has the same narrowness issue and is probably not doing what it looks like it's doing. The `< 6.11` ceiling in that repo's `pyproject.toml` is what's actually holding PySide back there.

Note `ignore` is the right lever here rather than `groups.pip-minor-patch` — an `exclude-patterns` entry would only split PySide into its own PR, not suppress it.

## What is the impact of this change?

No more Dependabot PRs for PySide6 in this repo. Intentional PySide upgrades are done by editing the pin in `pyproject.toml` directly, as part of a VFX Reference Platform move.

## How was this change tested?

Config-only change with no runtime surface. Validated that the file parses as YAML and that the `pip-minor-patch` group and `commit-message` prefix are unaffected; confirmed `pyside6*` matches `PySide6-Essentials` case-insensitively. The ignore semantics were verified against the `IgnoreCondition` source in dependabot-core rather than from the docs, which don't state the omitted-fields behavior. End-to-end confirmation is that no further PySide6 bump PRs appear after merge.

## Was this change documented?

The rationale and the VFX Reference Platform link are in a comment above the rule.

## Is this a breaking change?

No.