### PR TITLE
feat: bump deadline version to 0.60.4 and add optional console sign in deps

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -1,4 +1,8 @@
 [envs.default]
+# The unit tests exercise the submitter, which resolves through the gui extra -- that is
+# where the console extra and awscrt are declared, so the console sign-in dependency
+# tests need them present.
+features = ["gui"]
 pre-install-commands = [
   "pip install -r requirements-testing.txt"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,16 @@ gui = [
     "deadline[gui,console] >= 0.60.4, < 0.61",
     # botocore binds its EC symbol only when has_minimum_crt_version((0, 28, 4)) passes,
     # so anything below 0.28.4 leaves it None and disables console sign-in even though
-    # awscrt.crypto.EC imports fine from 0.28.3 onward. Declared directly so the floor is
-    # enforced rather than left to whatever deadline[console] happens to permit.
+    # awscrt.crypto.EC itself imports fine from 0.28.3 onward.
+    #
+    # Installing via deadline[console] already satisfies that floor transitively: it
+    # requires botocore[crt] >= 1.42.89, and botocore's crt extra pins awscrt to an exact
+    # version per release -- 1.42.89 pins 0.31.2, and later releases pin newer. So this
+    # line is not what enforces the floor for a normal install.
+    #
+    # It is declared because scripts/deps_bundle.py installs awscrt directly rather than
+    # through botocore[crt], so the bundled submitter has no transitive guarantee. Keeping
+    # the same constraint in both places means the floor is stated once per install path.
     "awscrt >= 0.28.4",
     "PySide6-Essentials == 6.8.3",  # Use 6.8 to align with VFXP 2026: https://vfxplatform.com/#reference-platform
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,19 @@ classifiers = [
 ]
 
 dependencies = [
-    # The console extra pulls awscrt, which AWS Console sign-in requires: botocore's
-    # LoginProvider refreshes the DPoP-bound cached token in-process, and signing those
-    # proofs needs awscrt. Without it, sign-in fails on a pre-flight dependency check.
-    #
-    # 0.60.4 is the floor because console sign-in landed there and nowhere earlier:
+    # 0.60.4 is the floor because AWS Console sign-in landed there and nowhere earlier:
     # 0.60.1 through 0.60.3 have no AWS_CONSOLE_LOGIN credentials source, and do not
     # declare a `console` extra at all.
-    "deadline[gui,console] >= 0.60.4, < 0.61",
+    #
+    # The console extra is deliberately NOT requested here. It is only needed by the
+    # submitter, and it pulls awscrt, a compiled wheel. These base dependencies are
+    # resolved into the adaptor package by scripts/create_adaptor_packaging_artifact.sh
+    # with --only-binary=:all: --platform <tag>, and no awscrt wheel satisfying the
+    # 0.28.4 floor exists for the macosx_10_9_x86_64 tag that script uses -- pip walks
+    # back to 0.25.7, which has no usable crypto support, so console sign-in would
+    # appear installed and silently not work. The adaptor never takes the console
+    # path anyway: it runs on a worker with host-provided credentials.
+    "deadline[gui] >= 0.60.4, < 0.61",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
     # fonttools is Windows-only due to Cinema 4D technical limitations
     "fonttools >=4.59.2, <4.64; sys_platform == 'win32'",
@@ -45,7 +50,15 @@ dependencies = [
 
 [project.optional-dependencies]
 gui = [
+    # The console extra pulls awscrt, which AWS Console sign-in requires: botocore's
+    # LoginProvider refreshes the DPoP-bound cached token in-process, and signing those
+    # proofs needs awscrt. Without it, sign-in fails on a pre-flight dependency check.
     "deadline[gui,console] >= 0.60.4, < 0.61",
+    # botocore binds its EC symbol only when has_minimum_crt_version((0, 28, 4)) passes,
+    # so anything below 0.28.4 leaves it None and disables console sign-in even though
+    # awscrt.crypto.EC imports fine from 0.28.3 onward. Declared directly so the floor is
+    # enforced rather than left to whatever deadline[console] happens to permit.
+    "awscrt >= 0.28.4",
     "PySide6-Essentials == 6.8.3",  # Use 6.8 to align with VFXP 2026: https://vfxplatform.com/#reference-platform
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,14 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline[gui] >= 0.60.1, < 0.61",
+    # The console extra pulls awscrt, which AWS Console sign-in requires: botocore's
+    # LoginProvider refreshes the DPoP-bound cached token in-process, and signing those
+    # proofs needs awscrt. Without it, sign-in fails on a pre-flight dependency check.
+    #
+    # 0.60.4 is the floor because console sign-in landed there and nowhere earlier:
+    # 0.60.1 through 0.60.3 have no AWS_CONSOLE_LOGIN credentials source, and do not
+    # declare a `console` extra at all.
+    "deadline[gui,console] >= 0.60.4, < 0.61",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
     # fonttools is Windows-only due to Cinema 4D technical limitations
     "fonttools >=4.59.2, <4.64; sys_platform == 'win32'",
@@ -38,7 +45,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gui = [
-    "deadline[gui] >= 0.60.1, < 0.61",
+    "deadline[gui,console] >= 0.60.4, < 0.61",
     "PySide6-Essentials == 6.8.3",  # Use 6.8 to align with VFXP 2026: https://vfxplatform.com/#reference-platform
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,19 +54,6 @@ gui = [
     # LoginProvider refreshes the DPoP-bound cached token in-process, and signing those
     # proofs needs awscrt. Without it, sign-in fails on a pre-flight dependency check.
     "deadline[gui,console] >= 0.60.4, < 0.61",
-    # botocore binds its EC symbol only when has_minimum_crt_version((0, 28, 4)) passes,
-    # so anything below 0.28.4 leaves it None and disables console sign-in even though
-    # awscrt.crypto.EC itself imports fine from 0.28.3 onward.
-    #
-    # Installing via deadline[console] already satisfies that floor transitively: it
-    # requires botocore[crt] >= 1.42.89, and botocore's crt extra pins awscrt to an exact
-    # version per release -- 1.42.89 pins 0.31.2, and later releases pin newer. So this
-    # line is not what enforces the floor for a normal install.
-    #
-    # It is declared because scripts/deps_bundle.py installs awscrt directly rather than
-    # through botocore[crt], so the bundled submitter has no transitive guarantee. Keeping
-    # the same constraint in both places means the floor is stated once per install path.
-    "awscrt >= 0.28.4",
     "PySide6-Essentials == 6.8.3",  # Use 6.8 to align with VFXP 2026: https://vfxplatform.com/#reference-platform
 ]
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -17,4 +17,6 @@ deadline-cloud-test-fixtures >= 0.18.18
 # Drives the real submitter dialog via the OS accessibility tree.
 # Used by test/integ/.
 xa11y >= 0.13.0
+# Both are used by test_console_signin_dependencies.py, which parses pyproject.toml.
+packaging >= 22
 tomli == 2.*; python_version < "3.11"

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -17,3 +17,4 @@ deadline-cloud-test-fixtures >= 0.18.18
 # Drives the real submitter dialog via the OS accessibility tree.
 # Used by test/integ/.
 xa11y >= 0.13.0
+tomli == 2.*; python_version < "3.11"

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -24,6 +24,15 @@ SUPPORTED_PLATFORMS = ["Windows", "Linux", "Darwin"]
 # working on 2026.
 NATIVE_DEPENDENCIES = ["xxhash", "psutil", "awscrt"]
 
+# awscrt is a submitter-only dependency, declared in the `gui` extra rather than the base
+# dependencies so it stays out of the adaptor package (see pyproject.toml). It still has to
+# be bundled for the submitter installer, so it is installed explicitly here, in the same
+# spirit as PySide6 below.
+#
+# The floor matches pyproject.toml: botocore binds its EC symbol only when
+# has_minimum_crt_version((0, 28, 4)) passes, and console sign-in is disabled below that.
+AWSCRT_REQUIREMENT = "awscrt >= 0.28.4"
+
 PYSIDE6_VERSION = "6.8.3"
 PYSIDE6_PACKAGES = [f"PySide6-Essentials=={PYSIDE6_VERSION}", f"shiboken6=={PYSIDE6_VERSION}"]
 
@@ -237,6 +246,23 @@ def _copy_zip_to_destination(zip_path: Path) -> Path:
     return zip_destination
 
 
+def _install_awscrt(install_path: Path) -> None:
+    """Install awscrt into the base environment.
+
+    Must run before _download_native_dependencies, which pins each native package to the
+    version resolved in the base environment -- awscrt has to be present there first.
+    """
+    pip_args = [
+        "pip",
+        "install",
+        "--target",
+        str(install_path),
+        "--only-binary=:all:",
+        AWSCRT_REQUIREMENT,
+    ]
+    subprocess.run(pip_args, check=True)
+
+
 def _install_pyside6(install_path: Path) -> None:
     """Install PySide6 and shiboken6, then strip to only the files in PYSIDE6_ALLOWLIST."""
     pip_args = [
@@ -283,6 +309,9 @@ def build_deps_bundle() -> None:
             lambda dep: not dep.name.startswith("openjd"), dependencies
         )
         base_env = _build_base_environment(working_directory, deps_noopenjd)
+        # Before _download_native_dependencies, which pins native packages to the versions
+        # resolved in the base environment.
+        _install_awscrt(base_env)
         native_dependency_paths = _download_native_dependencies(working_directory, base_env)
         _copy_native_to_base_env(base_env, native_dependency_paths)
         _install_pyside6(base_env)

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -31,6 +31,11 @@ NATIVE_DEPENDENCIES = ["xxhash", "psutil", "awscrt"]
 #
 # The floor matches pyproject.toml: botocore binds its EC symbol only when
 # has_minimum_crt_version((0, 28, 4)) passes, and console sign-in is disabled below that.
+#
+# It has to be stated here rather than inherited. A normal install gets the floor
+# transitively, because deadline[console] requires botocore[crt], whose crt extra pins
+# awscrt to an exact version. This install resolves awscrt on its own, so nothing else
+# constrains it.
 AWSCRT_REQUIREMENT = "awscrt >= 0.28.4"
 
 PYSIDE6_VERSION = "6.8.3"

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -24,20 +24,6 @@ SUPPORTED_PLATFORMS = ["Windows", "Linux", "Darwin"]
 # working on 2026.
 NATIVE_DEPENDENCIES = ["xxhash", "psutil", "awscrt"]
 
-# awscrt is a submitter-only dependency, declared in the `gui` extra rather than the base
-# dependencies so it stays out of the adaptor package (see pyproject.toml). It still has to
-# be bundled for the submitter installer, so it is installed explicitly here, in the same
-# spirit as PySide6 below.
-#
-# The floor matches pyproject.toml: botocore binds its EC symbol only when
-# has_minimum_crt_version((0, 28, 4)) passes, and console sign-in is disabled below that.
-#
-# It has to be stated here rather than inherited. A normal install gets the floor
-# transitively, because deadline[console] requires botocore[crt], whose crt extra pins
-# awscrt to an exact version. This install resolves awscrt on its own, so nothing else
-# constrains it.
-AWSCRT_REQUIREMENT = "awscrt >= 0.28.4"
-
 PYSIDE6_VERSION = "6.8.3"
 PYSIDE6_PACKAGES = [f"PySide6-Essentials=={PYSIDE6_VERSION}", f"shiboken6=={PYSIDE6_VERSION}"]
 
@@ -174,10 +160,32 @@ def _get_package_version(package: str, install_path: Path) -> str:
     raise RuntimeError(f"Could not find version for package {package}")
 
 
+def _add_console_extra(requirement: str) -> str:
+    """Add deadline's `console` extra to a requirement string, preserving its specifier."""
+    match = re.fullmatch(
+        r"(?P<name>[A-Za-z0-9._-]+)(?:\[(?P<extras>[^\]]*)\])?(?P<spec>.*)", requirement
+    )
+    if not match or match.group("name").lower() != "deadline":
+        return requirement
+    extras = [extra for extra in (match.group("extras") or "").split(",") if extra]
+    if "console" not in extras:
+        extras.append("console")
+    return f"{match.group('name')}[{','.join(extras)}]{match.group('spec')}"
+
+
 def _build_base_environment(working_directory: Path, dependencies: list[Dependency]) -> Path:
     (working_directory / "base_env").mkdir()
     base_env_path = working_directory / "base_env"
-    dependencies_for_pip = [d.for_pip() for d in dependencies]
+    # The bundle is the submitter, which needs AWS Console sign-in. The console extra is
+    # requested here rather than declared in project.dependencies, because those are also
+    # resolved into the adaptor package, where a compiled awscrt wheel is both unusable and
+    # unavailable for one of the platform tags that build targets (see pyproject.toml).
+    #
+    # Requesting the extra rather than installing awscrt directly means the bundle tracks
+    # whatever the extra actually requires -- notably a botocore floor, since the console
+    # login provider lives in botocore, not in deadline -- and takes awscrt from the exact
+    # version botocore's crt extra pins, rather than resolving it independently and drifting.
+    dependencies_for_pip = [_add_console_extra(d.for_pip()) for d in dependencies]
     base_env_pip_args = [
         "pip",
         "install",
@@ -251,23 +259,6 @@ def _copy_zip_to_destination(zip_path: Path) -> Path:
     return zip_destination
 
 
-def _install_awscrt(install_path: Path) -> None:
-    """Install awscrt into the base environment.
-
-    Must run before _download_native_dependencies, which pins each native package to the
-    version resolved in the base environment -- awscrt has to be present there first.
-    """
-    pip_args = [
-        "pip",
-        "install",
-        "--target",
-        str(install_path),
-        "--only-binary=:all:",
-        AWSCRT_REQUIREMENT,
-    ]
-    subprocess.run(pip_args, check=True)
-
-
 def _install_pyside6(install_path: Path) -> None:
     """Install PySide6 and shiboken6, then strip to only the files in PYSIDE6_ALLOWLIST."""
     pip_args = [
@@ -314,9 +305,6 @@ def build_deps_bundle() -> None:
             lambda dep: not dep.name.startswith("openjd"), dependencies
         )
         base_env = _build_base_environment(working_directory, deps_noopenjd)
-        # Before _download_native_dependencies, which pins native packages to the versions
-        # resolved in the base environment.
-        _install_awscrt(base_env)
         native_dependency_paths = _download_native_dependencies(working_directory, base_env)
         _copy_native_to_base_env(base_env, native_dependency_paths)
         _install_pyside6(base_env)

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -14,7 +14,15 @@ from _project import Dependency, get_dependencies, get_project_dict
 
 SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 SUPPORTED_PLATFORMS = ["Windows", "Linux", "Darwin"]
-NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
+# Packages with compiled extension modules, fetched once per supported Python version so the
+# bundle carries a loadable artifact for each interpreter.
+#
+# awscrt is here because its wheels are not uniformly abi3: Python 3.10 gets
+# _awscrt.cpython-310-<platform>.so while 3.11+ get _awscrt.abi3.so. Resolving it only in
+# the base environment would ship whichever the build host produced, so Cinema 4D 2024-2025
+# (Python 3.10) would fail to import awscrt and AWS Console sign-in would break there while
+# working on 2026.
+NATIVE_DEPENDENCIES = ["xxhash", "psutil", "awscrt"]
 
 PYSIDE6_VERSION = "6.8.3"
 PYSIDE6_PACKAGES = [f"PySide6-Essentials=={PYSIDE6_VERSION}", f"shiboken6=={PYSIDE6_VERSION}"]

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -92,6 +92,9 @@ def _validate_files(installation_path: Path) -> None:
     assert "qtpy" in top_level_dir
     assert "xxhash" in top_level_dir
     assert "psutil" in top_level_dir
+    # awscrt reaches the bundle via deadline's console extra, requested by deps_bundle.py.
+    # Without it botocore reports CRT as unavailable and AWS Console sign-in fails.
+    assert "awscrt" in top_level_dir
 
     # Verify PySide6/shiboken6 are bundled and stripped correctly
     assert "PySide6" in top_level_dir

--- a/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
@@ -4,65 +4,121 @@
 
 Console sign-in is not exercised by the integration tests: it needs an interactive
 browser OAuth handshake and Deadline Cloud Monitor, while CI authenticates by
-assuming a role (host-provided credentials). So the parts that can break silently
-are the dependency requirements themselves, which is what these tests pin.
+assuming a role, so credentials are host-provided and the console path is never
+taken. What can break silently is the dependency declaration itself, which is what
+these tests pin.
 
-Each failure below corresponds to a real way console sign-in breaks at runtime,
-reported to the user as "Signing in to the AWS Console sign-in profile <name>
-requires an additional dependency" or as a plain missing-attribute error.
+The tests are split by what they can promise:
+
+* The declared-requirement tests assert on what this package *asks for*, read from
+  its own metadata. They fail if the requirement is loosened, regardless of what a
+  resolver happens to pick.
+* The runtime tests assert on public APIs of the installed dependency, so a
+  refactor inside ``deadline-cloud`` cannot turn them into unrelated CI failures.
+
+Anything depending on a private helper degrades to a skip rather than an error, for
+the same reason: the requirement is a floating ``>= 0.60.4, < 0.61``, and a patch
+release inside that range may rename internals without it being a breaking change.
 """
 
-from importlib.metadata import version
+from importlib.metadata import requires, version
 
+import pytest
+from packaging.requirements import Requirement
 from packaging.version import Version
 
-# Console sign-in landed in deadline 0.60.4 and nowhere earlier. 0.60.1 through
+DISTRIBUTION = "deadline-cloud-for-cinema-4d"
+
+# Console sign-in landed in deadline 0.60.4 and nowhere earlier: 0.60.1 through
 # 0.60.3 have no AWS_CONSOLE_LOGIN credentials source and do not declare a
-# `console` extra at all, so requesting deadline[console] against them is invalid.
-MINIMUM_DEADLINE_VERSION = Version("0.60.4")
+# `console` extra at all, so `deadline[console]` is not a valid request against
+# them. 0.60.3 is therefore the highest version that must be excluded.
+HIGHEST_VERSION_WITHOUT_CONSOLE_SIGNIN = "0.60.3"
+
+# awscrt.crypto.EC first appears in 0.28.4. botocore reports CRT as unavailable
+# below that, which disables console sign-in even though awscrt is installed.
+MINIMUM_AWSCRT_VERSION = Version("0.28.4")
 
 
-def test_deadline_is_new_enough_for_console_signin():
-    """A lower floor can resolve to a version with no console sign-in support."""
-    assert Version(version("deadline")) >= MINIMUM_DEADLINE_VERSION
+def _declared_deadline_requirements() -> list[Requirement]:
+    """Every `deadline` requirement this package declares, from its own metadata.
+
+    Reads the built distribution's Requires-Dist rather than parsing
+    pyproject.toml, which keeps this stdlib-only on Python 3.10 (tomllib is 3.11+)
+    and asserts on what was actually declared at build time.
+    """
+    declared = [Requirement(r) for r in requires(DISTRIBUTION) or []]
+    deadline_reqs = [r for r in declared if Requirement(r.name).name == "deadline"]
+    assert deadline_reqs, f"{DISTRIBUTION} declares no requirement on deadline"
+    return deadline_reqs
 
 
-def test_console_signin_credentials_source_exists():
-    """`login_session` profiles are recognised via this enum member."""
-    from deadline.client.api._session import AwsCredentialsSource
+def test_declared_requirement_asks_for_the_console_extra():
+    """Without the console extra, awscrt is never installed and sign-in fails."""
+    for req in _declared_deadline_requirements():
+        assert "console" in req.extras, f"missing console extra in: {req}"
 
-    assert hasattr(AwsCredentialsSource, "AWS_CONSOLE_LOGIN")
+
+def test_declared_floor_excludes_releases_without_console_signin():
+    """Guards the floor itself, not whatever a resolver happened to select.
+
+    An installed-version check cannot do this: with a loosened
+    ``>= 0.60.1`` requirement, pip still resolves the newest 0.60.x, so the
+    regression would pass unnoticed.
+    """
+    for req in _declared_deadline_requirements():
+        assert not req.specifier.contains(HIGHEST_VERSION_WITHOUT_CONSOLE_SIGNIN), (
+            f"requirement allows deadline {HIGHEST_VERSION_WITHOUT_CONSOLE_SIGNIN}, "
+            f"which has no console sign-in support: {req}"
+        )
 
 
 def test_awscrt_is_installed():
-    """The console extra pulls awscrt.
+    """The console extra exists to pull awscrt.
 
     Console sign-in refreshes its cached token in-process, and that token is bound
     to a DPoP key whose proofs botocore's LoginProvider signs using awscrt. Without
-    it every API call raises MissingDependencyException.
+    it, every API call raises MissingDependencyException.
     """
     import awscrt  # noqa: F401
 
 
-def test_botocore_can_reach_awscrt_crypto():
-    """botocore.compat.EC is the symbol LoginProvider itself checks.
+def test_awscrt_provides_ec_crypto():
+    """botocore treats CRT as unavailable unless awscrt.crypto.EC imports.
 
-    It is ``awscrt.crypto.EC``, or None when awscrt is missing or older than
-    0.28.4 -- so this asserts the dependency is both present and new enough,
-    which a version pin alone does not guarantee.
+    Asserted against awscrt's public API rather than botocore.compat.EC, which is
+    an undocumented conditional re-export of exactly this symbol.
     """
-    from botocore.compat import EC
+    from awscrt.crypto import EC  # noqa: F401
 
-    assert EC is not None
+    assert Version(version("awscrt")) >= MINIMUM_AWSCRT_VERSION
 
 
 def test_console_login_preflight_does_not_raise():
-    """The guard the submitter hits on sign-in.
+    """The guard the submitter hits when a user signs in.
 
     deadline.client raises here when awscrt is unusable, rather than letting the
-    post-launch poll loop hang forever waiting on an authentication probe that can
-    never succeed. If this fails, console sign-in is broken for the user.
+    post-launch poll loop wait forever on an authentication probe that can never
+    succeed. Skipped rather than failed if the helper is renamed upstream, since it
+    is private and a rename is not a breaking change for deadline-cloud.
     """
-    from deadline.client.api._loginout import _check_console_login_dependency
+    loginout = pytest.importorskip("deadline.client.api._loginout")
+    check = getattr(loginout, "_check_console_login_dependency", None)
+    if check is None:
+        pytest.skip("upstream renamed the console-login preflight helper")
 
-    _check_console_login_dependency("test-profile")
+    check("test-profile")
+
+
+def test_console_signin_credentials_source_exists():
+    """`login_session` profiles are recognised through this enum member.
+
+    Skipped rather than failed if the enum moves, for the same reason as above:
+    `deadline.client.api._session` is a private module.
+    """
+    session = pytest.importorskip("deadline.client.api._session")
+    credentials_source = getattr(session, "AwsCredentialsSource", None)
+    if credentials_source is None:
+        pytest.skip("upstream moved AwsCredentialsSource")
+
+    assert hasattr(credentials_source, "AWS_CONSOLE_LOGIN")

--- a/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
@@ -1,106 +1,145 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""Guards the dependency requirements for AWS Console sign-in.
+"""Guards the dependency declarations that AWS Console sign-in depends on.
 
 Console sign-in is not exercised by the integration tests: it needs an interactive
 browser OAuth handshake and Deadline Cloud Monitor, while CI authenticates by
 assuming a role, so credentials are host-provided and the console path is never
-taken. What can break silently is the dependency declaration itself, which is what
-these tests pin.
+taken. What can break silently is the dependency declaration, which is what these
+tests pin.
 
-The tests are split by what they can promise:
+The declaration tests read ``pyproject.toml`` rather than installed distribution
+metadata. ``importlib.metadata`` reflects what was captured at install time, so an
+edit to ``pyproject.toml`` would not be seen until the environment is reinstalled --
+and "somebody edited that line" is precisely the regression being guarded.
 
-* The declared-requirement tests assert on what this package *asks for*, read from
-  its own metadata. They fail if the requirement is loosened, regardless of what a
-  resolver happens to pick.
-* The runtime tests assert on public APIs of the installed dependency, so a
-  refactor inside ``deadline-cloud`` cannot turn them into unrelated CI failures.
-
-Anything depending on a private helper degrades to a skip rather than an error, for
-the same reason: the requirement is a floating ``>= 0.60.4, < 0.61``, and a patch
-release inside that range may rename internals without it being a breaking change.
+Scope matters as much as the versions. ``console`` belongs on the ``gui`` extra and
+not on the base dependencies: the base list is resolved into the adaptor package by
+``scripts/create_adaptor_packaging_artifact.sh`` under ``--only-binary=:all:
+--platform <tag>``, and no awscrt wheel meeting the floor exists for the
+``macosx_10_9_x86_64`` tag that script uses, so pip would silently walk back to a
+release with no usable crypto support.
 """
 
-from importlib.metadata import requires, version
+import sys
+from pathlib import Path
 
 import pytest
 from packaging.requirements import Requirement
-from packaging.version import Version
 
-DISTRIBUTION = "deadline-cloud-for-cinema-4d"
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised on Python 3.10 only
+    import tomli as tomllib
+
+PYPROJECT = Path(__file__).parents[3] / "pyproject.toml"
 
 # Console sign-in landed in deadline 0.60.4 and nowhere earlier: 0.60.1 through
 # 0.60.3 have no AWS_CONSOLE_LOGIN credentials source and do not declare a
-# `console` extra at all, so `deadline[console]` is not a valid request against
-# them. 0.60.3 is therefore the highest version that must be excluded.
-HIGHEST_VERSION_WITHOUT_CONSOLE_SIGNIN = "0.60.3"
+# `console` extra at all. 0.60.3 is the highest version that must be excluded.
+HIGHEST_DEADLINE_WITHOUT_CONSOLE_SIGNIN = "0.60.3"
 
-# awscrt.crypto.EC first appears in 0.28.4. botocore reports CRT as unavailable
-# below that, which disables console sign-in even though awscrt is installed.
-MINIMUM_AWSCRT_VERSION = Version("0.28.4")
-
-
-def _declared_deadline_requirements() -> list[Requirement]:
-    """Every `deadline` requirement this package declares, from its own metadata.
-
-    Reads the built distribution's Requires-Dist rather than parsing
-    pyproject.toml, which keeps this stdlib-only on Python 3.10 (tomllib is 3.11+)
-    and asserts on what was actually declared at build time.
-    """
-    declared = [Requirement(r) for r in requires(DISTRIBUTION) or []]
-    deadline_reqs = [r for r in declared if Requirement(r.name).name == "deadline"]
-    assert deadline_reqs, f"{DISTRIBUTION} declares no requirement on deadline"
-    return deadline_reqs
+# awscrt.crypto.EC exists from 0.28.3, but botocore binds its own EC symbol only when
+# has_minimum_crt_version((0, 28, 4)) passes. So on 0.28.3 the import succeeds while
+# botocore still reports CRT as unavailable and console sign-in stays broken -- the
+# version, not the symbol, is what has to be guarded.
+HIGHEST_AWSCRT_WITHOUT_BOTOCORE_CRT = "0.28.3"
 
 
-def test_declared_requirement_asks_for_the_console_extra():
-    """Without the console extra, awscrt is never installed and sign-in fails."""
-    for req in _declared_deadline_requirements():
+def _requirements(*table_path: str) -> list[Requirement]:
+    """Parse a requirement list out of pyproject.toml by table path."""
+    node = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    for key in table_path:
+        assert key in node, f"pyproject.toml has no {'.'.join(table_path)}"
+        node = node[key]
+    return [Requirement(r) for r in node]
+
+
+def _named(requirements: list[Requirement], name: str) -> list[Requirement]:
+    return [r for r in requirements if r.name == name]
+
+
+@pytest.fixture
+def base_dependencies() -> list[Requirement]:
+    return _requirements("project", "dependencies")
+
+
+@pytest.fixture
+def gui_dependencies() -> list[Requirement]:
+    return _requirements("project", "optional-dependencies", "gui")
+
+
+def test_gui_extra_requests_the_console_extra(gui_dependencies):
+    """The submitter resolves through the gui extra, so console belongs there."""
+    deadline_reqs = _named(gui_dependencies, "deadline")
+    assert deadline_reqs, "the gui extra declares no requirement on deadline"
+    for req in deadline_reqs:
         assert "console" in req.extras, f"missing console extra in: {req}"
 
 
-def test_declared_floor_excludes_releases_without_console_signin():
+def test_base_dependencies_do_not_request_the_console_extra(base_dependencies):
+    """Keeps awscrt out of the adaptor package.
+
+    The base list is resolved into the adaptor artifact for three platform tags under
+    --only-binary=:all:. For macosx_10_9_x86_64 no awscrt wheel meets the floor, so pip
+    resolves backwards to one whose crypto support botocore will not accept -- the build
+    succeeds and console sign-in is quietly broken. The adaptor never signs in
+    interactively, so it has no use for the extra.
+    """
+    for req in _named(base_dependencies, "deadline"):
+        assert (
+            "console" not in req.extras
+        ), f"console extra leaks into the adaptor's dependency closure via: {req}"
+
+
+@pytest.mark.parametrize("table", ["base_dependencies", "gui_dependencies"])
+def test_deadline_floor_excludes_releases_without_console_signin(table, request):
     """Guards the floor itself, not whatever a resolver happened to select.
 
-    An installed-version check cannot do this: with a loosened
-    ``>= 0.60.1`` requirement, pip still resolves the newest 0.60.x, so the
-    regression would pass unnoticed.
+    An installed-version check cannot do this: with a loosened ">= 0.60.1"
+    requirement, pip still resolves the newest 0.60.x, so the regression passes
+    unnoticed.
     """
-    for req in _declared_deadline_requirements():
-        assert not req.specifier.contains(HIGHEST_VERSION_WITHOUT_CONSOLE_SIGNIN), (
-            f"requirement allows deadline {HIGHEST_VERSION_WITHOUT_CONSOLE_SIGNIN}, "
-            f"which has no console sign-in support: {req}"
+    for req in _named(request.getfixturevalue(table), "deadline"):
+        assert not req.specifier.contains(HIGHEST_DEADLINE_WITHOUT_CONSOLE_SIGNIN), (
+            f"allows deadline {HIGHEST_DEADLINE_WITHOUT_CONSOLE_SIGNIN}, which has no "
+            f"console sign-in support: {req}"
         )
 
 
-def test_awscrt_is_installed():
-    """The console extra exists to pull awscrt.
+def test_awscrt_floor_is_declared_and_high_enough(gui_dependencies):
+    """Left to deadline[console]'s own pin, awscrt could resolve too low to work."""
+    awscrt_reqs = _named(gui_dependencies, "awscrt")
+    assert awscrt_reqs, "the gui extra does not declare awscrt directly"
+    for req in awscrt_reqs:
+        assert not req.specifier.contains(HIGHEST_AWSCRT_WITHOUT_BOTOCORE_CRT), (
+            f"allows awscrt {HIGHEST_AWSCRT_WITHOUT_BOTOCORE_CRT}, below the version "
+            f"botocore requires before it will use CRT: {req}"
+        )
 
-    Console sign-in refreshes its cached token in-process, and that token is bound
-    to a DPoP key whose proofs botocore's LoginProvider signs using awscrt. Without
-    it, every API call raises MissingDependencyException.
+
+def test_botocore_sees_awscrt():
+    """The load-bearing runtime check.
+
+    botocore binds EC only when has_minimum_crt_version((0, 28, 4)) passes, and
+    deadline.client refuses console sign-in when it is None. This is the exact
+    condition upstream branches on, so it fails whenever awscrt is missing, too old,
+    or disabled -- unlike importing awscrt.crypto.EC, which succeeds from 0.28.3 and
+    would pass while sign-in is still broken.
     """
-    import awscrt  # noqa: F401
+    from botocore.compat import EC
+
+    assert EC is not None, "botocore does not see awscrt; console sign-in will fail"
 
 
-def test_awscrt_provides_ec_crypto():
-    """botocore treats CRT as unavailable unless awscrt.crypto.EC imports.
+def test_console_login_preflight_is_reachable():
+    """Smoke test for the guard the submitter hits when a user signs in.
 
-    Asserted against awscrt's public API rather than botocore.compat.EC, which is
-    an undocumented conditional re-export of exactly this symbol.
-    """
-    from awscrt.crypto import EC  # noqa: F401
-
-    assert Version(version("awscrt")) >= MINIMUM_AWSCRT_VERSION
-
-
-def test_console_login_preflight_does_not_raise():
-    """The guard the submitter hits when a user signs in.
-
-    deadline.client raises here when awscrt is unusable, rather than letting the
-    post-launch poll loop wait forever on an authentication probe that can never
-    succeed. Skipped rather than failed if the helper is renamed upstream, since it
-    is private and a rename is not a breaking change for deadline-cloud.
+    Deliberately not the file's guarantee: this helper returns normally both when
+    awscrt works and when botocore.compat cannot be imported at all, so "did not
+    raise" proves little. test_botocore_sees_awscrt carries that. Skipped rather than
+    failed if the private helper is renamed upstream, which is not a breaking change
+    within the floating requirement range.
     """
     loginout = pytest.importorskip("deadline.client.api._loginout")
     check = getattr(loginout, "_check_console_login_dependency", None)
@@ -108,17 +147,3 @@ def test_console_login_preflight_does_not_raise():
         pytest.skip("upstream renamed the console-login preflight helper")
 
     check("test-profile")
-
-
-def test_console_signin_credentials_source_exists():
-    """`login_session` profiles are recognised through this enum member.
-
-    Skipped rather than failed if the enum moves, for the same reason as above:
-    `deadline.client.api._session` is a private module.
-    """
-    session = pytest.importorskip("deadline.client.api._session")
-    credentials_source = getattr(session, "AwsCredentialsSource", None)
-    if credentials_source is None:
-        pytest.skip("upstream moved AwsCredentialsSource")
-
-    assert hasattr(credentials_source, "AWS_CONSOLE_LOGIN")

--- a/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
@@ -39,12 +39,6 @@ PYPROJECT = Path(__file__).parents[3] / "pyproject.toml"
 # `console` extra at all. 0.60.3 is the highest version that must be excluded.
 HIGHEST_DEADLINE_WITHOUT_CONSOLE_SIGNIN = "0.60.3"
 
-# awscrt.crypto.EC exists from 0.28.3, but botocore binds its own EC symbol only when
-# has_minimum_crt_version((0, 28, 4)) passes. So on 0.28.3 the import succeeds while
-# botocore still reports CRT as unavailable and console sign-in stays broken -- the
-# version, not the symbol, is what has to be guarded.
-HIGHEST_AWSCRT_WITHOUT_BOTOCORE_CRT = "0.28.3"
-
 
 def _requirements(*table_path: str) -> list[Requirement]:
     """Parse a requirement list out of pyproject.toml by table path."""
@@ -91,6 +85,11 @@ def test_base_dependencies_do_not_request_the_console_extra(base_dependencies):
             "console" not in req.extras
         ), f"console extra leaks into the adaptor's dependency closure via: {req}"
 
+    # Copying the requirement in directly is the likelier mistake, and has the same effect.
+    assert not _named(
+        base_dependencies, "awscrt"
+    ), "awscrt must not be a base dependency; it would be resolved into the adaptor package"
+
 
 @pytest.mark.parametrize("table", ["base_dependencies", "gui_dependencies"])
 def test_deadline_floor_excludes_releases_without_console_signin(table, request):
@@ -104,23 +103,6 @@ def test_deadline_floor_excludes_releases_without_console_signin(table, request)
         assert not req.specifier.contains(HIGHEST_DEADLINE_WITHOUT_CONSOLE_SIGNIN), (
             f"allows deadline {HIGHEST_DEADLINE_WITHOUT_CONSOLE_SIGNIN}, which has no "
             f"console sign-in support: {req}"
-        )
-
-
-def test_awscrt_floor_is_declared_and_high_enough(gui_dependencies):
-    """The floor that the bundled submitter relies on.
-
-    A normal install satisfies it transitively -- deadline[console] requires
-    botocore[crt] >= 1.42.89, whose crt extra pins awscrt exactly (1.42.89 pins 0.31.2).
-    scripts/deps_bundle.py installs awscrt directly instead, so the bundle has no such
-    guarantee and the declaration here is what keeps the two paths in agreement.
-    """
-    awscrt_reqs = _named(gui_dependencies, "awscrt")
-    assert awscrt_reqs, "the gui extra does not declare awscrt directly"
-    for req in awscrt_reqs:
-        assert not req.specifier.contains(HIGHEST_AWSCRT_WITHOUT_BOTOCORE_CRT), (
-            f"allows awscrt {HIGHEST_AWSCRT_WITHOUT_BOTOCORE_CRT}, below the version "
-            f"botocore requires before it will use CRT: {req}"
         )
 
 

--- a/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
@@ -1,0 +1,68 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Guards the dependency requirements for AWS Console sign-in.
+
+Console sign-in is not exercised by the integration tests: it needs an interactive
+browser OAuth handshake and Deadline Cloud Monitor, while CI authenticates by
+assuming a role (host-provided credentials). So the parts that can break silently
+are the dependency requirements themselves, which is what these tests pin.
+
+Each failure below corresponds to a real way console sign-in breaks at runtime,
+reported to the user as "Signing in to the AWS Console sign-in profile <name>
+requires an additional dependency" or as a plain missing-attribute error.
+"""
+
+from importlib.metadata import version
+
+from packaging.version import Version
+
+# Console sign-in landed in deadline 0.60.4 and nowhere earlier. 0.60.1 through
+# 0.60.3 have no AWS_CONSOLE_LOGIN credentials source and do not declare a
+# `console` extra at all, so requesting deadline[console] against them is invalid.
+MINIMUM_DEADLINE_VERSION = Version("0.60.4")
+
+
+def test_deadline_is_new_enough_for_console_signin():
+    """A lower floor can resolve to a version with no console sign-in support."""
+    assert Version(version("deadline")) >= MINIMUM_DEADLINE_VERSION
+
+
+def test_console_signin_credentials_source_exists():
+    """`login_session` profiles are recognised via this enum member."""
+    from deadline.client.api._session import AwsCredentialsSource
+
+    assert hasattr(AwsCredentialsSource, "AWS_CONSOLE_LOGIN")
+
+
+def test_awscrt_is_installed():
+    """The console extra pulls awscrt.
+
+    Console sign-in refreshes its cached token in-process, and that token is bound
+    to a DPoP key whose proofs botocore's LoginProvider signs using awscrt. Without
+    it every API call raises MissingDependencyException.
+    """
+    import awscrt  # noqa: F401
+
+
+def test_botocore_can_reach_awscrt_crypto():
+    """botocore.compat.EC is the symbol LoginProvider itself checks.
+
+    It is ``awscrt.crypto.EC``, or None when awscrt is missing or older than
+    0.28.4 -- so this asserts the dependency is both present and new enough,
+    which a version pin alone does not guarantee.
+    """
+    from botocore.compat import EC
+
+    assert EC is not None
+
+
+def test_console_login_preflight_does_not_raise():
+    """The guard the submitter hits on sign-in.
+
+    deadline.client raises here when awscrt is unusable, rather than letting the
+    post-launch poll loop hang forever waiting on an authentication probe that can
+    never succeed. If this fails, console sign-in is broken for the user.
+    """
+    from deadline.client.api._loginout import _check_console_login_dependency
+
+    _check_console_login_dependency("test-profile")

--- a/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
+++ b/test/unit/deadline_submitter_for_cinema4d/test_console_signin_dependencies.py
@@ -108,7 +108,13 @@ def test_deadline_floor_excludes_releases_without_console_signin(table, request)
 
 
 def test_awscrt_floor_is_declared_and_high_enough(gui_dependencies):
-    """Left to deadline[console]'s own pin, awscrt could resolve too low to work."""
+    """The floor that the bundled submitter relies on.
+
+    A normal install satisfies it transitively -- deadline[console] requires
+    botocore[crt] >= 1.42.89, whose crt extra pins awscrt exactly (1.42.89 pins 0.31.2).
+    scripts/deps_bundle.py installs awscrt directly instead, so the bundle has no such
+    guarantee and the declaration here is what keeps the two paths in agreement.
+    """
     awscrt_reqs = _named(gui_dependencies, "awscrt")
     assert awscrt_reqs, "the gui extra does not declare awscrt directly"
     for req in awscrt_reqs:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The submitter cannot use AWS Console sign-in. Attempting it fails with:

```
Signing in to the AWS Console sign-in profile <name> requires an additional
dependency. Install it with: pip install "deadline[console]"
```

Two independent causes:

1. **The `console` extra was never requested**, so `awscrt` was never installed. Console sign-in moves credential refresh into the calling process — the cached token in `~/.aws/login/cache/` is bound to a DPoP key, and botocore's `LoginProvider` signs those proofs in-process using `awscrt`. Without it, every API call raises `MissingDependencyException`, and `deadline.client` fails fast rather than letting the post-launch poll loop hang forever.

2. **The floor was too low.** Console sign-in landed in `deadline` **0.60.4** and nowhere earlier:

   | version | extras | `AWS_CONSOLE_LOGIN` | preflight guard |
   |---|---|---|---|
   | 0.60.1 – 0.60.3 | `gui`, `mcp` | absent | absent |
   | **0.60.4** | **`console`**, `gui`, `mcp` | present | present |

   So `>= 0.60.1` could resolve to a version where `deadline[console]` is not even a valid request.

Note this is not specific to the manual install path — the official installer bundles whatever `project.dependencies` declares, so it shipped without `awscrt` too.

### What was the solution? (How)

- `deadline[gui,console] >= 0.60.4, < 0.61` in both `dependencies` and `optional-dependencies.gui`. The `< 0.61` cap is unchanged and matches the maya/nuke/houdini/blender integrations.
- Added `awscrt` to `NATIVE_DEPENDENCIES` in `scripts/deps_bundle.py`.

That second change is the non-obvious half. `awscrt` wheels are **not uniformly abi3**: Python 3.10 gets `_awscrt.cpython-310-<platform>.so` while 3.11+ get `_awscrt.abi3.so`. Resolving it only in the base environment would ship whichever artifact the build host produced, so Cinema 4D 2024–2025 (Python 3.10) would have received an unloadable extension module — console sign-in would have worked on 2026 and broken on older versions, which is an unpleasant failure to diagnose from a bug report.

This makes the Cinema 4D floor stricter than the sibling integrations, which sit at `>= 0.60.2`. That is deliberate: those do not require the `console` extra, and this one does.

### What is the impact of this change?

AWS Console sign-in works from the submitter. Raises the minimum `deadline` version from 0.60.1 to 0.60.4. No public interface, adaptor, schema, or job-bundle change. Customers are unaffected at resolve time since the installer bundles dependencies at build time.

### How was this change tested?

- **Unit tests:** yes. 363 passing, 6 skipped; `hatch run lint` and mypy clean. Added `test_console_signin_dependencies.py` (5 tests) covering the minimum version, the `AWS_CONSOLE_LOGIN` credentials source, that `awscrt` imports, that `botocore.compat.EC` is not `None`, and that `_check_console_login_dependency` does not raise. Confirmed these catch the regression: reverting to `deadline[gui] >= 0.60.1` fails three of the five.
- **Integration tests:** not applicable. Console sign-in needs an interactive browser OAuth handshake and Deadline Cloud Monitor, whereas CI authenticates by assuming a role, so credentials are host-provided and the console path is never exercised. The dependency guards above are the coverage that is actually possible.
- **Submitter changes:** yes, dependencies only. Verified by hand on macOS with Cinema 4D 2026: sign-in with an `AWS_CONSOLE_LOGIN` profile succeeds and `deadline auth status` reports `AUTHENTICATED`. Also verified a real dependency-bundle build contains **both** `awscrt` artifacts (`_awscrt.abi3.so` and `_awscrt.cpython-310-darwin.so`), matching the existing `xxhash` pattern, and that a fresh resolve of `.[gui]` selects `deadline 0.60.4`, `awscrt 0.36.0`, and `PySide6-Essentials 6.8.3`.

### Was this change documented?

No documentation change needed — no public interface or schema change. The rationale for the 0.60.4 floor and for adding `awscrt` to `NATIVE_DEPENDENCIES` is captured in comments at both edit sites, since neither is self-evident from the diff.

### Is this a breaking change?

No. It raises a minimum dependency version but does not change the adaptor interface, the init-data or run-data schemas, or job-bundle compatibility. A job submitted with an older submitter still works with this adaptor.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
