### PR TITLE
chore: Release Cinema 4D OpenJD on weekly schedule.

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -1,6 +1,9 @@
 name: "Release: Bump"
 
 on:
+  schedule:
+    # Every Monday at 14:00 UTC (~6/7am Pacific, ~9/10am Eastern).
+    - cron: "0 14 * * 1"
   workflow_dispatch:
     inputs:
       force_version_bump:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Cinema 4D releases should be done periodically so that customers can take advantage of the latest features or bug fixes. 

### What was the solution? (How)

Now that we have integration tests, we should be able to release Cinema 4D weekly (if there are any bug-fixes or feature changes). 

### What is the impact of this change?

More weekly releases. 

### How was this change tested?

This is a workflow change only. Similar to the change in `deadline-cloud` repo. 

### Was this change documented?

No documentation change necessary. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
