### PR TITLE
fix: raise the osx-64 PyPI platform tag to macOS 10.15

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -33,7 +33,7 @@ if [ "$CONDA_PLATFORM" = "linux-64" ]; then
 elif [ "$CONDA_PLATFORM" = "win-64" ]; then
     PYPI_PLATFORM=win_amd64
 elif [ "$CONDA_PLATFORM" = "osx-64" ]; then
-    PYPI_PLATFORM=macosx_10_9_x86_64
+    PYPI_PLATFORM=macosx_10_15_x86_64
 else
     echo "Unknown Conda operating system option --platform $CONDA_PLATFORM"
     exit 1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`scripts/create_adaptor_packaging_artifact.sh` resolves the adaptor's dependencies for `osx-64` against the PyPI platform tag `macosx_10_9_x86_64`. macOS 10.9 shipped in 2013. pip treats the tag as a ceiling — it accepts any wheel built for an equal or older deployment target — so the effect is not "supports old macOS", it is "silently pins every dependency to whatever version last published a 10.9 build."

Resolving the adaptor for Python 3.11 under each tag, same package set, different versions:

| package | `macosx_10_9_x86_64` | `macosx_10_15_x86_64` |
|---|---|---|
| rpds-py | 0.13.2 | 2026.6.3 |
| PyYAML | 6.0.2 | 6.0.3 |
| jsonschema | 4.25.1 | 4.26.0 |

rpds-py is the notable one: the old tag holds it years behind because upstream stopped publishing a 10.9 wheel. Packages that publish no 10.9 wheel at all are excluded outright rather than downgraded — `awscrt` is one, its macOS wheels start at `macosx_10_15_universal2`, which is a blocker for anything that needs it (see #525).

### What was the solution? (How)

Raise the tag to `macosx_10_15_x86_64`. Because pip accepts wheels built for equal-or-older targets, 10.15 is a strict superset of 10.9 — no wheel that resolved before stops resolving.

The other `deadline-cloud-for-*` repos carry the same `macosx_10_9_x86_64` line in their copy of this script. This change is scoped to Cinema 4D.

### What is the impact of this change?

The `osx-64` adaptor conda artifact picks up current builds of its native dependencies instead of ones frozen by a 2013 deployment target, and packages with a 10.15 wheel floor become resolvable. macOS is not a supported fleet platform for this integration today (README: Windows and Linux fleets), so nothing in the shipped render path changes. No adaptor interface, schema, submitter, or job-bundle change.

### How was this change tested?

The script is not invoked by any workflow in this repo, so it was run by hand. `bash scripts/create_adaptor_packaging_artifact.sh --platform osx-64 --python 3.11` completes successfully and produces the tar artifact, installing `pyyaml 6.0.3`, `rpds-py 2026.6.3`, and `jsonschema 4.26.0` where the old tag installs `6.0.2`, `0.13.2`, and `4.25.1`. The version table above comes from `pip install --dry-run --report` under each tag, with `--only-binary=:all: --python-version 3.11`, confirming the package set is identical and only the selected builds differ.

- Unit tests: not run — no Python source changed.
- Integration tests: not applicable.
- Submitter changes: none.

### Was this change documented?

No documentation change needed. The tag is an internal packaging detail and no public interface or schema changed.

### Is this a breaking change?

No. It relaxes wheel selection rather than restricting it, and does not touch the adaptor interface, the init-data or run-data schemas, or job-bundle compatibility.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*