### PR TITLE
fix: improve Cinema 4D license error handling

### DIFF
--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -275,13 +275,8 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                 re.compile(r".*Rendering failed.*", re.IGNORECASE),
                 re.compile(r".*Asset missing.*", re.IGNORECASE),
                 re.compile(r".*Asset Error.*", re.IGNORECASE),
-                re.compile(r".*Invalid License.*", re.IGNORECASE),
-                re.compile(r".*licensing error.*", re.IGNORECASE),
-                re.compile(r".*License Check error.*", re.IGNORECASE),
                 re.compile(r".*Files cannot be written.*", re.IGNORECASE),
-                re.compile(r".*Enter Registration Data.*", re.IGNORECASE),
                 re.compile(r".*Unable to write file.*", re.IGNORECASE),
-                re.compile(r".*\[rlm\] abort_on_license_fail enabled.*", re.IGNORECASE),
                 re.compile(r".*RenderDocument failed with return code.*", re.IGNORECASE),
                 re.compile(r".*Frame rendering aborted.*", re.IGNORECASE),
                 re.compile(r".*Rendering was internally aborted.*", re.IGNORECASE),
@@ -311,6 +306,24 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
                 RegexCallback(
                     [nvidia_driver_regexes],
                     self._handle_nvidia_driver_error,
+                )
+            )
+
+            # License failures cannot recover non-interactively and would otherwise
+            # consume worker time until the initialization timeout.
+            license_error_regexes = [
+                re.compile(r".*Invalid License.*", re.IGNORECASE),
+                re.compile(r".*licensing error.*", re.IGNORECASE),
+                re.compile(r".*License Check error.*", re.IGNORECASE),
+                re.compile(r".*Enter Registration Data.*", re.IGNORECASE),
+                re.compile(r".*\[rlm\] abort_on_license_fail enabled.*", re.IGNORECASE),
+                re.compile(r".*No license found.*", re.IGNORECASE),
+                re.compile(r".*No available licenses to choose.*", re.IGNORECASE),
+            ]
+            callback_list.append(
+                RegexCallback(
+                    license_error_regexes,
+                    self._handle_license_error,
                 )
             )
 
@@ -400,6 +413,19 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         message = (
             f"{detail} "
             "Please update the NVIDIA drivers on your worker fleet. "
+            f"Error: {match.group(0)}"
+        )
+        self._exc_info = RuntimeError(message)
+
+    def _handle_license_error(self, match: re.Match) -> None:
+        """Handle a fatal Cinema 4D licensing failure."""
+        message = (
+            "Cinema 4D failed to acquire a license.\n"
+            "If you are using bring your own license (BYOL), check your license configuration "
+            "and availability.\n"
+            "If you are using usage-based licensing (UBL) from AWS Deadline Cloud and need a "
+            "higher 'License sessions per license endpoint' limit, contact the AWS Deadline Cloud "
+            "team to request an increase.\n"
             f"Error: {match.group(0)}"
         )
         self._exc_info = RuntimeError(message)

--- a/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_cinema4d/Cinema4DAdaptor/test_adaptor.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 # the same Cinema4DAdaptor action queue, which can cause race conditions and
 # test failures when tests run in parallel across multiple workers.
 import json
+import logging
 from pathlib import Path
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -71,8 +72,6 @@ class TestCinema4DAdaptor_errors_on_cleanup:
         [
             # Critical stops should not fail the job.
             ("CRITICAL: Stop [ge_file.cpp(1172)]", False),
-            # Any string with substring "Error:" should fail the job
-            ("Redshift Error: Maxon licensing error: User not logged in (7)", True),
             # This error can be printed but the jobs are still successful.
             # Hence, this should not fail the job.
             ("CRITICAL: nullptr [text_object.cpp(1082)] [objectbase1.hxx(549)]", False),
@@ -84,12 +83,8 @@ class TestCinema4DAdaptor_errors_on_cleanup:
             ("Rendering failed", True),
             ("Asset missing", True),
             ("Asset Error", True),
-            ("Invalid License", True),
-            ("License Check error", True),
             ("Files cannot be written", True),
-            ("Enter Registration Data", True),
             ("Unable to write file", True),
-            ("[rlm] abort_on_license_fail enabled", True),
             ("RenderDocument failed with return code", True),
             ("Frame rendering aborted", True),
             ("Rendering was internally aborted", True),
@@ -363,6 +358,66 @@ class TestCinema4DAdaptor_on_start:
 
         # THEN
         assert mock_sleep.call_count == 3
+
+    @pytest.mark.parametrize(
+        "license_error",
+        [
+            "Redshift Error: Maxon licensing error: User not logged in (7)",
+            "Invalid License",
+            "License Check error",
+            "Enter Registration Data",
+            "[rlm] abort_on_license_fail enabled",
+            "17:44:34 No license found",
+            "18:38:54 No available licenses to choose",
+        ],
+    )
+    def test_license_failure_from_stdout_interrupts_startup(
+        self, init_data: dict, license_error: str
+    ) -> None:
+        """Tests that a licensing prompt fails startup without waiting for the timeout."""
+        # General error checking is optional, but a licensing prompt cannot recover
+        # without interactive input and must always stop the worker.
+        init_data["activate_error_checking"] = "0"
+        adaptor = Cinema4DAdaptor(init_data)
+        expected_error = (
+            "Cinema 4D failed to acquire a license.\n"
+            "If you are using bring your own license (BYOL), check your license configuration "
+            "and availability.\n"
+            "If you are using usage-based licensing (UBL) from AWS Deadline Cloud and need a "
+            "higher 'License sessions per license endpoint' limit, contact the AWS Deadline Cloud "
+            "team to request an increase.\n"
+            f"Error: {license_error}"
+        )
+
+        def emit_license_error(*args, **kwargs):
+            kwargs["stdout_handler"].emit(
+                logging.LogRecord(
+                    name="cinema4d",
+                    level=logging.ERROR,
+                    pathname="",
+                    lineno=0,
+                    msg=license_error,
+                    args=(),
+                    exc_info=None,
+                )
+            )
+            process = Mock()
+            process.is_running = True
+            return process
+
+        with (
+            patch.object(adaptor, "_initialize_maxon_assets_db_connection"),
+            patch.object(adaptor, "_start_cinema4d_server_thread"),
+            patch.object(adaptor, "_populate_action_queue"),
+            patch(
+                "deadline.cinema4d_adaptor.Cinema4DAdaptor.adaptor.LoggingSubprocess",
+                side_effect=emit_license_error,
+            ),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            adaptor.on_start()
+
+        assert str(exc_info.value) == expected_error
 
 
 @pytest.mark.xdist_group(name="adaptor_tests")


### PR DESCRIPTION
## Summary

- fail Cinema 4D startup immediately when fatal RLM licensing output is detected
- emit the licensing failure and guidance as separate, readable log lines
- direct BYOL users to check their license configuration and availability
- direct AWS Deadline Cloud usage-based licensing (UBL) users who need a higher `License sessions per license endpoint` limit to contact the AWS Deadline Cloud team
- centralize definitive license errors and non-interactive license prompts under an unconditional fail-fast handler

## Testing

- `hatch run fmt`
- `hatch run lint`
- `hatch run test` (`371 passed, 6 skipped`)
- submitted a Cinema 4D 2026 job to an isolated Deadline Cloud queue and Spot GPU fleet with invalid license endpoints; `openjd_fail` followed the detected license error by 1 ms

```
2026/08/18 12:44:55-07:00 STDOUT: Enter RLM Settings (ENTER to keep input):
2026/08/18 12:44:55-07:00 STDOUT: No available licenses to choose.
2026/08/18 12:44:55-07:00 STDOUT: RLM method:
2026/08/18 12:44:55-07:00 STDOUT: 1) Online
2026/08/18 12:44:55-07:00 STDOUT: 2) Offline
2026/08/18 12:44:55-07:00 STDOUT: Q) Quit
2026/08/18 12:44:55-07:00 openjd_fail: Error encountered while starting adaptor: Cinema 4D failed to acquire a license.
2026/08/18 12:44:55-07:00 If you are using bring your own license (BYOL), check your license configuration and availability.
2026/08/18 12:44:55-07:00 If you are using usage-based licensing (UBL) from AWS Deadline Cloud and need a higher 'License sessions per license endpoint' limit, contact the AWS Deadline Cloud team to request an increase.
2026/08/18 12:44:55-07:00 Error: No available licenses to choose.
2026/08/18 12:44:55-07:00 Process pid 14433 exited with code: 1 (unsigned) / 0x1 (hex)
```
