### PR TITLE
fix: traveres from main take when setting a take for rendering

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py
@@ -420,7 +420,7 @@ class Cinema4DHandler:
                     all_takes.extend(get_child_takes(child_take))
             return all_takes
 
-        main_take = take_data.GetCurrentTake()
+        main_take = take_data.GetMainTake()
         all_takes = [main_take] + get_child_takes(main_take)
 
         matched_take = None

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DClient/test_cinema4d_handler.py
@@ -82,7 +82,7 @@ class TestCinema4DHandler:
         mock_take_a.GetChildren.return_value = []
 
         mock_take_data = Mock()
-        mock_take_data.GetCurrentTake.return_value = mock_main_take
+        mock_take_data.GetMainTake.return_value = mock_main_take
         mock_main_take.GetChildren.return_value = [mock_take_a]
 
         mock_doc = Mock()
@@ -109,7 +109,7 @@ class TestCinema4DHandler:
         mock_take_a.GetChildren.return_value = []
 
         mock_take_data = Mock()
-        mock_take_data.GetCurrentTake.return_value = mock_main_take
+        mock_take_data.GetMainTake.return_value = mock_main_take
         mock_main_take.GetChildren.return_value = [mock_take_a]
 
         mock_doc = Mock()
@@ -118,6 +118,50 @@ class TestCinema4DHandler:
 
         handler.set_take({"take": "A"})
         mock_take_data.SetCurrentTake.assert_called_once_with(mock_take_a)
+
+    @patch(
+        "deadline.cinema4d_adaptor.Cinema4DClient.cinema4d_handler.c4d.documents.GetActiveDocument"
+    )
+    def test_set_take_from_non_parent_current_take(self, mock_get_doc: Mock):
+        """Verify that set_take finds and sets a take even if the active take is not an ancestor of the target take."""
+        handler = Cinema4DHandler(mock_map_path)
+
+        # Hierarchy:
+        #           Main
+        #          /    \
+        #     Take A   Take B
+        #       |
+        #    Take A1 (current active take)
+        mock_main_take = Mock()
+        mock_main_take.GetName.return_value = "Main"
+
+        mock_take_a = Mock()
+        mock_take_a.GetName.return_value = "Take A"
+
+        mock_take_a1 = Mock()
+        mock_take_a1.GetName.return_value = "Take A1"
+        mock_take_a1.GetChildren.return_value = []
+
+        mock_take_b = Mock()
+        mock_take_b.GetName.return_value = "Take B"
+        mock_take_b.GetChildren.return_value = []
+
+        mock_main_take.GetChildren.return_value = [mock_take_a, mock_take_b]
+        mock_take_a.GetChildren.return_value = [mock_take_a1]
+
+        mock_take_data = Mock()
+        # Current active take is Take A1 (which has no children)
+        mock_take_data.GetCurrentTake.return_value = mock_take_a1
+        # GetMainTake returns Main take, which roots the entire hierarchy
+        mock_take_data.GetMainTake.return_value = mock_main_take
+
+        mock_doc = Mock()
+        mock_doc.GetTakeData.return_value = mock_take_data
+        mock_get_doc.return_value = mock_doc
+
+        # Setting take to "Take B" should succeed because search starts from GetMainTake()
+        handler.set_take({"take": "Take B"})
+        mock_take_data.SetCurrentTake.assert_called_once_with(mock_take_b)
 
 
 class TestShouldCacheText:


### PR DESCRIPTION
Prior to this change, the user would need to set/activate the main take first before submitting the file to deadline cloud.
If the user did not select the Main/Base take, a take that is a sub-descent from the currently selected take would not be found.

### What was the problem/requirement? (What/Why)

Submitting a cinema4d file, where the active/selected take was not the base take of the document would lead to the following failure:

```
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "take", "args": {"take": "TakeB"}}
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT: Traceback (most recent call last):
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:   File "C:\Python311\Lib\site-packages\deadline\cinema4d_adaptor\Cinema4DClient\plugin\DeadlineCloudClient.pyp", line 30, in PluginMessage
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:     return parse_argv(sys.argv)
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:            ^^^^^^^^^^^^^^^^^^^^
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:   File "C:\Python311\Lib\site-packages\deadline\cinema4d_adaptor\Cinema4DClient\plugin\DeadlineCloudClient.pyp", line 23, in parse_argv
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:     main()
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:   File "C:\Python311\Lib\site-packages\deadline\cinema4d_adaptor\Cinema4DClient\cinema4d_client.py", line 137, in main
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:     client.poll()
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:   File "C:\Python311\Lib\site-packages\openjd\adaptor_runtime_client\base_client_interface.py", line 212, in poll
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:     self._perform_action(action)
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:   File "C:\Python311\Lib\site-packages\openjd\adaptor_runtime_client\base_client_interface.py", line 233, in _perform_action
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:     action_func(a.args)
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:   File "C:\Python311\Lib\site-packages\deadline\cinema4d_adaptor\Cinema4DClient\cinema4d_handler.py", line 388, in set_take
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT:     raise RuntimeError("Take not found: %s" % take_name)
2026/07/31 11:17:04+02:00 ADAPTOR_OUTPUT: STDOUT: RuntimeError: Take not found: TakeB
```

However - the document contained the take `TakeB` - though `TakeA` was selected in the UI when it was saved (and not the main take )

### What was the solution? (How)

Perform the check starting from the Base/Main take of a document

### What is the impact of this change?

- 

### How was this change tested?

Tested on our render farm and run the unit tests

- Have you run the unit tests?

yes

- Have you run the integration tests? (Add your integration test report below)

no

- Have you made changes to the submitter?

no

### Was this change documented?

No - no change needed from my opinion

### Is this a breaking change?

no

