### PR TITLE
test: xfail macOS take-selection integ tests in CI

### DIFF
--- a/test/integ/test_cinema4d.py
+++ b/test/integ/test_cinema4d.py
@@ -649,6 +649,22 @@ _XFAIL_REDSHIFT_TEXTURED_IN_CI = pytest.mark.xfail(
     reason="Redshift textured rendering can fail with Cinema 4D 2024, 2025, and 2026",
     strict=False,
 )
+# Changing the Takes combo cannot be automated on the macOS CI runners. The
+# accessibility action opens the popup and its rows are found, but no synthesised
+# click or keypress commits the selection. The only correlated change is the hosted
+# image moving from macOS 26.5.2 to 26.6.2 (image 20260728.0273.1 -> 20260831.0337.3,
+# around 2026-09-03); the same tests pass locally and a real user with a mouse is
+# unaffected, so this is a CI automation limit rather than a product defect. Tracked
+# internally along with what has already been ruled out, so it is not re-investigated.
+#
+# Gated on CI so local runs keep asserting the real behaviour. Not strict: the cause
+# is a runner image we do not control, so a future image that fixes this should show up
+# as an xpass to clean up, not as a red build.
+_XFAIL_MACOS_TAKE_COMBO_IN_CI = pytest.mark.xfail(
+    sys.platform == "darwin" and os.environ.get("CI") == "true",
+    reason="macOS CI: synthesised input does not commit the Takes combo popup",
+    strict=False,
+)
 _SKIP_OCIO_2024 = pytest.mark.skipif(
     os.environ.get("C4D_VERSION", "2026") == "2024",
     reason="BakeOcioViewToBitmap requires Cinema 4D 2025.2 or newer",
@@ -680,8 +696,8 @@ _CASES = [
     "physical_nonascii",
     "physical_textured",
     "physical_custom_fps",
-    "physical_multi_takes",
-    "physical_tiles_multi_takes",
+    pytest.param("physical_multi_takes", marks=_XFAIL_MACOS_TAKE_COMBO_IN_CI),
+    pytest.param("physical_tiles_multi_takes", marks=_XFAIL_MACOS_TAKE_COMBO_IN_CI),
     "phy_apos_path",
     pytest.param("redshift", marks=_XFAIL_REDSHIFT_2024_2025_IN_CI),
     pytest.param("redshift_textured", marks=_XFAIL_REDSHIFT_TEXTURED_IN_CI),
@@ -689,10 +705,12 @@ _CASES = [
 ]
 
 _TAKE_SELECTIONS = [
-    pytest.param("current", "Current Take", id="current"),
+    pytest.param("current", "Current Take", id="current", marks=_XFAIL_MACOS_TAKE_COMBO_IN_CI),
+    # "main" is the combo's starting value, so selecting it never opens the popup and is
+    # unaffected. Left unmarked so it keeps asserting take selection on macOS CI.
     pytest.param("main", "Main Take", id="main"),
-    pytest.param("marked", "Marked Takes", id="marked"),
-    pytest.param("all", "All Takes", id="all"),
+    pytest.param("marked", "Marked Takes", id="marked", marks=_XFAIL_MACOS_TAKE_COMBO_IN_CI),
+    pytest.param("all", "All Takes", id="all", marks=_XFAIL_MACOS_TAKE_COMBO_IN_CI),
 ]
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Five macOS integration tests that change the Takes combo box have been failing on every Cinema 4D version (2024/2025/2026) since 2026-09-03, blocking the macOS integration test workflow: `test_integ[physical_multi_takes]`, `test_integ[physical_tiles_multi_takes]`, and `test_job_specific_take_selection[current|marked|all]`.

The accessibility action opens the combo popup and its rows are found and hit-testable, but no synthesised click or keypress commits the selection — the combo keeps reading `"Main Take"` until the test times out.

The only change correlated with the regression is the macOS version in GitHub's hosted runner image:

| | image | macOS |
|---|---|---|
| last green run | `macos-26-arm64/20260728.0273.1` | 26.5.2 (25F84) |
| first failures | `macos-26-arm64/20260831.0337.3` | 26.6.2 (25G83) |

One run exercised both images from the same commit, with Cinema 4D 2024 on the new image (failed) and 2025/2026 on the old image (passed), so the image is the variable rather than anything in this repo. The next image release, `20260907.0351`, stays on macOS 26.6.2, so waiting for a newer image does not resolve it.

**This is a CI automation limit, not a product defect.** The same tests pass when run locally on macOS, and a real user clicking the dropdown with a mouse can change the take normally. No user-facing behaviour is affected, and this change touches no product code.

### What was the solution? (How)

Mark the five affected cases `xfail` so the workflow is unblocked while the underlying issue is tracked internally, alongside the areas already ruled out so they are not re-investigated.

Two deliberate choices, both explained in a comment next to the marker:

- **Gated on `CI`** (`sys.platform == "darwin" and os.environ.get("CI") == "true"`) rather than on macOS alone, so local macOS runs keep asserting the real behaviour instead of being silently excused.
- **Not strict**, matching the existing `_XFAIL_REDSHIFT_*` markers in this file. The cause is a runner image we do not control, so a future image that fixes this should surface as an `xpass` to clean up rather than turning the build red with no code change on our side.

`test_job_specific_take_selection[main]` is deliberately left unmarked: `"Main Take"` is the combo's starting value, so that case never opens the popup and still passes. It keeps some take-selection coverage on macOS CI.

### What is the impact of this change?

Test-only. The macOS integration workflow stops failing on these five cases; Windows is unaffected because the marker is platform-gated. No product code, adaptor, submitter, or packaging change.

The coverage cost is explicit and temporary: on macOS CI these five cases no longer assert that the Takes dropdown can be driven. They continue to run and assert normally on Windows CI and on local macOS.

### How was this change tested?

- Unit tests: 382 passed, 6 skipped.
- `ruff` and `black` clean.
- Test collection verified — all 26 integration tests still collect, so the `pytest.param` rewrites did not change any test IDs.
- Verified the marker condition evaluates `True` under macOS + `CI=true` and `False` on macOS without `CI`, confirming local runs are not excused.

Note on integration test verification: the xa11y integration workflow triggers on pushes to `mainline` and `feature/ci-tests`, not on pull requests, so this PR does not run it. The macOS cases will report as `xfailed` on the first push to `mainline` after merge. The failures being marked were reproduced repeatedly beforehand across all three Cinema 4D versions.

### Was this change documented?

No user-facing documentation is needed for a test-only change. The rationale, the image versions involved, and both marker decisions are documented in a comment beside the marker, along with a note that removing it is the follow-up once the underlying issue is fixed.

### Is this a breaking change?

No. No public contract, adaptor interface, or init-data/run-data schema is touched.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
