### PR TITLE
test: Run Cinema 4D 2026 integ tests on GPU.

### DIFF
--- a/.github/workflows/integ_windows.yml
+++ b/.github/workflows/integ_windows.yml
@@ -30,7 +30,7 @@ jobs:
       (github.ref == 'refs/heads/mainline' ||
       github.ref == 'refs/heads/feature/ci-tests')
     name: Integration Tests (Windows, Cinema 4D ${{ inputs.c4d_version }})
-    runs-on: windows-latest
+    runs-on: ${{ inputs.c4d_version == '2026' && 'aws-deadline_windows-2025_gpu-t4-4-core' || 'windows-latest' }}
     timeout-minutes: 60
     permissions:
       id-token: write

--- a/test/integ/test_cinema4d.py
+++ b/test/integ/test_cinema4d.py
@@ -631,23 +631,14 @@ def _run_integ_case(
     rmtree(actual_dir, ignore_errors=True)
 
 
-# Keep the Redshift cases running in Windows CI, but do not block the workflow
-# on their intermittent render failures. All Redshift cases are affected in
-# Cinema 4D 2024 and 2025; the textured case is also affected in Cinema 4D 2026.
-# This is a Cinema 4D issue and we have a ticket with Maxon to add a fix.
-_XFAIL_REDSHIFT_2024_2025_IN_CI = pytest.mark.xfail(
+# Reliable Redshift rendering requires a GPU. Unlike standard runners, GPU
+# runners are billed, so Windows CI runs Redshift only for the latest supported
+# Cinema 4D version, 2026, and skips the 2024 and 2025 cases.
+_SKIP_REDSHIFT_2024_2025_IN_CI = pytest.mark.skipif(
     sys.platform == "win32"
     and os.environ.get("CI") == "true"
     and os.environ.get("C4D_VERSION") in {"2024", "2025"},
-    reason="Redshift rendering can fail with Cinema 4D 2024 and 2025",
-    strict=False,
-)
-_XFAIL_REDSHIFT_TEXTURED_IN_CI = pytest.mark.xfail(
-    sys.platform == "win32"
-    and os.environ.get("CI") == "true"
-    and os.environ.get("C4D_VERSION") in {"2024", "2025", "2026"},
-    reason="Redshift textured rendering can fail with Cinema 4D 2024, 2025, and 2026",
-    strict=False,
+    reason="Redshift requires a billed GPU runner, so CI runs it only for the latest Cinema 4D version (2026)",
 )
 _SKIP_OCIO_2024 = pytest.mark.skipif(
     os.environ.get("C4D_VERSION", "2026") == "2024",
@@ -683,9 +674,9 @@ _CASES = [
     "physical_multi_takes",
     "physical_tiles_multi_takes",
     "phy_apos_path",
-    pytest.param("redshift", marks=_XFAIL_REDSHIFT_2024_2025_IN_CI),
-    pytest.param("redshift_textured", marks=_XFAIL_REDSHIFT_TEXTURED_IN_CI),
-    pytest.param("redshift_tiles", marks=_XFAIL_REDSHIFT_2024_2025_IN_CI),
+    pytest.param("redshift", marks=_SKIP_REDSHIFT_2024_2025_IN_CI),
+    pytest.param("redshift_textured", marks=_SKIP_REDSHIFT_2024_2025_IN_CI),
+    pytest.param("redshift_tiles", marks=_SKIP_REDSHIFT_2024_2025_IN_CI),
 ]
 
 _TAKE_SELECTIONS = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Redshift tests were flaky. Maxon developers informed us that Redshift can have unpredictable behavior on only CPU environments. 

Their guidance was to run the tests on GPU. 

### What was the solution? (How)

So, modified the test to run Redshift tests on GPU for Windows. 

The reason we only run Redshift tests on Cinema 4D 2026 and not 2024-2025 is: 
- 2026 is the most updated version which most of our customers use and hence some coverage with Redshift is useful even though in terms of GUI there's no difference. 
- We have other adaptor tests that we run that specifically check complex Redshift scenes internally. 
- Running GPU runners is not cheap compared to standard runners which is free. 

### What is the impact of this change?

No customer impact, but we now run tests for Redshift on GPU. 
In the future, we could probably make separate tests that run only Redshift related tests on GPU. 

### How was this change tested?
Ran the test on CI here: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/actions/runs/34279964743

The failures are unrelated to the actual changes in this PR. There is an existing issue: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/546 

### Was this change documented?

No document change necessary. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
