### PR TITLE
ci: Split release preparation and publishing

### DIFF
--- a/.github/workflows/release_prepare.yml
+++ b/.github/workflows/release_prepare.yml
@@ -1,0 +1,105 @@
+name: "Release: Prepare"
+run-name: "Release: Prepare ${{ github.event.head_commit.message || inputs.tag }}"
+
+on:
+  push:
+    branches:
+      - mainline
+    paths:
+      - CHANGELOG.md
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: Specify a tag to re-run a release.
+
+concurrency:
+  group: release
+
+permissions:
+  contents: read
+
+jobs:
+  TagRelease:
+    if: >-
+      github.repository == 'aws-deadline/deadline-cloud-for-cinema-4d' &&
+      github.ref == 'refs/heads/mainline'
+    uses: aws-deadline/.github/.github/workflows/reusable_tag_release.yml@mainline
+    secrets: inherit
+    with:
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+
+  UnitTests:
+    needs: [TagRelease]
+    name: Unit Tests
+    uses: ./.github/workflows/code_quality.yml
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
+  Xa11yWindows:
+    needs: [TagRelease, UnitTests]
+    name: xa11y Integration Tests (Windows, Cinema 4D ${{ matrix.c4d_version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        c4d_version: ["2024", "2025", "2026"]
+    uses: ./.github/workflows/integ_windows.yml
+    with:
+      c4d_version: ${{ matrix.c4d_version }}
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      RLM_PORT: ${{ secrets.RLM_PORT }}
+      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
+      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
+      LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
+      BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
+    permissions:
+      id-token: write
+      contents: read
+
+  Xa11yMacOS:
+    needs: [TagRelease, UnitTests]
+    name: xa11y Integration Tests (macOS, Cinema 4D ${{ matrix.c4d_version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        c4d_version: ["2024", "2025", "2026"]
+    uses: ./.github/workflows/integ_macos.yml
+    with:
+      c4d_version: ${{ matrix.c4d_version }}
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      RLM_PORT: ${{ secrets.RLM_PORT }}
+      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
+      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
+      LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
+      BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
+    permissions:
+      id-token: write
+      contents: read
+
+  BuildInstaller:
+    needs: [TagRelease, UnitTests, Xa11yWindows, Xa11yMacOS]
+    uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      ref_type: tags
+      ref: ${{ needs.TagRelease.outputs.tag }}
+      oses: "['Windows', 'MacOS']"
+      environment: release
+      project_name: ${{ github.event.repository.name }}
+
+  PublishToCodeArtifact:
+    needs: [TagRelease, BuildInstaller]
+    uses: aws-deadline/.github/.github/workflows/reusable_publish_python.yml@mainline
+    permissions:
+      id-token: write
+    secrets: inherit
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,18 +1,21 @@
 name: "Release: Publish"
-run-name: "Release: ${{ github.event.head_commit.message || inputs.tag }}"
+run-name: "Release: Publish ${{ inputs.tag || 'next pending release' }}"
 
 on:
-  push:
-    branches:
-      - mainline
-    paths:
-      - CHANGELOG.md
+  schedule:
+    # Check at 00:17, 06:17, 12:17, and 18:17 UTC.
+    - cron: "17 */6 * * *"
   workflow_dispatch:
     inputs:
       tag:
-        required: true
+        description: Specific pending release tag to check
+        required: false
         type: string
-        description: Specify a tag to re-run a release.
+      force_publish:
+        description: Bypass Conda availability after release-gate approval (requires tag)
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release
@@ -21,150 +24,149 @@ permissions:
   contents: read
 
 jobs:
-  TagRelease:
-    uses: aws-deadline/.github/.github/workflows/reusable_tag_release.yml@mainline
-    secrets: inherit
-    with:
-      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+  CheckConda:
+    if: github.repository == 'aws-deadline/deadline-cloud-for-cinema-4d'
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.readiness.outputs.ready }}
+      tag: ${{ steps.readiness.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-  UnitTests:
-    needs: [TagRelease]
-    name: Unit Tests
-    uses: ./.github/workflows/code_quality.yml
-    with:
-      tag: ${{ needs.TagRelease.outputs.tag }}
+      - name: Check release readiness
+        id: readiness
+        uses: aws-deadline/.github/.github/actions/check-release-readiness@mainline
+        with:
+          github-token: ${{ github.token }}
+          requested-tag: ${{ inputs.tag }}
+          force-publish: ${{ inputs.force_publish }}
+          package-name: cinema4d-openjd
+          required-platforms: linux-64,win-64
+          timeout-days: 4
 
-  Xa11yWindows:
-    needs: [TagRelease, UnitTests]
-    name: xa11y Integration Tests (Windows, Cinema 4D ${{ matrix.c4d_version }})
-    strategy:
-      fail-fast: false
-      matrix:
-        c4d_version: ["2024", "2025", "2026"]
-    uses: ./.github/workflows/integ_windows.yml
-    with:
-      c4d_version: ${{ matrix.c4d_version }}
-    secrets:
-      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      RLM_PORT: ${{ secrets.RLM_PORT }}
-      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
-      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
-      LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
-      BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
-    permissions:
-      id-token: write
-      contents: read
-
-  Xa11yMacOS:
-    needs: [TagRelease, UnitTests]
-    name: xa11y Integration Tests (macOS, Cinema 4D ${{ matrix.c4d_version }})
-    strategy:
-      fail-fast: false
-      matrix:
-        c4d_version: ["2024", "2025", "2026"]
-    uses: ./.github/workflows/integ_macos.yml
-    with:
-      c4d_version: ${{ matrix.c4d_version }}
-    secrets:
-      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      RLM_PORT: ${{ secrets.RLM_PORT }}
-      INSTALLER_BUCKET: ${{ secrets.INSTALLER_BUCKET }}
-      INSTALLER_BUCKET_EXPECTED_OWNER: ${{ secrets.INSTALLER_BUCKET_EXPECTED_OWNER }}
-      LICENSE_ROLE_ARN: ${{ secrets.LICENSE_ROLE_ARN }}
-      BASTION_INSTANCE_TAG: ${{ secrets.BASTION_INSTANCE_TAG }}
-    permissions:
-      id-token: write
-      contents: read
-
-  PreRelease:
-      needs: [TagRelease, UnitTests, Xa11yWindows, Xa11yMacOS]
-      uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
-      permissions:
-        id-token: write
-        contents: write
-      secrets: inherit
-      with:
-          tag: ${{ needs.TagRelease.outputs.tag }}
-
-  BuildInstaller:
-    needs: [TagRelease, PreRelease]
-    uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      ref_type: tags
-      ref: ${{ needs.TagRelease.outputs.tag }}
-      oses: "['Windows', 'MacOS']"
-      environment: release
-      project_name: ${{ github.event.repository.name }}
-
-  Publish:
-      needs: [TagRelease, BuildInstaller]
-      uses: aws-deadline/.github/.github/workflows/reusable_publish_python.yml@mainline
-      permissions:
-        id-token: write
-      secrets: inherit
-      with:
-          tag: ${{ needs.TagRelease.outputs.tag }}
-
-  IsCondaReady:
-    needs: Publish
+  ApproveManifestOverride:
+    needs: CheckConda
+    if: >-
+      inputs.force_publish == true &&
+      needs.CheckConda.outputs.tag != '' &&
+      needs.CheckConda.outputs.ready != 'true'
     runs-on: ubuntu-latest
     environment: release-gate
-    name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
+    permissions: {}
     steps:
-      - run: |
-         :
-  
+      - name: Record approved override
+        env:
+          TAG: ${{ needs.CheckConda.outputs.tag }}
+        run: |
+          echo "Conda manifest override approved for release $TAG."
+          {
+            echo "### Conda manifest override"
+            echo
+            printf 'Release `%s` was approved without a published Conda package.\n' "$TAG"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  AuthorizePublish:
+    needs: [CheckConda, ApproveManifestOverride]
+    if: >-
+      always() &&
+      needs.CheckConda.result == 'success' &&
+      needs.CheckConda.outputs.tag != '' &&
+      (
+        needs.CheckConda.outputs.ready == 'true' ||
+        needs.ApproveManifestOverride.result == 'success'
+      )
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+    steps:
+      - name: Authorize public release
+        id: release
+        env:
+          TAG: ${{ needs.CheckConda.outputs.tag }}
+        run: echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  ValidateRelease:
+    needs: AuthorizePublish
+    if: needs.AuthorizePublish.outputs.tag != ''
+    uses: aws-deadline/.github/.github/workflows/reusable_tag_release.yml@mainline
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      tag: ${{ needs.AuthorizePublish.outputs.tag }}
+
+  PreRelease:
+    needs: ValidateRelease
+    if: needs.ValidateRelease.outputs.tag != ''
+    uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
+    permissions:
+      id-token: write
+      contents: write
+    secrets: inherit
+    with:
+      tag: ${{ needs.ValidateRelease.outputs.tag }}
+
   ReleaseInstaller:
-    needs: [TagRelease, IsCondaReady]
+    needs: [ValidateRelease, PreRelease]
+    if: needs.ValidateRelease.outputs.tag != ''
     uses: aws-deadline/.github/.github/workflows/reusable_release_installers.yml@mainline
     secrets: inherit
     permissions:
       id-token: write
       contents: read
     with:
-      tag: ${{ needs.TagRelease.outputs.tag }}
+      tag: ${{ needs.ValidateRelease.outputs.tag }}
       oses: "['Windows', 'MacOS']"
       project_name: ${{ github.event.repository.name }}
 
+  # Create the completion marker before PyPI so scheduled retries cannot
+  # repeatedly release installers. Recover PyPI by rerunning this run's failed job.
   Release:
-      needs: [TagRelease, ReleaseInstaller]
-      uses: aws-deadline/.github/.github/workflows/reusable_release.yml@mainline
-      secrets: inherit
-      permissions:
-        id-token: write
-        contents: write
-      with:
-          tag: ${{ needs.TagRelease.outputs.tag }}
-          
-  # PyPI does not support reusable workflows yet
-  # # See https://github.com/pypi/warehouse/issues/11096
+    needs: [ValidateRelease, PreRelease, ReleaseInstaller]
+    if: needs.ValidateRelease.outputs.tag != ''
+    uses: aws-deadline/.github/.github/workflows/reusable_release.yml@mainline
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      tag: ${{ needs.ValidateRelease.outputs.tag }}
+
+  # PyPI does not support reusable workflows yet.
+  # See https://github.com/pypi/warehouse/issues/11096
   PublishToPyPI:
-    needs: [TagRelease, Release]
+    needs: [ValidateRelease, Release]
+    if: needs.ValidateRelease.outputs.tag != ''
     runs-on: ubuntu-latest
     environment: release
     permissions:
       id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.TagRelease.outputs.tag }}
+          ref: ${{ needs.ValidateRelease.outputs.tag }}
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: ${{ needs.TagRelease.outputs.build-python-version }}
+          python-version: ${{ needs.ValidateRelease.outputs.build-python-version }}
+
       - name: Install dependencies
-        run: |
-          pip install --upgrade hatch
+        run: pip install --upgrade hatch
+
       - name: Build
         run: hatch -v build
-      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          skip-existing: true


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The release workflow waited for asynchronous Conda production promotion and required a manual approval before completing public publication. This required maintainer coordination and left a long gap between preparation and release completion.

### What was the solution? (How)

Split publication into two workflows:

- `Release: Prepare` creates or validates the tag, runs unit and xa11y integration tests, builds and stages installers, and publishes the Python package to CodeArtifact.
- Preparation is restricted to the canonical repository and `mainline`.
- `Release: Publish` runs every six hours or on demand and checks the public Conda manifest for the exact `cinema4d-openjd` version on `linux-64` and `win-64`.
- The public manifest is treated as confirmation that Conda promotion completed across all production waves.
- Automatic publication considers only the newest valid release tag. Newer tags intentionally supersede older unpublished tags.
- The selected tag is validated before releasing installers, publishing to PyPI, and creating the GitHub Release.
- The GitHub Release is created after installer publication and before PyPI. It acts as the completion marker so scheduled runs cannot repeatedly release installers; a PyPI failure is recovered by rerunning the failed job from the original workflow run.
- Force-publishing requires an explicit tag and approval through the `release-gate` environment.

### What is the impact of this change?

Release completion becomes unattended once the package reaches the public Conda manifest. The previous manual readiness gate is removed because production-wave completion is represented by the manifest and required manual coverage has been replaced by xa11y integration tests.

Normal release preparation and artifact publication remain serialized through the shared `release` concurrency group.

### How was this change tested?

- Existing Code Quality, CodeQL, and Security Scan checks passed.
- Ran a [release-readiness smoke workflow](https://github.com/karthikbekalp/deadline-cloud-for-cinema-4d/actions/runs/33443827541) in a personal fork. It verified ready, pending, four-day timeout, and approved manifest-override paths.
- Manually dispatched `Release: Publish` in readiness-only mode to verify a [ready release](https://github.com/karthikbekalp/deadline-cloud-for-cinema-4d/actions/runs/33427972352), [pending release](https://github.com/karthikbekalp/deadline-cloud-for-cinema-4d/actions/runs/33428061602), [approved override](https://github.com/karthikbekalp/deadline-cloud-for-cinema-4d/actions/runs/33428195946), and [expected timeout failure](https://github.com/karthikbekalp/deadline-cloud-for-cinema-4d/actions/runs/33428887250). The timeout harness captured and asserted the action's failure, so the test run itself completed successfully; the production workflow does not suppress that failure. Publication jobs were skipped during these checks.
- End-to-end publication was not run because it would modify production release artifacts.
- Submitter integration tests were not run because this change only modifies release automation.

### Was this change documented?

The release automation design guide was updated to document the latest-release-only publication policy.

### Is this a breaking change?

No. This changes internal release automation and does not modify the submitter or adaptor interfaces.
