### PR TITLE
fix: stop the submitter replacing Cinema 4D's menu bar on macOS

### DIFF
--- a/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
+++ b/src/deadline/cinema4d_submitter/cinema4d_render_submitter.py
@@ -40,7 +40,7 @@ from .data_classes import (
 )
 from .detailed_logging_utils import get_detailed_logging_environment
 from .font_utils import FONTS_DIR, get_font_manager_environment, scene_has_fonts
-from .platform_utils import is_windows
+from .platform_utils import is_macos, is_windows
 from .scene import Animation, Scene, get_renderer_warning
 from .style import C4D_STYLE
 from .takes import TakeSelection
@@ -93,6 +93,37 @@ def show_submitter():
     try:
         app = QtWidgets.QApplication.instance()
         if not app:
+            # Cinema 4D is not a Qt application, so there is no QApplication to reuse and we
+            # construct one inside the host process. On macOS that makes Qt load its own nib
+            # for the main menu and take possession of the native menu bar, replacing Cinema
+            # 4D's menus for the rest of the session.
+            #
+            # AA_PluginApplication tells Qt it is being used to author a plugin, which is
+            # exactly our situation, and suppresses that initialisation. Per the Qt
+            # documentation it avoids "loading our nib for the main menu and not taking
+            # possession of the native menu bar", and implies AA_DontUseNativeMenuBar. It
+            # must be set before the QApplication is constructed; setting it afterwards has
+            # no effect.
+            #
+            # Scoped only to macOS because Windows does not exhibit the problem, and the
+            # attribute also disables native event filters -- a behaviour change not worth
+            # taking on a platform that works.
+            #
+            # DCCs that are themselves Qt applications (Maya, Nuke) never reach this branch,
+            # which is why the problem is specific to Cinema 4D.
+            if is_macos():
+                try:
+                    QtWidgets.QApplication.setAttribute(
+                        Qt.ApplicationAttribute.AA_PluginApplication, True
+                    )
+                except Exception:
+                    # Losing the host's menu bar is a cosmetic problem; failing to open the
+                    # submitter is not. Never let this be fatal.
+                    logger.warning(
+                        "Could not set AA_PluginApplication; Cinema 4D's menu bar may be "
+                        "replaced for this session.",
+                        exc_info=True,
+                    )
             app = QtWidgets.QApplication([])
             app.setQuitOnLastWindowClosed(False)
             app.aboutToQuit.connect(app.deleteLater)

--- a/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_cinema4d_render_submitter.py
@@ -3,7 +3,9 @@
 from unittest import mock
 
 import yaml
+from qtpy.QtCore import Qt
 
+from deadline.cinema4d_submitter import cinema4d_render_submitter
 from deadline.cinema4d_submitter._yaml_utils import _build_embedded_yaml
 from deadline.cinema4d_submitter.cinema4d_render_submitter import (
     TakeData,
@@ -533,3 +535,67 @@ class TestBuildEmbeddedYaml:
         assert parsed["use_cached_text"] == "0"
         assert isinstance(parsed["activate_error_checking"], str)
         assert isinstance(parsed["use_cached_text"], str)
+
+
+class TestShowSubmitterNativeMenuBar:
+    """Cinema 4D is not a Qt application, so show_submitter constructs the QApplication
+    itself. On macOS that makes Qt take possession of the native menu bar, so
+    AA_PluginApplication has to be set first."""
+
+    @staticmethod
+    def _run(mock_qtwidgets, existing_app=None, macos=True):
+        mock_qtwidgets.QApplication.instance.return_value = existing_app
+        with (
+            mock.patch.object(
+                cinema4d_render_submitter, "_prompt_save_current_document", return_value=True
+            ),
+            mock.patch.object(
+                cinema4d_render_submitter, "check_and_show_update_dialog", return_value=True
+            ),
+            mock.patch.object(cinema4d_render_submitter, "is_macos", return_value=macos),
+        ):
+            cinema4d_render_submitter.show_submitter()
+
+    def test_sets_plugin_application_on_macos(self):
+        with mock.patch.object(cinema4d_render_submitter, "QtWidgets") as mock_qtwidgets:
+            self._run(mock_qtwidgets)
+
+        mock_qtwidgets.QApplication.setAttribute.assert_called_once_with(
+            Qt.ApplicationAttribute.AA_PluginApplication, True
+        )
+
+    def test_set_before_the_application_is_constructed(self):
+        """Qt only honours the attribute if it is set before construction."""
+        with mock.patch.object(cinema4d_render_submitter, "QtWidgets") as mock_qtwidgets:
+            self._run(mock_qtwidgets)
+
+        names = [c[0] for c in mock_qtwidgets.QApplication.mock_calls]
+        # The construction itself is recorded as a call on the mock with an empty name.
+        assert "setAttribute" in names, names
+        assert "" in names, names
+        assert names.index("setAttribute") < names.index(""), names
+
+    def test_not_set_off_macos(self):
+        """Windows does not exhibit the problem, and the attribute disables native event
+        filters, so it is not worth the behaviour change there."""
+        with mock.patch.object(cinema4d_render_submitter, "QtWidgets") as mock_qtwidgets:
+            self._run(mock_qtwidgets, macos=False)
+
+        mock_qtwidgets.QApplication.setAttribute.assert_not_called()
+
+    def test_leaves_an_existing_application_alone(self):
+        """A host that already owns a QApplication must not be reconfigured."""
+        with mock.patch.object(cinema4d_render_submitter, "QtWidgets") as mock_qtwidgets:
+            self._run(mock_qtwidgets, existing_app=mock.Mock())
+
+        mock_qtwidgets.QApplication.setAttribute.assert_not_called()
+
+    def test_failure_to_set_the_attribute_is_not_fatal(self):
+        """A cosmetic menu-bar fix must never stop the submitter opening."""
+        with mock.patch.object(cinema4d_render_submitter, "QtWidgets") as mock_qtwidgets:
+            mock_qtwidgets.QApplication.setAttribute.side_effect = RuntimeError("nope")
+            self._run(mock_qtwidgets)
+
+        # The QApplication is still constructed despite setAttribute raising.
+        names = [c[0] for c in mock_qtwidgets.QApplication.mock_calls]
+        assert "" in names, names


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Opening the submitter for the first time on macOS replaces Cinema 4D's application menu bar for the rest of the session, so the host's menus are lost.

Cinema 4D is not a Qt application, so `QApplication.instance()` returns `None` and `show_submitter` constructs one inside the host process. On macOS, Qt loads its own nib for the main menu and takes possession of the native menu bar while that `QApplication` is being constructed.

DCCs that are themselves Qt applications (Maya, Nuke) always find an existing `QApplication` and never reach that branch, which is why this is specific to Cinema 4D.

### What was the solution? (How)

Set `AA_PluginApplication` before constructing the `QApplication`. Qt documents this attribute as indicating that Qt is being used to author a plugin — exactly this case — and states that it avoids "loading our nib for the main menu and not taking possession of the native menu bar". It also implies `AA_DontUseNativeMenuBar`.

Two deliberate constraints:

- **Scoped to macOS.** Windows does not exhibit the problem, and the attribute also disables native event filters — not a behaviour change worth taking on a platform that works.
- **Cannot be fatal.** The call is wrapped and logs a warning on failure. Losing the host's menu bar is cosmetic; failing to open the submitter is not.

Note that `AA_DontUseNativeMenuBar` on its own does *not* fix this. It only governs where `QMenuBar` widgets render, whereas the symptom is Qt claiming the NSApplication menu at construction time.

### What is the impact of this change?

Cinema 4D keeps its own menu bar when the submitter is opened. macOS only; no change on Windows or Linux. No public interface, adaptor, or job-bundle change.

### How was this change tested?

- **Unit tests:** yes. 5 new tests covering the attribute value, that it is set *before* construction, that it is skipped off macOS, that an existing host `QApplication` is left untouched, and that a `setAttribute` failure still allows the submitter to open. 343 passing total; `hatch run lint` and mypy clean.
- **Integration tests:** not run (macOS; integration tests are Windows-only).
- **Submitter changes:** yes. Verified by hand in Cinema 4D 2026 on macOS — the menu bar was replaced on first open before the change and is retained after it.

The tests pin the ordering as well as the value, because Qt silently ignores the attribute when it is set after the `QApplication` exists. I confirmed the ordering test fails if the call is moved below `QApplication([])`, so it would catch that regression.

### Was this change documented?

No documentation changes needed — no public interface, schema, or workflow change. The rationale, including the Qt documentation reference and why the attribute is macOS-only, is captured in a comment at the call site.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
